### PR TITLE
Add the conformance jobs and a bundle job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,10 +158,20 @@ jobs:
   # rather than on zero failures. The per-subtest budget is raised from its 180 s
   # default because the GPU here is paravirtual, and a subtest killed for taking
   # too long is reported as a crash.
+  # continue-on-error, because this baseline cannot gate here: it records the
+  # behaviour of a real Apple GPU, and the paravirtual one diverges in BOTH
+  # directions. On both arches, 13 sites fail here that pass there and 16 pass
+  # here that fail there, plus all 16 pixel checks of visual.c's zenable_test.
+  # Measured, not assumed: the same pinned test binaries against the same builtin
+  # on an Apple GPU reproduce the baseline exactly (device 778, the two flaky
+  # test_wndproc sites aside; visual 437), so the divergence is the environment
+  # and not test-source drift. Gating it needs a decision about whether a runner
+  # deserves a baseline of its own.
   conformance:
     needs: setup
     runs-on: macos-26
     timeout-minutes: 45
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,13 +189,14 @@ jobs:
 
   # The distribution bundle, which no other leg covers: it stages both install
   # routes, marks the builtins, and packs the symbols archive alongside, all from
-  # artifacts for four targets. PROD=0 takes the release profile instead of
-  # production, so this exercises that staging without paying for fat LTO on four
-  # targets; a release build is still made by hand.
+  # artifacts for four targets. Built the way a release is, at the default PROD=1,
+  # so the production profile's fat LTO is exercised here rather than first
+  # failing when a release is cut. It is the longest job by some way, and runs
+  # alongside the others.
   bundle:
     needs: setup
     runs-on: macos-26
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
         with:
@@ -206,4 +207,4 @@ jobs:
         with:
           pe: 'true'
           wine-release: ${{ env.WINE_RELEASE }}
-      - run: make bundle PROD=0
+      - run: make bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,21 @@ jobs:
       - run: make conformance-${{ matrix.arch }}
         env:
           MTLD3D_CONFORMANCE_TIMEOUT_SECS: "600"
+          # Every subtest's full output, which is what carries the
+          # `Got <actual>, expected <expected>` values behind each site. The
+          # job's own log reduces to per-site counts, and counts alone cannot
+          # say why this environment diverges.
+          MTLD3D_CONFORMANCE_RAW_DIR: ${{ runner.temp }}/conformance-raw
+
+      # `always()`, because a diverging run is exactly the one whose output is
+      # worth reading, and the job reports failure whenever it diverges.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: conformance-raw-${{ matrix.arch }}
+          path: ${{ runner.temp }}/conformance-raw
+          retention-days: 14
+          if-no-files-found: error
 
   # The distribution bundle, which no other leg covers: it stages both install
   # routes, marks the builtins, and packs the symbols archive alongside, all from

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,8 @@ jobs:
   # routes, marks the builtins, and packs the symbols archive alongside, all from
   # artifacts for four targets. Built the way a release is, at the default PROD=1,
   # so the production profile's fat LTO is exercised here rather than first
-  # failing when a release is cut. It is the longest job by some way, and runs
-  # alongside the others.
+  # failing when a release is cut. Costs about 5 minutes, which is less than the
+  # e2e legs take.
   bundle:
     needs: setup
     runs-on: macos-26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 # syntax. The MSVC CRT and Windows SDK versions are pinned in the Makefile
 # instead, beside the xwin call that consumes them.
 env:
-  WINE_RELEASE: cx-26.3.0-0
+  WINE_RELEASE: cx-26.3.0-1
   RUST_STABLE: 1.97.1
   RUST_NIGHTLY: nightly-2026-08-18
   CARGO_TOOLS: xwin@0.10.0 cargo-nextest@0.9.143
@@ -152,7 +152,48 @@ jobs:
         env:
           NEXTEST_PROFILE: ci
 
