### PR TITLE
conformance: tolerate the map_sync timing flap

### DIFF
--- a/unix/conformance/CONFORMANCE.md
+++ b/unix/conformance/CONFORMANCE.md
@@ -166,8 +166,8 @@ the line is `real`.
 Audit provenance: every cluster below was re-derived on 2026-07-20 from the
 Wine test source, the raw actual-vs-expected failure messages
 (`MTLD3D_CONFORMANCE_RAW_DIR`), and the implementation — independently
-re-checked before retagging. Headline: **45 `real` · 124 `expected` ·
-6 `caps` · 2 `flaky` · 0 `untriaged`** unique sites; all 8 subtest-arches
+re-checked before retagging. Headline: **45 `real` · 123 `expected` ·
+6 `caps` · 3 `flaky` · 0 `untriaged`** unique sites; all 8 subtest-arches
 `crash=0`. Tags do not affect the gate (which rejects count/site/crash
 regressions), so tag corrections are documentation, not gate changes.
 
@@ -641,12 +641,17 @@ broken(). Accepted platform limitation (no cap branch — old `caps` tag was
 wrong).
 
 ### visual.c/test_map_synchronisation
-Sites: 25148=expected
+Sites: 25148=flaky
 
 The failing config is exactly the plain (no DISCARD/NOOVERWRITE) PARTIAL
 lock of a contended Direct buffer, which native stalls for. Our buffer-
 rename design deliberately removed that stall (`plan_lock` → WriteInPlace);
-re-adding it is the only fix and is a rejected perf regression.
+re-adding it is the only fix and is a rejected perf regression. Whether the
+test observes the divergence is a per-run CPU-vs-GPU race (the probe's Lock
+write lands before or after the GPU consumes the in-flight draw), so the
+count flutters between 0 and 1 across runs of the same binary; it read 0 on
+the CI runner and tripped the stale-baseline gate (PR #12), hence the flaky
+tolerance. The kept divergence itself is unchanged.
 
 ### visual.c/test_sysmem_draw
 Sites: 25431=real 25436=real 25505=expected 25518=expected 25565=expected


### PR DESCRIPTION
PR #12's x86_64 conformance leg failed with `visual.c:25148 1 -> 0 STALE BASELINE (site gone)` even though the branch doesn't touch anything near buffer locking. The site is Wine's test_map_synchronisation check that a plain (no DISCARD/NOOVERWRITE) partial lock of a contended Direct buffer behaves synchronised. We deliberately rename at overlap instead of stalling, so whether the test observes the divergence is a per-run CPU vs GPU race: the probe's Lock write either beats the in-flight draw or it doesn't. It read 0 on the CI runner this time and has been seen flapping in both directions on a clean main checkout.

Since #13 the gate also fails when a site reads below its pin, so this flutter now gates. Per the reactive tagging policy the site gets the flaky class: expected -> flaky in CONFORMANCE.md, headline tally moved accordingly, prose extended with the race mechanism. The kept divergence itself is unchanged, and baseline.txt is untouched (the pin stays 1 on both arches; flaky tolerates both directions).

Verification: the conformance crate's unit tests pass (including the triage sync test that checks CONFORMANCE.md/baseline coverage both ways) and `make audit` is clean. Once this lands, #12 rebases and its conformance leg goes green regardless of which way the race rolls.