### PR TITLE
Filter screen-parameter notifications before Wine re-enumerates displays

### DIFF
--- a/unix/Cargo.toml
+++ b/unix/Cargo.toml
@@ -33,6 +33,7 @@ log = "0.4"
 # value come back and makes capturable debug builds behave like production.
 objc2 = { version = "0.6", features = ["disable-encoding-assertions"] }
 objc2-app-kit = { version = "0.3", default-features = false, features = [
+    "NSApplication",
     "NSColorSpace",
     "NSResponder",
     "NSScreen",
@@ -42,7 +43,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
     "objc2-core-graphics",
 ] }
 objc2-core-foundation = { version = "0.3", features = ["CFCGTypes"] }
-objc2-core-graphics = { version = "0.3", features = ["CGColorSpace"] }
+objc2-core-graphics = { version = "0.3", features = ["CGColorSpace", "CGDirectDisplay"] }
 objc2-foundation = { version = "0.3", features = [
     "NSString",
     "NSURL",

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -103,8 +103,9 @@ const PRESENTED_MIN_EXCESS_NS: u64 = 3_000_000;
 /// frame's sequence number and its `nextDrawable` wait. Together with the
 /// PE-side `frame hitch` line (Present-call cadence on the API thread) it
 /// separates a stalled game thread from a frame that was produced on time
-/// and displayed late. One block allocation per frame; the line only forms
-/// on a hitch.
+/// and displayed late. One block allocation per frame while the target is
+/// at debug or below; the caller skips the registration otherwise, and the
+/// line only forms on a hitch.
 fn register_presented_probe(
     drawable: &ProtocolObject<dyn CAMetalDrawable>,
     seq: u64,
@@ -500,7 +501,11 @@ pub fn submit_frame(params: &mut SubmitFrameParams) -> bool {
             } else {
                 cmd_buf.presentDrawable(drawable_obj);
             }
-            register_presented_probe(&drawable, params.submit_seq, params.drawable_wait_ns);
+            // Debug and trace output only, so the per-frame block allocation
+            // and handler registration are skipped when the target is off.
+            if log::log_enabled!(target: PRESENT_LOG_TARGET, log::Level::Debug) {
+                register_presented_probe(&drawable, params.submit_seq, params.drawable_wait_ns);
+            }
         }
     }
 

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use block2::RcBlock;
-use log::error;
+use log::{debug, error};
 use mtld3d_shared::{
     BlitCommand, BlitCommandType, Command, CommandType, MetalHandle, PassDescriptor,
     SubmitFrameParams,
@@ -26,10 +26,10 @@ use objc2::{rc::Retained, runtime::ProtocolObject};
 use objc2_foundation::NSRange;
 use objc2_metal::{
     MTLBlitCommandEncoder, MTLBuffer, MTLClearColor, MTLCommandBuffer, MTLCommandBufferStatus,
-    MTLCommandEncoder, MTLCommandQueue, MTLCullMode, MTLDevice, MTLIndexType, MTLLoadAction,
-    MTLOrigin, MTLPixelFormat, MTLPrimitiveType, MTLRenderCommandEncoder, MTLRenderPassDescriptor,
-    MTLResource, MTLResourceOptions, MTLScissorRect, MTLSize, MTLStoreAction, MTLTexture,
-    MTLViewport, MTLVisibilityResultMode,
+    MTLCommandEncoder, MTLCommandQueue, MTLCullMode, MTLDevice, MTLDrawable, MTLIndexType,
+    MTLLoadAction, MTLOrigin, MTLPixelFormat, MTLPrimitiveType, MTLRenderCommandEncoder,
+    MTLRenderPassDescriptor, MTLResource, MTLResourceOptions, MTLScissorRect, MTLSize,
+    MTLStoreAction, MTLTexture, MTLViewport, MTLVisibilityResultMode,
 };
 use objc2_metal_fx::MTLFXSpatialScalerColorProcessingMode;
 use objc2_quartz_core::CAMetalDrawable;
@@ -71,6 +71,83 @@ unsafe impl Sync for PendingCmdBuf {}
 /// `waitUntilCompleted` on. The completion handler always removes,
 /// so the map size is bounded by in-flight frames.
 static PENDING_CMDBUFS: Mutex<BTreeMap<u64, PendingCmdBuf>> = Mutex::new(BTreeMap::new());
+
+/// Host time (ns) at which the previous drawable reached the screen.
+///
+/// Half of the presented-cadence probe, see [`register_presented_probe`].
+/// Atomics because Metal runs the presented handler on its own thread.
+static LAST_PRESENTED_NS: AtomicU64 = AtomicU64::new(0);
+/// Exponential running average of the presented interval, ns; 0 = unseeded.
+static TYPICAL_PRESENTED_NS: AtomicU64 = AtomicU64::new(0);
+/// A presented interval above this is a pause, not a hitch; it reseeds.
+const PRESENTED_MAX_INTERVAL_NS: u64 = 500_000_000;
+/// Minimum excess over the typical presented interval for a hitch, ns.
+///
+/// Applied on top of the 1.5x ratio, so jitter on a fast panel stays quiet
+/// while one dropped refresh at 120 Hz (8.3 ms to 16.6 ms) registers.
+const PRESENTED_MIN_EXCESS_NS: u64 = 3_000_000;
+
+/// Presented-cadence probe: when each frame actually reached the screen.
+///
+/// Registers a presented handler on the drawable. The handler reads
+/// `presentedTime`, the compositor's host time for the frame hitting the
+/// panel, keeps an exponential running typical interval, and logs one
+/// debug line when an interval exceeds 1.5x the typical one by at least
+/// `PRESENTED_MIN_EXCESS_NS`: the interval, the typical interval, the
+/// frame's sequence number and its `nextDrawable` wait. Together with the
+/// PE-side `frame hitch` line (Present-call cadence on the API thread) it
+/// separates a stalled game thread from a frame that was produced on time
+/// and displayed late. One block allocation per frame; the line only forms
+/// on a hitch.
+fn register_presented_probe(
+    drawable: &ProtocolObject<dyn CAMetalDrawable>,
+    seq: u64,
+    drawable_wait_ns: u64,
+) {
+    let handler = RcBlock::new(
+        move |d_ptr: core::ptr::NonNull<ProtocolObject<dyn MTLDrawable>>| {
+            // SAFETY: Metal invokes the block with the presented drawable;
+            // the pointer is valid for the handler's duration.
+            let d = unsafe { d_ptr.as_ref() };
+            let now_ns = super::macdrv::host_seconds_to_ns(d.presentedTime());
+            if now_ns == 0 {
+                // Never presented (drawable dropped): leave the chain alone.
+                return;
+            }
+            let last_ns = LAST_PRESENTED_NS.swap(now_ns, Ordering::AcqRel);
+            if last_ns == 0 || now_ns <= last_ns {
+                return;
+            }
+            let interval_ns = now_ns - last_ns;
+            if interval_ns > PRESENTED_MAX_INTERVAL_NS {
+                TYPICAL_PRESENTED_NS.store(0, Ordering::Relaxed);
+                return;
+            }
+            let typical_ns = TYPICAL_PRESENTED_NS.load(Ordering::Relaxed);
+            let next_typical = if typical_ns == 0 {
+                interval_ns
+            } else {
+                typical_ns - typical_ns / 16 + interval_ns / 16
+            };
+            TYPICAL_PRESENTED_NS.store(next_typical, Ordering::Relaxed);
+            let hitch = typical_ns != 0
+                && interval_ns * 2 > typical_ns * 3
+                && interval_ns > typical_ns + PRESENTED_MIN_EXCESS_NS;
+            if hitch {
+                debug!(
+                    target: LOG_TARGET,
+                    "presented hitch: presented interval {} us (typical {} us) seq={seq} next_drawable_wait_us={}",
+                    interval_ns / 1000,
+                    typical_ns / 1000,
+                    drawable_wait_ns / 1000,
+                );
+            }
+        },
+    );
+    // SAFETY: objc2 typed binding; Metal copies (retains) the block on
+    // registration, so the stack `handler` may drop when this returns.
+    unsafe { drawable.addPresentedHandler(RcBlock::as_ptr(&handler)) };
+}
 
 /// Block until `coherent_seq >= target_seq` by calling `waitUntilCompleted`.
 ///
@@ -407,6 +484,7 @@ pub fn submit_frame(params: &mut SubmitFrameParams) -> bool {
             } else {
                 cmd_buf.presentDrawable(drawable_obj);
             }
+            register_presented_probe(&drawable, params.submit_seq, params.drawable_wait_ns);
         }
     }
 

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use block2::RcBlock;
-use log::{debug, error};
+use log::{debug, error, trace};
 use mtld3d_shared::{
     BlitCommand, BlitCommandType, Command, CommandType, MetalHandle, PassDescriptor,
     SubmitFrameParams,
@@ -72,6 +72,12 @@ unsafe impl Sync for PendingCmdBuf {}
 /// so the map size is bounded by in-flight frames.
 static PENDING_CMDBUFS: Mutex<BTreeMap<u64, PendingCmdBuf>> = Mutex::new(BTreeMap::new());
 
+/// Log sub-target of the presented-cadence probe.
+///
+/// Inherits `mtld3d::unix` filters by prefix; `mtld3d::unix::present=trace`
+/// turns on the per-frame rows without touching anything else.
+const PRESENT_LOG_TARGET: &str = "mtld3d::unix::present";
+
 /// Host time (ns) at which the previous drawable reached the screen.
 ///
 /// Half of the presented-cadence probe, see [`register_presented_probe`].
@@ -119,6 +125,16 @@ fn register_presented_probe(
                 return;
             }
             let interval_ns = now_ns - last_ns;
+            // Per-frame timeline at trace, the presented-side twin of the
+            // PE `present:` row; `t_us` is the absolute host time so rows
+            // can be aligned across threads.
+            trace!(
+                target: PRESENT_LOG_TARGET,
+                "presented: seq={seq} interval_us={} wait_us={} t_us={}",
+                interval_ns / 1000,
+                drawable_wait_ns / 1000,
+                now_ns / 1000,
+            );
             if interval_ns > PRESENTED_MAX_INTERVAL_NS {
                 TYPICAL_PRESENTED_NS.store(0, Ordering::Relaxed);
                 return;
@@ -135,7 +151,7 @@ fn register_presented_probe(
                 && interval_ns > typical_ns + PRESENTED_MIN_EXCESS_NS;
             if hitch {
                 debug!(
-                    target: LOG_TARGET,
+                    target: PRESENT_LOG_TARGET,
                     "presented hitch: presented interval {} us (typical {} us) seq={seq} next_drawable_wait_us={}",
                     interval_ns / 1000,
                     typical_ns / 1000,

--- a/unix/unix/src/metal/macdrv.rs
+++ b/unix/unix/src/metal/macdrv.rs
@@ -2,10 +2,10 @@ use core::{
     ffi::c_void,
     sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering},
 };
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex};
 
 use libloading::os::unix::Library;
-use log::{error, info};
+use log::{debug, error, info, log_enabled};
 use mtld3d_shared::{
     MetalHandle,
     mtl_handle::{CAMetalLayerKind, MTLDeviceKind, NSViewKind},
@@ -187,6 +187,193 @@ fn install_occlusion_tracking(view: *mut c_void) {
             .contains(NSWindowOcclusionState::Visible);
         WINDOW_OCCLUDED.store(occluded, Ordering::Relaxed);
         install_occlusion_observer_once();
+        // SAFETY: inside the main-thread dispatch above.
+        let mtm = unsafe { objc2::MainThreadMarker::new_unchecked() };
+        install_screen_params_filter_once(mtm);
+    });
+}
+
+/// Count of `NSApplicationDidChangeScreenParametersNotification` deliveries.
+static SCREEN_PARAM_CHANGES: AtomicU64 = AtomicU64::new(0);
+
+/// Wine's `NSApplication` delegate, retained for the process lifetime.
+///
+/// Set once by [`install_screen_params_filter_once`]; zero until then. Held
+/// as an address because the observer block that reads it must not capture
+/// a `!Send` `Retained`, and the delegate is only ever touched on the main
+/// thread, where the notification is posted.
+static WINE_APP_DELEGATE_PTR: AtomicUsize = AtomicUsize::new(0);
+
+/// One screen's contribution to the configuration snapshot.
+///
+/// Floats are kept as bit patterns so the comparison is exact and the
+/// struct stays `Eq`.
+#[derive(PartialEq, Eq)]
+struct ScreenEntry {
+    frame: [u64; 4],
+    visible_frame: [u64; 4],
+    scale: u64,
+}
+
+/// The screen configuration Wine's view of the displays depends on.
+///
+/// The per-screen geometry and scale, plus the main display's CG mode
+/// (size, refresh rate, IO mode id), which is what macdrv reports through
+/// `EnumDisplaySettings`. A refresh-rate-only change on a secondary display
+/// is the one real change this misses; it is picked up on the next change
+/// that moves any geometry.
+#[derive(PartialEq, Eq)]
+struct ScreenConfiguration {
+    screens: Vec<ScreenEntry>,
+    main_mode: (usize, usize, u64, i32),
+}
+
+/// Snapshot the current screen configuration. **Main thread only.**
+fn current_screen_configuration(mtm: objc2::MainThreadMarker) -> ScreenConfiguration {
+    use objc2_app_kit::NSScreen;
+    use objc2_core_graphics::{CGDisplayCopyDisplayMode, CGDisplayMode, CGMainDisplayID};
+
+    let rect_bits = |r: objc2_foundation::NSRect| {
+        [
+            r.origin.x.to_bits(),
+            r.origin.y.to_bits(),
+            r.size.width.to_bits(),
+            r.size.height.to_bits(),
+        ]
+    };
+    let screens = NSScreen::screens(mtm)
+        .iter()
+        .map(|s| ScreenEntry {
+            frame: rect_bits(s.frame()),
+            visible_frame: rect_bits(s.visibleFrame()),
+            scale: s.backingScaleFactor().to_bits(),
+        })
+        .collect();
+    let main_mode = CGDisplayCopyDisplayMode(CGMainDisplayID()).map_or((0, 0, 0, 0), |m| {
+        (
+            CGDisplayMode::width(Some(&m)),
+            CGDisplayMode::height(Some(&m)),
+            CGDisplayMode::refresh_rate(Some(&m)).to_bits(),
+            CGDisplayMode::io_display_mode_id(Some(&m)),
+        )
+    });
+    ScreenConfiguration { screens, main_mode }
+}
+
+/// Last configuration forwarded to Wine. **Main thread only.**
+static LAST_SCREEN_CONFIGURATION: Mutex<Option<ScreenConfiguration>> = Mutex::new(None);
+
+/// Take over `NSApplicationDidChangeScreenParametersNotification` from Wine. **Main thread only.**
+///
+/// macOS posts this notification not only for display topology or mode
+/// changes but for every step of an EDR headroom ramp, and the headroom
+/// follows ambient light, thermal state and on-screen content, so with the
+/// HDR layer attached it arrives at up to the refresh rate. Wine's macdrv
+/// answers each one as a display-mode change: a window-level pass here, a
+/// full display re-enumeration in the desktop process and a display-cache
+/// invalidation everywhere, all of it on the main thread that `SetCapture`
+/// and `SetCursorPos` wait on synchronously. That wait is what made every
+/// mouse press and release frame run 1 to 3 ms long.
+///
+/// `AppKit` wires the notification to the delegate's
+/// `applicationDidChangeScreenParameters:` through the default notification
+/// center, so unregistering the delegate for this one name and observing it
+/// ourselves lets us forward only the deliveries whose
+/// [`ScreenConfiguration`] differs from the last one forwarded. Everything
+/// Wine does in its handler still happens on real changes, and nothing at
+/// all happens on a headroom step. The desktop process never loads mtld3d,
+/// so its own copy of the storm is out of reach here; that half is a Wine
+/// patch. Installed once; the observer token is leaked for the process
+/// lifetime like the occlusion observer.
+fn install_screen_params_filter_once(mtm: objc2::MainThreadMarker) {
+    use core::ptr::NonNull;
+    use std::sync::Once;
+
+    use block2::RcBlock;
+    use objc2::{MainThreadMarker, runtime::ProtocolObject};
+    use objc2_app_kit::{
+        NSApplication, NSApplicationDelegate, NSApplicationDidChangeScreenParametersNotification,
+        NSScreen,
+    };
+    use objc2_foundation::{NSNotification, NSNotificationCenter};
+
+    static INSTALLED: Once = Once::new();
+    INSTALLED.call_once(|| {
+        let Some(delegate) = NSApplication::sharedApplication(mtm).delegate() else {
+            mtld3d_shared::log_once_warn!(
+                target: LOG_TARGET,
+                "present: NSApp has no delegate; screen-parameter notifications are not \
+                 filtered, every EDR headroom step will cost a Wine display re-enumeration",
+            );
+            return;
+        };
+        let center = NSNotificationCenter::defaultCenter();
+        // SAFETY: AppKit-exported notification-name constant, valid for the
+        // process lifetime.
+        let name = unsafe { NSApplicationDidChangeScreenParametersNotification };
+        // SAFETY: `ProtocolObject` is a transparent wrapper over `AnyObject`,
+        // so the pointer reinterprets losslessly for the call below.
+        let observer = unsafe { &*Retained::as_ptr(&delegate).cast::<objc2::runtime::AnyObject>() };
+        // SAFETY: objc2 typed binding; the delegate is a live observer of the
+        // center (AppKit registered it), and removing a registration that
+        // does not exist is a documented no-op.
+        unsafe { center.removeObserver_name_object(observer, Some(name), None) };
+        WINE_APP_DELEGATE_PTR.store(Retained::as_ptr(&delegate) as usize, Ordering::Release);
+        // Leaked on purpose: the delegate is Wine's application controller
+        // and lives as long as the process.
+        core::mem::forget(delegate);
+
+        let block = RcBlock::new(move |notification: NonNull<NSNotification>| {
+            let count = SCREEN_PARAM_CHANGES.fetch_add(1, Ordering::Relaxed) + 1;
+            // SAFETY: AppKit posts this notification on the main thread.
+            let mtm = unsafe { MainThreadMarker::new_unchecked() };
+            let config = current_screen_configuration(mtm);
+            let changed = {
+                let mut last = LAST_SCREEN_CONFIGURATION
+                    .lock()
+                    .expect("screen-configuration mutex poisoned");
+                let changed = last.as_ref() != Some(&config);
+                if changed {
+                    *last = Some(config);
+                }
+                changed
+            };
+            if log_enabled!(target: LOG_TARGET, log::Level::Debug) {
+                let headroom = NSScreen::mainScreen(mtm)
+                    .map_or(0.0, |s| s.maximumExtendedDynamicRangeColorComponentValue());
+                debug!(
+                    target: LOG_TARGET,
+                    "screen params changed #{count}: headroom={headroom:.3} {}",
+                    if changed { "configuration changed, forwarded to Wine" } else { "filtered" },
+                );
+            }
+            if !changed {
+                return;
+            }
+            let delegate_ptr = WINE_APP_DELEGATE_PTR.load(Ordering::Acquire);
+            if delegate_ptr == 0 {
+                return;
+            }
+            // SAFETY: the pointer was taken from a `Retained` that is leaked
+            // above, so the delegate outlives this block, and the call is on
+            // the main thread, which is the delegate's thread.
+            let delegate =
+                unsafe { &*(delegate_ptr as *const ProtocolObject<dyn NSApplicationDelegate>) };
+            // SAFETY: the notification pointer is valid for the handler's
+            // duration; Wine implements this optional delegate method.
+            unsafe { delegate.applicationDidChangeScreenParameters(notification.as_ref()) };
+        });
+        // SAFETY: objc2 typed binding; the center copies the block, and the
+        // token is leaked below so the observer is never removed.
+        let token = unsafe {
+            center.addObserverForName_object_queue_usingBlock(Some(name), None, None, &block)
+        };
+        core::mem::forget(token);
+        info!(
+            target: LOG_TARGET,
+            "present: filtering NSApplicationDidChangeScreenParametersNotification for Wine \
+             (forwarded only when screen geometry, scale or the main display mode changed)",
+        );
     });
 }
 

--- a/unix/unix/src/metal/macdrv.rs
+++ b/unix/unix/src/metal/macdrv.rs
@@ -640,6 +640,14 @@ pub fn set_display_sync_enabled(
     store_min_present_duration(panel_max_hz, pacing);
 }
 
+/// Host-time seconds (`CFTimeInterval`) to nanoseconds, saturating.
+///
+/// `presentedTime` is a `CACurrentMediaTime`-based host time; a session's
+/// uptime in nanoseconds sits far below `u64::MAX`.
+pub fn host_seconds_to_ns(secs: f64) -> u64 {
+    bounded_cast::f64_to_u64_saturating(secs * 1e9)
+}
+
 /// Numeric casts where the cast lints fire but the bounds are established by the caller.
 ///
 /// Grouping them under one mod-level allow collapses what would otherwise be
@@ -663,6 +671,20 @@ mod bounded_cast {
             return u32::MAX;
         }
         v as u32
+    }
+
+    /// Saturating `f64 → u64`.
+    ///
+    /// NaN/negative → 0, ≥ `u64::MAX` → `u64::MAX`; all other inputs land in
+    /// `(0.0, u64::MAX)` where the cast is exact to f64 precision.
+    pub fn f64_to_u64_saturating(v: f64) -> u64 {
+        if !v.is_finite() || v <= 0.0 {
+            return 0;
+        }
+        if v >= u64::MAX as f64 {
+            return u64::MAX;
+        }
+        v as u64
     }
 
     /// `f64 → f32` narrowing.

--- a/windows/d3d9/src/cursor.rs
+++ b/windows/d3d9/src/cursor.rs
@@ -343,13 +343,18 @@ impl CursorState {
 
     /// Fold one `Present` into the hitch probe; see `HitchProbe`.
     ///
-    /// Called once per `Present` from `device_present`. Two `Instant` reads
-    /// per frame; the log line only forms on a hitched frame.
+    /// Called once per `Present` from `device_present`. Everything it
+    /// produces is a debug or trace line, so with the cursor target below
+    /// debug the whole body is one level check; with it on, two `Instant`
+    /// reads per frame and the log line only on a hitched frame.
     pub fn note_present(&mut self) {
-        let now = Instant::now();
         let probe = &mut self.probe;
         let calls_us = core::mem::take(&mut probe.calls_us_since_present);
         let msgs = core::mem::take(&mut probe.setcursor_msgs_since_present);
+        if !log_enabled!(target: LOG_TARGET, Level::Debug) {
+            return;
+        }
+        let now = Instant::now();
         let Some(last) = probe.last_present.replace(now) else {
             return;
         };

--- a/windows/d3d9/src/cursor.rs
+++ b/windows/d3d9/src/cursor.rs
@@ -15,9 +15,11 @@ use std::{
     collections::{HashMap, hash_map::DefaultHasher},
     hash::Hasher,
     sync::{LazyLock, Mutex},
+    time::Instant,
 };
 
 use log::{Level, debug, error, log_enabled, trace, warn};
+use mtld3d_core::perf::DeviceSubCategory;
 use mtld3d_shared::InPtr;
 use mtld3d_types::{
     D3DLOCK_READONLY, D3DLOCKED_RECT, D3DSURFACE_DESC, ICONINFO, IDirect3DSurface9Vtbl, POINT,
@@ -25,7 +27,7 @@ use mtld3d_types::{
 
 use super::{
     D3D_OK, D3DERR_INVALIDCALL,
-    device::{DeviceInner, Direct3DDevice9},
+    device::{DeviceInner, Direct3DDevice9, device_timer},
     fullscreen::set_window_long_ptr,
 };
 
@@ -73,6 +75,26 @@ fn set_cursor(handle: *mut c_void) {
     unsafe {
         SetCursor(handle);
     }
+}
+
+/// `set_cursor` plus its wall time in microseconds.
+///
+/// The Win32 cursor calls can stall the calling thread on Wine's Cocoa
+/// main thread: `SetCursorPos` and an idle `GetCursorPos` (no pointer
+/// change for 100 ms) go through a synchronous `OnMainThread`, and
+/// `SetCursor` is a wineserver round trip. Every cursor log line carries
+/// the microseconds its calls took, so a frame hitch around a cursor
+/// transition can be attributed to, or cleared of, these calls from a
+/// `RUST_LOG=mtld3d::d3d9::cursor=debug` log alone.
+fn timed_set_cursor(handle: *mut c_void) -> u64 {
+    let started = Instant::now();
+    set_cursor(handle);
+    elapsed_us(started)
+}
+
+/// Microseconds since `started`, saturating.
+fn elapsed_us(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX)
 }
 
 fn set_cursor_pos(x: i32, y: i32) {
@@ -387,6 +409,7 @@ pub extern "system" fn device_set_cursor_properties(
     y_hotspot: u32,
     cursor_bitmap: *mut c_void,
 ) -> i32 {
+    let _timer = device_timer(this, DeviceSubCategory::Misc);
     if cursor_bitmap.is_null() {
         warn!(target: LOG_TARGET, "reject SetCursorProperties(null bitmap) → INVALIDCALL");
         return D3DERR_INVALIDCALL;
@@ -502,41 +525,53 @@ pub extern "system" fn device_set_cursor_properties(
     cur.hash = hash;
     cur.handle = handle;
     let visible = cur.effective_visible();
-    debug!(
-        target: LOG_TARGET,
-        "SetCursorProperties: {width}x{height} fmt={} pool={} hotspot=({x_hotspot},{y_hotspot}) hash={hash:#018x} outcome={outcome} handle={handle:p} visible={visible} cache_entries={} tid={}",
-        desc.format, desc.pool, cur.cache.len(), current_thread_id(),
-    );
     // Realize only while shown (D3D9 sets the Win32 cursor only when the cursor is visible).
     // While hidden the game owns the win32 cursor — pushing null here clobbers
     // the cursor the game's own wndproc set (WoW's login screen never calls
     // ShowCursor(TRUE); its glove is the game's own cursor).
-    if visible {
-        set_cursor(handle);
-    }
+    // `set_cursor_us` is 0 when nothing was realized.
+    let set_cursor_us = if visible { timed_set_cursor(handle) } else { 0 };
+    debug!(
+        target: LOG_TARGET,
+        "SetCursorProperties: {width}x{height} fmt={} pool={} hotspot=({x_hotspot},{y_hotspot}) hash={hash:#018x} outcome={outcome} handle={handle:p} visible={visible} set_cursor_us={set_cursor_us} cache_entries={} tid={}",
+        desc.format, desc.pool, cur.cache.len(), current_thread_id(),
+    );
     D3D_OK
 }
 
-pub extern "system" fn device_set_cursor_position(_this: *mut c_void, x: i32, y: i32, _flags: u32) {
+pub extern "system" fn device_set_cursor_position(this: *mut c_void, x: i32, y: i32, _flags: u32) {
+    let _timer = device_timer(this, DeviceSubCategory::Misc);
+    // The pre-check earns its keep: a `SetCursorPos` to the current position
+    // still queues a `WM_MOUSEMOVE`, so skipping it keeps the game's message
+    // queue quiet. Its cost is the idle `GetCursorPos` main-thread hop
+    // described on `timed_set_cursor`, hence the timing.
+    let started = Instant::now();
     let current = get_cursor_pos();
+    let get_us = elapsed_us(started);
     let suppress = current.is_some_and(|p| p.x == x && p.y == y);
     if suppress {
-        debug!(target: LOG_TARGET, "SetCursorPosition: noop ({x},{y})");
+        debug!(target: LOG_TARGET, "SetCursorPosition: noop ({x},{y}) get_us={get_us}");
         return;
     }
+    let started = Instant::now();
+    set_cursor_pos(x, y);
+    let set_us = elapsed_us(started);
     if let Some(p) = current {
         debug!(
             target: LOG_TARGET,
-            "SetCursorPosition: ({},{}) → ({x},{y}) dx={} dy={}",
+            "SetCursorPosition: ({},{}) → ({x},{y}) dx={} dy={} get_us={get_us} set_us={set_us}",
             p.x, p.y, x - p.x, y - p.y,
         );
     } else {
-        debug!(target: LOG_TARGET, "SetCursorPosition: → ({x},{y}) got_current=none");
+        debug!(
+            target: LOG_TARGET,
+            "SetCursorPosition: → ({x},{y}) got_current=none get_us={get_us} set_us={set_us}",
+        );
     }
-    set_cursor_pos(x, y);
 }
 
 pub extern "system" fn device_show_cursor(this: *mut c_void, show: i32) -> i32 {
+    let _timer = device_timer(this, DeviceSubCategory::Misc);
     // SAFETY: vtable thunk; `this` is *mut Direct3DDevice9 per IDirect3DDevice9 ABI.
     let Some(obj) = (unsafe { InPtr::<Direct3DDevice9>::opt(this) }) else {
         return D3DERR_INVALIDCALL;
@@ -580,17 +615,17 @@ pub extern "system" fn device_show_cursor(this: *mut c_void, show: i32) -> i32 {
     // WM_SETCURSOR branch below, or the pointer re-entering the window gets
     // through.
     let handle = if next { cur.handle } else { null_mut() };
-    set_cursor(handle);
+    let set_cursor_us = timed_set_cursor(handle);
     if prev == next {
         trace!(
             target: LOG_TARGET,
-            "ShowCursor(show={show}) → prev={prev} handle={handle:p} tid={} (re-assert)",
+            "ShowCursor(show={show}) → prev={prev} handle={handle:p} set_cursor_us={set_cursor_us} tid={} (re-assert)",
             current_thread_id(),
         );
     } else {
         debug!(
             target: LOG_TARGET,
-            "ShowCursor(show={show}) → prev={prev} next={next} handle={handle:p} tid={} (transition)",
+            "ShowCursor(show={show}) → prev={prev} next={next} handle={handle:p} set_cursor_us={set_cursor_us} tid={} (transition)",
             current_thread_id(),
         );
     }
@@ -631,6 +666,7 @@ extern "system" fn cursor_wnd_proc(hwnd: *mut c_void, msg: u32, wp: usize, lp: i
             // WM_SETCURSOR): the game shows its own cursor — WoW's login
             // screen never calls ShowCursor(TRUE) and relies on exactly that.
             let was_dirty = cur.dirty();
+            let started = Instant::now();
             if was_dirty {
                 cur.set_dirty(false);
                 // Null-then-set forces macdrv to drop a lingering native
@@ -638,17 +674,18 @@ extern "system" fn cursor_wnd_proc(hwnd: *mut c_void, msg: u32, wp: usize, lp: i
                 set_cursor(null_mut());
             }
             set_cursor(cur.handle);
+            let set_cursor_us = elapsed_us(started);
             if was_dirty {
                 debug!(
                     target: LOG_TARGET,
-                    "wndproc WM_SETCURSOR: hit_test={hit_test:#x} (HTCLIENT) dirty_was=true → re-asserted handle={:p} tid={} → consumed",
+                    "wndproc WM_SETCURSOR: hit_test={hit_test:#x} (HTCLIENT) dirty_was=true → re-asserted handle={:p} set_cursor_us={set_cursor_us} tid={} → consumed",
                     cur.handle,
                     current_thread_id(),
                 );
             } else if log_enabled!(target: LOG_TARGET, Level::Trace) {
                 trace!(
                     target: LOG_TARGET,
-                    "wndproc WM_SETCURSOR: hit_test={hit_test:#x} (HTCLIENT) dirty_was=false handle={:p} tid={} → consumed",
+                    "wndproc WM_SETCURSOR: hit_test={hit_test:#x} (HTCLIENT) dirty_was=false handle={:p} set_cursor_us={set_cursor_us} tid={} → consumed",
                     cur.handle,
                     current_thread_id(),
                 );

--- a/windows/d3d9/src/cursor.rs
+++ b/windows/d3d9/src/cursor.rs
@@ -260,6 +260,51 @@ bitflags::bitflags! {
     }
 }
 
+/// Frame-hitch attribution around cursor transitions.
+///
+/// `CursorState::note_present` feeds it once per `Present`. It keeps a
+/// running typical Present-to-Present interval and, when one interval blows
+/// past it, logs a single debug line that ties the hitched frame to the
+/// last show/hide transition, to the wall time the Win32 cursor calls
+/// consumed since the previous `Present`, and to the `WM_SETCURSOR`
+/// re-asserts in that window. A clean game thread on a hitched frame (zero
+/// cursor microseconds, no other calls) points at the present side instead.
+struct HitchProbe {
+    last_present: Option<Instant>,
+    /// Exponential running average of the Present interval, microseconds.
+    ///
+    /// Zero until warm, so the first frames never trip the threshold.
+    interval_ewma_us: u64,
+    /// Instant of the last `ShowCursor` transition and whether it showed.
+    last_transition: Option<(Instant, bool)>,
+    /// Wall time of every Win32 cursor call since the last `Present`, µs.
+    calls_us_since_present: u64,
+    /// `WM_SETCURSOR` re-asserts consumed since the last `Present`.
+    setcursor_msgs_since_present: u32,
+}
+
+impl HitchProbe {
+    const fn new() -> Self {
+        Self {
+            last_present: None,
+            interval_ewma_us: 0,
+            last_transition: None,
+            calls_us_since_present: 0,
+            setcursor_msgs_since_present: 0,
+        }
+    }
+}
+
+/// A Present interval this many times the typical one is a hitch.
+const HITCH_RATIO: u64 = 2;
+/// Minimum excess over the typical interval for a hitch, µs.
+///
+/// Applied on top of `HITCH_RATIO`, so a 4 ms frame at 240 Hz doubling to
+/// 8 ms does not count.
+const HITCH_MIN_EXCESS_US: u64 = 4_000;
+/// Intervals above this are pauses (alt-tab, loading), not frame hitches.
+const HITCH_MAX_INTERVAL_US: u64 = 500_000;
+
 /// Cursor state owned by `DeviceInner` as a single field.
 ///
 /// Fields are private to this module — only code in `cursor.rs` reads or
@@ -271,6 +316,7 @@ pub struct CursorState {
     flags: CursorFlags,
     hash: u64,
     cache: HashMap<u64, *mut c_void>,
+    probe: HitchProbe,
     /// Nearest-neighbor upscale factor applied to the cursor bitmap.
     ///
     /// Sourced from the display's `backingScaleFactor` at `CreateDevice` so
@@ -291,8 +337,58 @@ impl CursorState {
             flags: CursorFlags::DIRTY,
             hash: 0,
             cache: HashMap::new(),
+            probe: HitchProbe::new(),
             scale: scale.clamp(1, 8),
         }
+    }
+
+    /// Fold one `Present` into the hitch probe; see `HitchProbe`.
+    ///
+    /// Called once per `Present` from `device_present`. Two `Instant` reads
+    /// per frame; the log line only forms on a hitched frame.
+    pub fn note_present(&mut self) {
+        let now = Instant::now();
+        let probe = &mut self.probe;
+        let calls_us = core::mem::take(&mut probe.calls_us_since_present);
+        let msgs = core::mem::take(&mut probe.setcursor_msgs_since_present);
+        let Some(last) = probe.last_present.replace(now) else {
+            return;
+        };
+        let interval_us = elapsed_us(last);
+        if interval_us > HITCH_MAX_INTERVAL_US {
+            return;
+        }
+        let typical_us = probe.interval_ewma_us;
+        // EWMA with a 1/16 weight; seeded by the first interval.
+        probe.interval_ewma_us = if typical_us == 0 {
+            interval_us
+        } else {
+            typical_us - typical_us / 16 + interval_us / 16
+        };
+        let hitch = typical_us != 0
+            && interval_us > typical_us * HITCH_RATIO
+            && interval_us > typical_us + HITCH_MIN_EXCESS_US;
+        if !hitch {
+            return;
+        }
+        // `since_transition_ms` is -1 when no transition happened yet.
+        let (transition, since_transition_ms) =
+            probe
+                .last_transition
+                .map_or(("none", -1i64), |(at, shown)| {
+                    let since = i64::try_from(elapsed_us(at) / 1000).unwrap_or(i64::MAX);
+                    (if shown { "show" } else { "hide" }, since)
+                });
+        debug!(
+            target: LOG_TARGET,
+            "frame hitch: present interval {interval_us} us (typical {typical_us} us) last_transition={transition} since_transition_ms={since_transition_ms} cursor_calls_since_present_us={calls_us} wm_setcursor_since_present={msgs} tid={}",
+            current_thread_id(),
+        );
+    }
+
+    /// Charge `us` of Win32 cursor-call wall time to the current frame.
+    const fn charge_call_us(&mut self, us: u64) {
+        self.probe.calls_us_since_present = self.probe.calls_us_since_present.saturating_add(us);
     }
 
     const fn visible(&self) -> bool {
@@ -531,6 +627,7 @@ pub extern "system" fn device_set_cursor_properties(
     // ShowCursor(TRUE); its glove is the game's own cursor).
     // `set_cursor_us` is 0 when nothing was realized.
     let set_cursor_us = if visible { timed_set_cursor(handle) } else { 0 };
+    cur.charge_call_us(set_cursor_us);
     debug!(
         target: LOG_TARGET,
         "SetCursorProperties: {width}x{height} fmt={} pool={} hotspot=({x_hotspot},{y_hotspot}) hash={hash:#018x} outcome={outcome} handle={handle:p} visible={visible} set_cursor_us={set_cursor_us} cache_entries={} tid={}",
@@ -548,14 +645,21 @@ pub extern "system" fn device_set_cursor_position(this: *mut c_void, x: i32, y: 
     let started = Instant::now();
     let current = get_cursor_pos();
     let get_us = elapsed_us(started);
+    // SAFETY: vtable thunk; `this` is *mut Direct3DDevice9 per IDirect3DDevice9 ABI.
+    let Some(obj) = (unsafe { InPtr::<Direct3DDevice9>::opt(this) }) else {
+        return;
+    };
+    let cur = obj.inner().cursor_mut();
     let suppress = current.is_some_and(|p| p.x == x && p.y == y);
     if suppress {
+        cur.charge_call_us(get_us);
         debug!(target: LOG_TARGET, "SetCursorPosition: noop ({x},{y}) get_us={get_us}");
         return;
     }
     let started = Instant::now();
     set_cursor_pos(x, y);
     let set_us = elapsed_us(started);
+    cur.charge_call_us(get_us + set_us);
     if let Some(p) = current {
         debug!(
             target: LOG_TARGET,
@@ -616,6 +720,10 @@ pub extern "system" fn device_show_cursor(this: *mut c_void, show: i32) -> i32 {
     // through.
     let handle = if next { cur.handle } else { null_mut() };
     let set_cursor_us = timed_set_cursor(handle);
+    cur.charge_call_us(set_cursor_us);
+    if prev != next {
+        cur.probe.last_transition = Some((Instant::now(), next));
+    }
     if prev == next {
         trace!(
             target: LOG_TARGET,
@@ -675,6 +783,9 @@ extern "system" fn cursor_wnd_proc(hwnd: *mut c_void, msg: u32, wp: usize, lp: i
             }
             set_cursor(cur.handle);
             let set_cursor_us = elapsed_us(started);
+            cur.charge_call_us(set_cursor_us);
+            cur.probe.setcursor_msgs_since_present =
+                cur.probe.setcursor_msgs_since_present.saturating_add(1);
             if was_dirty {
                 debug!(
                     target: LOG_TARGET,

--- a/windows/d3d9/src/cursor.rs
+++ b/windows/d3d9/src/cursor.rs
@@ -263,8 +263,9 @@ bitflags::bitflags! {
 /// Frame-hitch attribution around cursor transitions.
 ///
 /// `CursorState::note_present` feeds it once per `Present`. It keeps a
-/// running typical Present-to-Present interval and, when one interval blows
-/// past it, logs a single debug line that ties the hitched frame to the
+/// running typical Present-to-Present interval and, when one interval exceeds
+/// 1.5x of it by at least `HITCH_MIN_EXCESS_US`, logs a single debug line
+/// that ties the hitched frame to the
 /// last show/hide transition, to the wall time the Win32 cursor calls
 /// consumed since the previous `Present`, and to the `WM_SETCURSOR`
 /// re-asserts in that window. A clean game thread on a hitched frame (zero
@@ -295,13 +296,11 @@ impl HitchProbe {
     }
 }
 
-/// A Present interval this many times the typical one is a hitch.
-const HITCH_RATIO: u64 = 2;
 /// Minimum excess over the typical interval for a hitch, µs.
 ///
-/// Applied on top of `HITCH_RATIO`, so a 4 ms frame at 240 Hz doubling to
-/// 8 ms does not count.
-const HITCH_MIN_EXCESS_US: u64 = 4_000;
+/// Applied on top of a 1.5x ratio, so jitter on a fast panel stays quiet
+/// while one dropped refresh at 120 Hz (8.3 ms to 16.6 ms) registers.
+const HITCH_MIN_EXCESS_US: u64 = 3_000;
 /// Intervals above this are pauses (alt-tab, loading), not frame hitches.
 const HITCH_MAX_INTERVAL_US: u64 = 500_000;
 
@@ -366,7 +365,7 @@ impl CursorState {
             typical_us - typical_us / 16 + interval_us / 16
         };
         let hitch = typical_us != 0
-            && interval_us > typical_us * HITCH_RATIO
+            && interval_us * 2 > typical_us * 3
             && interval_us > typical_us + HITCH_MIN_EXCESS_US;
         if !hitch {
             return;

--- a/windows/d3d9/src/cursor.rs
+++ b/windows/d3d9/src/cursor.rs
@@ -354,6 +354,14 @@ impl CursorState {
             return;
         };
         let interval_us = elapsed_us(last);
+        // Per-frame timeline at trace: with `mtld3d::d3d9::cursor=trace`
+        // every Present gets a row, so a blip too small for the hitch rule
+        // below (one late refresh under VRR pacing) is still on record next
+        // to the transition line it follows.
+        trace!(
+            target: LOG_TARGET,
+            "present: interval_us={interval_us} cursor_calls_us={calls_us} wm_setcursor={msgs}",
+        );
         if interval_us > HITCH_MAX_INTERVAL_US {
             return;
         }

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -3342,6 +3342,7 @@ extern "system" fn device_present(
     let dev = obj.inner();
 
     mtld3d_shared::crumb!("d3d9:present");
+    dev.cursor_mut().note_present();
     let fresh = dev.fresh_frame();
     dev.present(fresh);
 

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -2404,14 +2404,14 @@ enum RtBinding {
 
 /// Constructs an `ApiTimer` keyed to this device's `ApiPerfState`.
 ///
-/// Hot path: every `IDirect3DDevice9` vtable entry calls it. `#[inline]`
-/// suffices — release uses thin-LTO so the null-check + handoff folds
-/// into the caller. The `sub` arg picks which `DeviceSubCategory`
-/// bucket the elapsed cycles land in for the per-sub breakdown in the
-/// 5-second summary; the top-level `Device` bucket is bumped in
-/// parallel under one `rdtsc()` delta.
+/// Hot path: every `IDirect3DDevice9` vtable entry calls it, the cursor
+/// thunks in `cursor.rs` included. `#[inline]` suffices — release uses
+/// thin-LTO so the null-check + handoff folds into the caller. The `sub`
+/// arg picks which `DeviceSubCategory` bucket the elapsed cycles land in
+/// for the per-sub breakdown in the 5-second summary; the top-level
+/// `Device` bucket is bumped in parallel under one `rdtsc()` delta.
 #[inline]
-fn device_timer(this: *mut c_void, sub: DeviceSubCategory) -> ApiTimer {
+pub fn device_timer(this: *mut c_void, sub: DeviceSubCategory) -> ApiTimer {
     // SAFETY: vtable thunk; `this` is *mut Direct3DDevice9 per IDirect3DDevice9 ABI.
     let perf_ptr = (unsafe { InPtr::<Direct3DDevice9>::opt(this) })
         .map_or(core::ptr::null_mut(), |obj| {


### PR DESCRIPTION
## Problem

With the hardware cursor and the HDR present pipeline, every mouse press and release frame ran 1 to 3 ms long. WoW hides the cursor while a button is held and shows it on release, so rapid clicking dropped the frame rate from 120 to 118, which reads as a hitch on every cursor show.

## What it was not

Everything cursor-related was measured innocent. Our `ShowCursor` is one `SetCursor` (a wineserver round trip, 50 to 120 µs). Wine's macdrv serves it asynchronously. A clean-room Metal app showed `NSCursor` hide, unhide and a fresh cursor image set all under 1 ms with no effect on the presented cadence, SDR or EDR. In game, the presented-time cadence stayed at 8.33 ms p99 across 5,600 frames, including the frames after every show.

## Root cause

macOS posts `NSApplicationDidChangeScreenParametersNotification` for every step of an EDR headroom ramp, and the headroom follows ambient light, thermal state and on-screen content, so with the EDR layer attached the notification arrives at up to the refresh rate. Wine's application delegate treats each one as a display-mode change: a window-level pass on its main thread, a full GPU and monitor re-enumeration with registry writes in the desktop process, and a display-cache invalidation in every process. The press and release frames wait on that main thread synchronously, through `SetCapture`, `ReleaseCapture` and `SetCursorPos`, which is where their extra milliseconds came from. With `color.hdr.enable=false` the game saw 5 such notifications in 35 seconds; with HDR on, 366.

## Fix

At layer attach, the unix side unregisters Wine's `NSApplication` delegate from this one notification and observes it itself. Each delivery is compared against a snapshot of what Wine's display view depends on (per-screen frame, visible frame, backing scale, and the main display's CG mode) and forwarded to the delegate's own handler only when the snapshot changed. At the login screen this turned 121 deliveries into 2 forwarded, and the game's threads saw 3 `DISPLAYS_CHANGED` instead of about 120. The desktop process never loads mtld3d, so its copy of the storm is handled by a matching patch in the bundled Wine (`winemac: Ignore screen parameter notifications that change nothing Wine uses`).

In game: fast clicking no longer drops the frame rate, 120 is stable at idle, and the residual occasional blip after some releases is a 17 ms game-thread frame two frames after the release with no cursor call and no drawable wait in it, which is the game processing the click.

## Diagnostics that ride along

The first four commits are the instrumentation the investigation had to build and which stays: the cursor thunks join the per-thunk `ApiTimer` accounting (the only device thunks that were untimed), every cursor log line carries the wall time of its Win32 call, `device_present` feeds a hitch probe that names the late frame together with the last cursor transition and the cursor-call time inside it, and the unix side logs the presented-time cadence with the `nextDrawable` wait per frame. All of it is debug or trace output; the last commit makes the per-frame probes a single level check when their targets are off.

## Verification

`make check` and `make test` green on every commit (165 e2e per architecture). Login-screen counts above were taken with `WINEDEBUG=+event`; the in-game result was confirmed by hand with the per-frame rows enabled.