-  # d3d9 conformance is deliberately absent: it runs Wine's own d3d9_test.exe out
-  # of the SDK bundle, and no wine-build release carries those binaries yet.
-  # Adding conformance-i686 / conformance-x86_64 is a follow-up, together with the
-  # WINE_RELEASE bump that brings them.
+  # Wine's own d3d9_test.exe against our builtin, per-site counts diffed against
+  # unix/conformance/baseline.txt. One arch per runner process, and not part of
+  # `make test`: many subtests fail by design, so this gates on a regression
+  # rather than on zero failures. The per-subtest budget is raised from its 180 s
+  # default because the GPU here is paravirtual, and a subtest killed for taking
+  # too long is reported as a crash.
+  conformance:
+    needs: setup
+    runs-on: macos-26
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [i686, x86_64]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/prepare
+        with:
+          pe: 'true'
+          wine: 'true'
+          wine-release: ${{ env.WINE_RELEASE }}
+      - run: make conformance-${{ matrix.arch }}
+        env:
+          MTLD3D_CONFORMANCE_TIMEOUT_SECS: "600"
+
+  # The distribution bundle, which no other leg covers: it stages both install
+  # routes, marks the builtins, and packs the symbols archive alongside, all from
+  # artifacts for four targets. PROD=0 takes the release profile instead of
+  # production, so this exercises that staging without paying for fat LTO on four
+  # targets; a release build is still made by hand.
+  bundle:
+    needs: setup
+    runs-on: macos-26
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # BUILD_ID, which names the build inside the symbols archive, comes
+          # from `git describe --tags`.
+          fetch-tags: true
+      - uses: ./.github/actions/prepare
+        with:
+          pe: 'true'
+          wine-release: ${{ env.WINE_RELEASE }}
+      - run: make bundle PROD=0


### PR DESCRIPTION
Adds the two conformance jobs and a bundle job, and bumps the pinned Wine release to `cx-26.3.0-1`, which is the first one carrying `lib/wine/tests/{i386,x86_64}-windows/d3d9_test.exe`.

`bundle` had no coverage at all, and it is the only path that stages both install routes, marks the builtins and packs the symbols archive, from artifacts for four targets. It builds the way a release does, at `PROD=1`, so the production profile's fat LTO is exercised here rather than first failing when a release is cut. That costs about five minutes, less than the e2e legs.

The conformance jobs run one arch each, gating on a regression against `baseline.txt` rather than on zero failures, since many subtests fail by design. Their per-subtest budget is raised to 600 seconds, because the GPU on a runner is paravirtual and a subtest killed for taking too long is reported as a crash rather than as slow.

They are `continue-on-error` for now, because that baseline cannot gate there. The runner's GPU diverges from it in both directions, identically on both arches: 13 sites newly fail (34 checks), 18 stop failing (20 checks), so a net of 14 more checks across five fewer sites. The whole `visual` delta is one site, `visual.c:18065` in `zenable_test`, where all 16 pixel checks of its 4x4 grid fail on the runner and pass on real Apple silicon. `stateblock` and `d3d9ex` match the baseline exactly.

That is not wine test-source drift, which is the obvious reading and is wrong: the runner even warns that the baseline was taken against a different version, but that warning compares the loader version while the sites come from the test exe. Running this release's own test binaries against the same installed builtin on an Apple GPU reproduces the baseline exactly, device 778 against 780 with only the two known-flaky `test_wndproc` sites moving, and visual 437 on the nose. So the binaries agree with the baseline and the environment does not.

Each run keeps its raw conformance output as a per-arch artifact, since the job log reduces everything to per-site counts and counts cannot say why an environment diverges. The raw logs carry the `Got <actual>, expected <expected>` value behind each site, which is what a proper investigation of those divergences needs. Whether conformance should gate here, and whether a runner deserves a baseline of its own, is left open deliberately: that is a decision about the conformance model rather than about this workflow.