### PR TITLE
Remove the remaining SipHash users and let the audit keep them out

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -18,6 +18,8 @@ Most of this document is enforced by `make check`: `cargo +nightly fmt --check`,
 | `pub(crate)` = 0 | §No `pub(crate)` |
 | `extern "stdcall"` = 0 | §`extern "system"` everywhere |
 | `msg_send!` / `class!` / `sel!` = 0 | §No raw `msg_send!` |
+| `HashMap` / `HashSet` = 0 (maps are `FxHashMap` / `FxHashSet`) | §FxHash for maps, xxh3 for content |
+| `DefaultHasher` / `RandomState` = 0 (content hashes are xxh3) | §FxHash for maps, xxh3 for content |
 | `mod.rs` files = 0 | §Module style |
 | Release hygiene (see below) | §Release hygiene |
 
@@ -392,6 +394,14 @@ The title is what rustdoc puts in the summary column of every index, and what a 
 /// own persistent `metal_color_handle` distinct from the backbuffer, plus its
 /// own format and dimensions.
 ```
+
+## FxHash for maps, xxh3 for content
+
+Every hash map and set in both workspaces is `rustc_hash::FxHashMap` / `FxHashSet`, never std's default `HashMap` / `HashSet`. The keys here are `u64`s, handles, ids and small derived-`Hash` structs; SipHash's DoS resistance buys nothing in a renderer and costs a dozen rounds per lookup where FxHash is one multiply. Build with `FxHashMap::default()` or `with_capacity_and_hasher(n, FxBuildHasher)`. `std::collections::hash_map::Entry` is hasher-agnostic and stays.
+
+Content hashing is a different job: folding a byte buffer or a composite key into a `u64` that then *is* the identity (shader bytecode, vertex declarations, cursor pixels, the on-disk shader-cache keys). That uses `xxhash_rust::xxh3::Xxh3`: fast over buffers, real avalanche, stable across toolchains. Never `DefaultHasher` (SipHash, and std documents its algorithm as unspecified between releases) and never `FxHasher`, which spreads keys across buckets but is not an identity: a map absorbs a collision with the `Eq` compare that follows, a content hash has nothing behind it.
+
+The audit bans `HashMap`, `HashSet`, `DefaultHasher` and `RandomState` outside comments.
 
 ## Dependencies
 

--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -191,6 +191,10 @@ case "${1:-}" in
         'extern "stdcall"' "$file"
     banned 'msg_send!|class!\(|sel!\(' 'No raw msg_send! — use typed objc2-* bindings' \
         'untyped Obj-C selector' "$file"
+    banned '(^|[^A-Za-z0-9_])Hash(Map|Set)([^A-Za-z0-9_]|$)' 'FxHash for maps, xxh3 for content' \
+        'std HashMap/HashSet: use rustc_hash::FxHashMap / FxHashSet' "$file"
+    banned 'DefaultHasher|RandomState' 'FxHash for maps, xxh3 for content' \
+        'SipHash hasher: content hashing uses xxhash_rust::xxh3::Xxh3' "$file"
     confined 'inline\(always\)' 'Inline attributes' \
         '#[inline(always)] outside the one measured site' "$INLINE_ALWAYS_SITES" "$file"
     confined '^[ \t]*static .*: *OnceLock' 'LazyLock over OnceLock' \
@@ -230,6 +234,10 @@ banned 'extern "stdcall"' 'extern "system" everywhere, not extern "stdcall"' \
     'extern "stdcall"' "$@"
 banned 'msg_send!|class!\(|sel!\(' 'No raw msg_send! — use typed objc2-* bindings' \
     'untyped Obj-C selector' "$@"
+banned '(^|[^A-Za-z0-9_])Hash(Map|Set)([^A-Za-z0-9_]|$)' 'FxHash for maps, xxh3 for content' \
+    'std HashMap/HashSet: use rustc_hash::FxHashMap / FxHashSet' "$@"
+banned 'DefaultHasher|RandomState' 'FxHash for maps, xxh3 for content' \
+    'SipHash hasher: content hashing uses xxhash_rust::xxh3::Xxh3' "$@"
 
 confined 'inline\(always\)' 'Inline attributes' \
     '#[inline(always)] outside the one measured site' "$INLINE_ALWAYS_SITES" "$@"

--- a/unix/Cargo.lock
+++ b/unix/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "objc2-metal",
  "objc2-metal-fx",
  "objc2-quartz-core",
+ "rustc-hash",
  "strum",
 ]
 
@@ -462,6 +463,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "serde_core"

--- a/unix/Cargo.toml
+++ b/unix/Cargo.toml
@@ -74,6 +74,7 @@ objc2-metal = { version = "0.3", features = [
 ] }
 objc2-metal-fx = { version = "0.3", features = ["MTLFXSpatialScaler"] }
 objc2-quartz-core = { version = "0.3", features = ["CAMetalLayer", "objc2-metal"] }
+rustc-hash = "2"
 strum = { version = "0.28", default-features = false }
 
 [profile.dev]

--- a/unix/unix/Cargo.toml
+++ b/unix/unix/Cargo.toml
@@ -25,6 +25,7 @@ objc2-foundation = { workspace = true }
 objc2-metal = { workspace = true }
 objc2-metal-fx = { workspace = true }
 objc2-quartz-core = { workspace = true }
+rustc-hash = { workspace = true }
 strum = { workspace = true }
 
 [lints]

--- a/unix/unix/src/metal/blit.rs
+++ b/unix/unix/src/metal/blit.rs
@@ -16,10 +16,7 @@
 //! Pipelines + library are process-lifetime (leaked via `Retained::into_raw`)
 //! — same posture as `clear_quad` / `present`.
 
-use std::{
-    collections::HashMap,
-    sync::{Mutex, OnceLock},
-};
+use std::sync::{Mutex, OnceLock};
 
 use mtld3d_shared::{
     EnsureBlitPipelineParams, MetalHandle,
@@ -32,6 +29,7 @@ use objc2_metal::{
     MTLCompileOptions, MTLDevice, MTLLanguageVersion, MTLLibrary, MTLMathMode,
     MTLRenderPipelineDescriptor,
 };
+use rustc_hash::FxHashMap;
 
 use super::texture::mtl_pixel_format;
 use crate::{LOG_TARGET, metal::handle::IntoRetained};
@@ -99,7 +97,7 @@ const PS_NAME: &str = "mtld3d_blit_ps";
 struct BlitCache {
     vs_fn: MetalHandle<MTLFunctionKind>,
     ps_fn: MetalHandle<MTLFunctionKind>,
-    pipelines: Mutex<HashMap<PixelFormat, MetalHandle<MTLRenderPipelineStateKind>>>,
+    pipelines: Mutex<FxHashMap<PixelFormat, MetalHandle<MTLRenderPipelineStateKind>>>,
 }
 
 static CACHE: OnceLock<Option<BlitCache>> = OnceLock::new();
@@ -166,7 +164,7 @@ fn build_library_and_functions(device: &ProtocolObject<dyn MTLDevice>) -> Option
     Some(BlitCache {
         vs_fn: vs_handle,
         ps_fn: ps_handle,
-        pipelines: Mutex::new(HashMap::new()),
+        pipelines: Mutex::new(FxHashMap::default()),
     })
 }
 

--- a/unix/unix/src/metal/clear_quad.rs
+++ b/unix/unix/src/metal/clear_quad.rs
@@ -28,10 +28,7 @@
 //! entries. Pipelines + library are process-lifetime (leaked via
 //! `Retained::into_raw`) — same posture as `present`.
 
-use std::{
-    collections::HashMap,
-    sync::{Mutex, OnceLock},
-};
+use std::sync::{Mutex, OnceLock};
 
 use mtld3d_shared::{
     EnsureClearQuadPipelineParams, MetalHandle,
@@ -44,6 +41,7 @@ use objc2_metal::{
     MTLCompileOptions, MTLDevice, MTLLanguageVersion, MTLLibrary, MTLMathMode, MTLPixelFormat,
     MTLRenderPipelineDescriptor,
 };
+use rustc_hash::FxHashMap;
 
 use super::texture::mtl_pixel_format;
 use crate::{LOG_TARGET, metal::handle::IntoRetained};
@@ -114,7 +112,7 @@ struct ClearQuadKey {
 struct ClearQuadCache {
     vs_fn: MetalHandle<MTLFunctionKind>,
     ps_color_fn: MetalHandle<MTLFunctionKind>,
-    pipelines: Mutex<HashMap<ClearQuadKey, MetalHandle<MTLRenderPipelineStateKind>>>,
+    pipelines: Mutex<FxHashMap<ClearQuadKey, MetalHandle<MTLRenderPipelineStateKind>>>,
 }
 
 static CACHE: OnceLock<Option<ClearQuadCache>> = OnceLock::new();
@@ -190,7 +188,7 @@ fn build_library_and_functions(device: &ProtocolObject<dyn MTLDevice>) -> Option
     Some(ClearQuadCache {
         vs_fn: vs_handle,
         ps_color_fn: ps_color_handle,
-        pipelines: Mutex::new(HashMap::new()),
+        pipelines: Mutex::new(FxHashMap::default()),
     })
 }
 

--- a/unix/unix/src/metal/upscale.rs
+++ b/unix/unix/src/metal/upscale.rs
@@ -33,7 +33,7 @@
 //! release deferred to a command buffer that outlives the evicted scaler.
 
 use std::{
-    collections::{HashMap, hash_map::Entry},
+    collections::hash_map::Entry,
     sync::{Mutex, OnceLock},
 };
 
@@ -49,6 +49,7 @@ use objc2_metal_fx::{
     MTLFXSpatialScaler, MTLFXSpatialScalerBase, MTLFXSpatialScalerColorProcessingMode,
     MTLFXSpatialScalerDescriptor,
 };
+use rustc_hash::FxHashMap;
 
 use crate::{LOG_TARGET, metal::handle::IntoRetained};
 
@@ -87,7 +88,7 @@ static CACHE: OnceLock<Option<Mutex<ScalerCache>>> = OnceLock::new();
 /// The live scalers, plus what it takes to bound them.
 struct ScalerCache {
     /// One entry per geometry currently served.
-    scalers: HashMap<ScalerKey, ScalerEntry>,
+    scalers: FxHashMap<ScalerKey, ScalerEntry>,
     /// Monotonic lookup counter that orders [`ScalerEntry::last_used`].
     tick: u64,
     /// Evicted scalers, awaiting a command buffer to outlive them.
@@ -320,7 +321,7 @@ fn init_cache(device: &ProtocolObject<dyn MTLDevice>) -> Option<Mutex<ScalerCach
         return None;
     }
     Some(Mutex::new(ScalerCache {
-        scalers: HashMap::new(),
+        scalers: FxHashMap::default(),
         tick: 0,
         evicted: Vec::new(),
     }))
@@ -394,7 +395,7 @@ struct ScratchKey {
 /// Stores the wire handle rather than a `Retained` so the map is trivially
 /// `Send`; each use re-borrows through `IntoRetained`, which bumps the refcount
 /// and leaves the cache's own retain live.
-static SCRATCH: OnceLock<Mutex<HashMap<ScratchKey, u64>>> = OnceLock::new();
+static SCRATCH: OnceLock<Mutex<FxHashMap<ScratchKey, u64>>> = OnceLock::new();
 
 /// Get, or create and cache, a `Private` scratch texture of this size and format.
 ///
@@ -415,7 +416,7 @@ pub fn scratch_target(
         height,
         format,
     };
-    let cache = SCRATCH.get_or_init(|| Mutex::new(HashMap::new()));
+    let cache = SCRATCH.get_or_init(|| Mutex::new(FxHashMap::default()));
     let handle = {
         let mut scratch = cache.lock().ok()?;
         match scratch.entry(key) {

--- a/windows/Cargo.lock
+++ b/windows/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "rustc-hash",
  "snmalloc-rs",
  "xbr",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/windows/core/src/convert.rs
+++ b/windows/core/src/convert.rs
@@ -30,6 +30,7 @@ use mtld3d_types::{
     D3DTADDRESS_MIRROR, D3DTADDRESS_MIRRORONCE, D3DTADDRESS_WRAP, D3DTEXF_ANISOTROPIC,
     D3DTEXF_LINEAR, D3DTEXF_NONE, D3DTEXF_POINT, D3DVERTEXELEMENT9,
 };
+use xxhash_rust::xxh3::Xxh3;
 
 use crate::dxso::{DeclUsage, ff_attr_index_for_semantic};
 
@@ -857,7 +858,7 @@ pub fn resolve_attrs_for_ff(elements: &[D3DVERTEXELEMENT9]) -> (Vec<VertexAttrDe
 /// same elements produce the same hash.
 #[must_use]
 pub fn hash_elements(elements: &[D3DVERTEXELEMENT9]) -> u64 {
-    let mut h = std::collections::hash_map::DefaultHasher::new();
+    let mut h = Xxh3::new();
     for e in elements {
         e.hash(&mut h);
     }

--- a/windows/core/src/passes.rs
+++ b/windows/core/src/passes.rs
@@ -3,11 +3,6 @@
 //! Holds the `passes: Vec<Pass>` plus the bookkeeping for pass breaks on
 //! `SetRenderTarget`, `SetDepthStencilSurface`, and mid-frame `Clear`.
 
-use std::{
-    collections::{HashMap, HashSet},
-    hash::BuildHasher,
-};
-
 use log::{Level, log_enabled, trace};
 use mtld3d_shared::{
     BlitCommand, BlitCommandType, Command, CommandType, MetalHandle,
@@ -549,11 +544,11 @@ pub struct PassState {
     /// so accumulated draws survive across pass breaks. Reset each frame
     /// in `reset_frame`. Capacity hint matches a typical frame shape
     /// (backbuffer + a few CSM ping-pong RTs).
-    seen_color_rts: HashSet<(MetalHandle<MTLTextureKind>, u32)>,
+    seen_color_rts: FxHashSet<(MetalHandle<MTLTextureKind>, u32)>,
     /// Depth-attachment textures that have already been used as a depth rt in this frame.
     ///
     /// Same semantics as `seen_color_rts`.
-    seen_depth_rts: HashSet<MetalHandle<MTLTextureKind>>,
+    seen_depth_rts: FxHashSet<MetalHandle<MTLTextureKind>>,
     /// The swap-chain backbuffer texture for this frame, captured in `reset_frame`.
     ///
     /// Rule D (last-use color `Store=DontCare`) exempts this handle so
@@ -629,18 +624,18 @@ pub struct PassState {
     /// handle in this set is a cascade-depth read, and is counted
     /// into `frame_cascade_samples`. Persistent across frames
     /// (textures are stable resource identities).
-    seen_sampleable_depth_textures: HashSet<MetalHandle<MTLTextureKind>>,
+    seen_sampleable_depth_textures: FxHashSet<MetalHandle<MTLTextureKind>>,
     /// Per-frame counter: how many caster draws targeted each cascade depth handle.
     ///
     /// Counts the draws made this frame. Incremented in `note_caster_draw`,
     /// drained + cleared by `take_cascade_frame_summary`.
-    frame_caster_writes: HashMap<MetalHandle<MTLTextureKind>, u32>,
+    frame_caster_writes: FxHashMap<MetalHandle<MTLTextureKind>, u32>,
     /// Per-frame counter: how many `SetFragmentTexture` binds of a known cascade depth handle.
     ///
     /// Counts the binds emitted this frame. Incremented in `emit_command`
     /// when the bound texture is in `seen_sampleable_depth_textures`.
     /// Drained by `take_cascade_frame_summary`.
-    frame_cascade_samples: HashMap<MetalHandle<MTLTextureKind>, u32>,
+    frame_cascade_samples: FxHashMap<MetalHandle<MTLTextureKind>, u32>,
     /// Monotonic per-frame counter for the cascade-summary log line.
     ///
     /// Distinct from `submit_seq` (encoder-thread): incremented in
@@ -710,8 +705,8 @@ impl PassState {
             viewport_max_z: 1.0,
             last_emitted_viewport: None,
             pending_leading_blits: Vec::new(),
-            seen_color_rts: HashSet::with_capacity(4),
-            seen_depth_rts: HashSet::with_capacity(2),
+            seen_color_rts: FxHashSet::with_capacity_and_hasher(4, FxBuildHasher),
+            seen_depth_rts: FxHashSet::with_capacity_and_hasher(2, FxBuildHasher),
             backbuffer_texture: MetalHandle::NULL,
             // Placeholder; `reset_frame` reseeds it from the frame stamp.
             // Identity means a `PassState` that never saw a frame cannot
@@ -722,9 +717,9 @@ impl PassState {
             backbuffer_logical_size: (0, 0),
             seen_sampled_textures: FxHashSet::with_capacity_and_hasher(8, FxBuildHasher),
             frame_sampled_textures: FxHashSet::with_capacity_and_hasher(64, FxBuildHasher),
-            seen_sampleable_depth_textures: HashSet::with_capacity(8),
-            frame_caster_writes: HashMap::with_capacity(8),
-            frame_cascade_samples: HashMap::with_capacity(8),
+            seen_sampleable_depth_textures: FxHashSet::with_capacity_and_hasher(8, FxBuildHasher),
+            frame_caster_writes: FxHashMap::with_capacity_and_hasher(8, FxBuildHasher),
+            frame_cascade_samples: FxHashMap::with_capacity_and_hasher(8, FxBuildHasher),
             frame_seq: 0,
             cmd_vec_realloc_bytes: 0,
             command_vec_pool: Vec::with_capacity(MAX_CMD_VEC_POOL),
@@ -1140,8 +1135,9 @@ impl PassState {
     pub fn take_cascade_frame_summary(
         &mut self,
     ) -> (u64, Vec<(MetalHandle<MTLTextureKind>, u32, u32)>) {
-        let mut keys: HashSet<MetalHandle<MTLTextureKind>> = HashSet::with_capacity(
+        let mut keys: FxHashSet<MetalHandle<MTLTextureKind>> = FxHashSet::with_capacity_and_hasher(
             self.frame_caster_writes.len() + self.frame_cascade_samples.len(),
+            FxBuildHasher,
         );
         keys.extend(self.frame_caster_writes.keys().copied());
         keys.extend(self.frame_cascade_samples.keys().copied());
@@ -2148,9 +2144,9 @@ impl PassState {
     /// so clear-only passes are already handled, and before
     /// `cull_dead_clear_only_passes` (Rule F) — though Rule F won't
     /// touch the pass anyway because it still has draws.
-    pub fn strip_color_from_no_color_draw_passes<S: BuildHasher>(
+    pub fn strip_color_from_no_color_draw_passes(
         &mut self,
-        alt: &HashMap<u64, MetalHandle<MTLRenderPipelineStateKind>, S>,
+        alt: &FxHashMap<u64, MetalHandle<MTLRenderPipelineStateKind>>,
     ) {
         if !ENABLE_NO_COLOR_PASS_FOR_DRAWS {
             return;
@@ -2494,8 +2490,8 @@ impl PassState {
     ///   `i.color_store`. Then update the map with `i`.
     pub fn finalize_store_actions(&mut self) {
         if ENABLE_LAST_USE_DEPTH_DONTCARE {
-            let mut handled: HashSet<MetalHandle<MTLTextureKind>> =
-                HashSet::with_capacity(self.seen_depth_rts.len());
+            let mut handled: FxHashSet<MetalHandle<MTLTextureKind>> =
+                FxHashSet::with_capacity_and_hasher(self.seen_depth_rts.len(), FxBuildHasher);
             for pass in self.passes.iter_mut().rev() {
                 if pass.depth_texture.is_null() {
                     continue;
@@ -2531,8 +2527,8 @@ impl PassState {
             }
         }
         if ENABLE_NEXT_CLEAR_COLOR_DONTCARE {
-            let mut next_color_use: HashMap<(MetalHandle<MTLTextureKind>, u32), usize> =
-                HashMap::with_capacity(self.seen_color_rts.len());
+            let mut next_color_use: FxHashMap<(MetalHandle<MTLTextureKind>, u32), usize> =
+                FxHashMap::with_capacity_and_hasher(self.seen_color_rts.len(), FxBuildHasher);
             for i in (0..self.passes.len()).rev() {
                 let rt = self.passes[i].color_texture;
                 let key = (rt, self.passes[i].color_subresource);
@@ -2553,8 +2549,8 @@ impl PassState {
             }
         }
         if ENABLE_LAST_USE_COLOR_DONTCARE {
-            let mut handled: HashSet<(MetalHandle<MTLTextureKind>, u32)> =
-                HashSet::with_capacity(self.seen_color_rts.len());
+            let mut handled: FxHashSet<(MetalHandle<MTLTextureKind>, u32)> =
+                FxHashSet::with_capacity_and_hasher(self.seen_color_rts.len(), FxBuildHasher);
             for pass in self.passes.iter_mut().rev() {
                 let rt = pass.color_texture;
                 if rt.is_null() || rt == self.backbuffer_texture {
@@ -4912,7 +4908,7 @@ mod tests {
             s.emit_command(dummy_draw());
         }
         s.end_current_pass("test");
-        let mut alt = HashMap::new();
+        let mut alt = FxHashMap::default();
         alt.insert(PSO_WITH, pso(PSO_NO_COLOR));
         s.strip_color_from_no_color_draw_passes(&alt);
         let pass = &s.passes()[0];
@@ -4950,7 +4946,7 @@ mod tests {
         s.emit_command(set_pso(PSO_WITH));
         s.emit_command(dummy_draw());
         s.end_current_pass("test");
-        let mut alt = HashMap::new();
+        let mut alt = FxHashMap::default();
         alt.insert(PSO_WITH, pso(PSO_NO_COLOR));
         s.strip_color_from_no_color_draw_passes(&alt);
         let pass = &s.passes()[0];
@@ -4977,7 +4973,7 @@ mod tests {
         s.emit_command(set_pso(PSO_WITH));
         s.emit_command(dummy_draw());
         s.end_current_pass("test");
-        let mut alt = HashMap::new();
+        let mut alt = FxHashMap::default();
         alt.insert(PSO_WITH, pso(PSO_NO_COLOR));
         s.strip_color_from_no_color_draw_passes(&alt);
         let pass = &s.passes()[0];
@@ -4995,7 +4991,7 @@ mod tests {
         let mut s = fresh();
         s.clear_color(0, 0, 0, 0);
         s.flush_pending_clears();
-        let alt: HashMap<u64, MetalHandle<MTLRenderPipelineStateKind>> = HashMap::new();
+        let alt: FxHashMap<u64, MetalHandle<MTLRenderPipelineStateKind>> = FxHashMap::default();
         s.strip_color_from_no_color_draw_passes(&alt);
         let pass = &s.passes()[0];
         // Color still attached — Rule H bailed because the pass had
@@ -5015,7 +5011,7 @@ mod tests {
         s.emit_command(set_pso(PSO_WITH));
         s.emit_command(dummy_draw());
         s.end_current_pass("test");
-        let alt: HashMap<u64, MetalHandle<MTLRenderPipelineStateKind>> = HashMap::new();
+        let alt: FxHashMap<u64, MetalHandle<MTLRenderPipelineStateKind>> = FxHashMap::default();
         s.strip_color_from_no_color_draw_passes(&alt);
         let pass = &s.passes()[0];
         assert_eq!(
@@ -5054,7 +5050,7 @@ mod tests {
         }
         s.end_current_pass("test");
 
-        let mut alt = HashMap::new();
+        let mut alt = FxHashMap::default();
         alt.insert(PSO_CASTER, pso(PSO_CASTER_NO_COLOR));
         alt.insert(PSO_CLEAR_QUAD_DEPTH, pso(PSO_CLEAR_QUAD_DEPTH));
         s.strip_color_from_no_color_draw_passes(&alt);
@@ -5111,7 +5107,7 @@ mod tests {
         s.end_current_pass("test");
         // Only the real caster needs a side-map entry; clear-quad
         // PSOs are removed wholesale and don't need to resolve.
-        let mut alt = HashMap::new();
+        let mut alt = FxHashMap::default();
         alt.insert(PSO_WITH, pso(PSO_NO_COLOR));
         s.strip_color_from_no_color_draw_passes(&alt);
 
@@ -5167,7 +5163,7 @@ mod tests {
         s.emit_command(dummy_draw());
         s.end_current_pass("test");
 
-        let mut alt = HashMap::new();
+        let mut alt = FxHashMap::default();
         alt.insert(PSO_WITH, pso(PSO_NO_COLOR));
         s.strip_color_from_no_color_draw_passes(&alt);
 
@@ -5214,7 +5210,7 @@ mod tests {
         s.close_color_clear_quad_block(start);
         s.end_current_pass("test");
 
-        let alt: HashMap<u64, MetalHandle<MTLRenderPipelineStateKind>> = HashMap::new();
+        let alt: FxHashMap<u64, MetalHandle<MTLRenderPipelineStateKind>> = FxHashMap::default();
         s.strip_color_from_no_color_draw_passes(&alt);
 
         let pass = &s.passes()[0];

--- a/windows/core/src/perf.rs
+++ b/windows/core/src/perf.rs
@@ -29,7 +29,7 @@
 //! from their device pointer at construction time.
 
 #[cfg(perf_tracking)]
-use std::{collections::HashMap, fmt::Write as _, sync::LazyLock};
+use std::{fmt::Write as _, sync::LazyLock};
 
 #[cfg(perf_tracking)]
 use log::{info, trace};
@@ -46,6 +46,8 @@ use mtld3d_shared::{
     tsc::{cycles_to_ms, rdtsc, secs_to_cycles},
 };
 use mtld3d_shared::{MetalHandle, mtl_handle::MTLTextureKind};
+#[cfg(perf_tracking)]
+use rustc_hash::FxHashMap;
 // Brings `OpSub::COUNT` (the `strum::EnumCount` associated const) into scope
 // for the `[_; OpSub::COUNT]` arrays below. Only referenced from
 // perf-tracking code, so the import is elided under `not(perf_tracking)`.
@@ -1392,9 +1394,9 @@ impl FramePerfPayload {
 /// Used as a map key for the per-pair stats and as the formatted tag in
 /// trace dumps.
 ///
-/// The module in d3d9 that constructs these fills `hash` from
-/// `ProgramId.raw()` when `is_programmable`, or from a `DefaultHasher` over
-/// the fixed-function key otherwise.
+/// The module in d3d9 that constructs these fills `hash` with the shader's
+/// on-disk cache key (xxh3 over the program id or the fixed-function key),
+/// so the tag matches the entry-point name seen in Metal captures.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PairShaderId {
     pub is_programmable: bool,
@@ -1518,7 +1520,7 @@ pub struct EncoderPerfState {
     /// frame with nothing returned yet reports 0 rather than stale data).
     enc: EncoderFrameCounters,
 
-    per_pair_stats: HashMap<(u32, u32, PairShaderId, PairShaderId), PerPairStats>,
+    per_pair_stats: FxHashMap<(u32, u32, PairShaderId, PairShaderId), PerPairStats>,
 
     // ── Running totals (live across frames) ──
     /// Byte total of live `PageBoxes` in the encoder's retention queue.
@@ -1566,7 +1568,7 @@ impl EncoderPerfState {
             counters: FrameCounters::new(),
             timing: FrameTiming::new(),
             enc: EncoderFrameCounters::new(),
-            per_pair_stats: HashMap::new(),
+            per_pair_stats: FxHashMap::default(),
             vbib_retained_bytes: 0,
             tex_staging_retained_bytes: 0,
             prev_pagebox_volume: PageBoxVolume::new(),

--- a/windows/core/src/shader_cache.rs
+++ b/windows/core/src/shader_cache.rs
@@ -42,11 +42,9 @@
 //! testable. Encoder-side write hooks and pre-warm-thread plumbing live in
 //! `windows/d3d9`.
 
-use std::{
-    collections::HashSet,
-    hash::{Hash, Hasher},
-};
+use std::hash::{Hash, Hasher};
 
+use rustc_hash::FxHashSet;
 use xxhash_rust::xxh3::Xxh3;
 
 use crate::shader_compile_stats::CompileBucket;
@@ -426,7 +424,7 @@ pub fn read_records(bytes: &[u8]) -> (Vec<CacheEntry>, bool) {
     let mut single_count: usize = 0;
     let mut bundle_count: usize = 0;
     let mut other_chunk = false;
-    let mut seen_keys: HashSet<u64> = HashSet::new();
+    let mut seen_keys: FxHashSet<u64> = FxHashSet::default();
     let mut duplicates = false;
 
     while off + CHUNK_HEADER_LEN <= bytes.len() {

--- a/windows/d3d9/Cargo.toml
+++ b/windows/d3d9/Cargo.toml
@@ -19,6 +19,7 @@ log = { workspace = true }
 rustc-hash = { workspace = true }
 snmalloc-rs = { workspace = true }
 xbr = { workspace = true }
+xxhash-rust = { workspace = true }
 
 [lints]
 workspace = true

--- a/windows/d3d9/src/cursor.rs
+++ b/windows/d3d9/src/cursor.rs
@@ -12,7 +12,6 @@
 
 use core::{ffi::c_void, ptr::null_mut};
 use std::{
-    collections::{HashMap, hash_map::DefaultHasher},
     hash::Hasher,
     sync::{LazyLock, Mutex},
     time::Instant,
@@ -24,6 +23,8 @@ use mtld3d_shared::InPtr;
 use mtld3d_types::{
     D3DLOCK_READONLY, D3DLOCKED_RECT, D3DSURFACE_DESC, ICONINFO, IDirect3DSurface9Vtbl, POINT,
 };
+use rustc_hash::FxHashMap;
+use xxhash_rust::xxh3::Xxh3;
 
 use super::{
     D3D_OK, D3DERR_INVALIDCALL,
@@ -230,8 +231,8 @@ const WM_APP_REASSERT_FULLSCREEN: u32 = 0x8000 + 0x03D9;
 /// when more than one device exists at once (the second `CreateDevice` would
 /// orphan the first window's cursor and, once either device tears down, leave a
 /// still-subclassed window pointing at a stale/cleared device).
-static DEVICE_INSTANCES: LazyLock<Mutex<HashMap<usize, usize>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static DEVICE_INSTANCES: LazyLock<Mutex<FxHashMap<usize, usize>>> =
+    LazyLock::new(|| Mutex::new(FxHashMap::default()));
 
 // ── CursorState ──
 
@@ -314,7 +315,7 @@ pub struct CursorState {
     handle: *mut c_void,
     flags: CursorFlags,
     hash: u64,
-    cache: HashMap<u64, *mut c_void>,
+    cache: FxHashMap<u64, *mut c_void>,
     probe: HitchProbe,
     /// Nearest-neighbor upscale factor applied to the cursor bitmap.
     ///
@@ -335,7 +336,7 @@ impl CursorState {
             // cursor image is set and shown).
             flags: CursorFlags::DIRTY,
             hash: 0,
-            cache: HashMap::new(),
+            cache: FxHashMap::default(),
             probe: HitchProbe::new(),
             scale: scale.clamp(1, 8),
         }
@@ -936,9 +937,10 @@ extern "system" fn cursor_wnd_proc(hwnd: *mut c_void, msg: u32, wp: usize, lp: i
 
 /// Content-hash over hotspot + dimensions + pixel bytes.
 ///
-/// Used as the cursor cache key inside `SetCursorProperties`. Cold-path (a
-/// handful of calls per session), so `DefaultHasher` is used here for
-/// consistency with `ProgramId::from_tokens`.
+/// Used as the cursor cache key inside `SetCursorProperties`. xxh3 is the
+/// content hash for byte buffers throughout the tree (see `ProgramId`); the
+/// value is the whole identity of the cursor, so it needs real avalanche, not
+/// a map hasher.
 fn hash_cursor(
     x_hotspot: u32,
     y_hotspot: u32,
@@ -947,7 +949,7 @@ fn hash_cursor(
     src: *const u8,
     pitch: usize,
 ) -> u64 {
-    let mut h = DefaultHasher::new();
+    let mut h = Xxh3::new();
     h.write_u32(x_hotspot);
     h.write_u32(y_hotspot);
     h.write_u32(width);

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashSet, VecDeque, hash_map::Entry},
+    collections::{VecDeque, hash_map::Entry},
     fs::{File, OpenOptions},
     io::Write as _,
     path::PathBuf,
@@ -66,7 +66,7 @@ use mtld3d_types::{D3DCMP_ALWAYS, D3DSAMP_MIPMAPLODBIAS, SAMPLER_STATE_COUNT};
 // (texture/lib/pipeline/sampler/buffer/...). Keys are small trusted integers
 // or fixed structs; SipHash's DoS resistance buys nothing here and its
 // per-probe cost shows up in the encoder `resolve`/`binds`/`samplers` phases.
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::{
     LOG_TARGET,
@@ -671,7 +671,7 @@ pub struct FrameEncoder {
     /// happen to share dimensions stay distinguishable. Lives on
     /// `FrameEncoder` rather than the perf struct because the log itself
     /// is a shader-debug aid (target `mtld3d::d3d9`), not perf telemetry.
-    pass_shader_log_fired: HashSet<(MetalHandle<MTLTextureKind>, PairShaderId, PairShaderId)>,
+    pass_shader_log_fired: FxHashSet<(MetalHandle<MTLTextureKind>, PairShaderId, PairShaderId)>,
 
     /// Captured at encoder spawn from `MTLDevice` queries.
     ///
@@ -1069,7 +1069,7 @@ impl FrameEncoder {
             backbuffer_width: 0,
             backbuffer_height: 0,
             perf: EncoderPerfState::new(),
-            pass_shader_log_fired: HashSet::new(),
+            pass_shader_log_fired: FxHashSet::default(),
             gpu_caps,
             device_handle: MetalHandle::NULL,
             depth_stencil_cache: FxHashMap::default(),

--- a/windows/d3d9/src/private_data.rs
+++ b/windows/d3d9/src/private_data.rs
@@ -8,11 +8,11 @@
 //! it) falls out of the store's own `Drop`.
 
 use core::ffi::c_void;
-use std::collections::HashMap;
 
 use mtld3d_types::{
     D3D_OK, D3DERR_INVALIDCALL, D3DERR_MOREDATA, D3DERR_NOTFOUND, D3DSPD_IUNKNOWN, Guid,
 };
+use rustc_hash::FxHashMap;
 
 /// `IUnknown` vtable head, enough to call `AddRef`/`Release` on an external COM pointer.
 ///
@@ -78,7 +78,7 @@ impl Entry {
 /// Per-resource GUID-keyed private-data table.
 #[derive(Default)]
 pub struct PrivateDataStore {
-    entries: HashMap<Guid, Entry>,
+    entries: FxHashMap<Guid, Entry>,
 }
 
 impl PrivateDataStore {

--- a/windows/d3d9/src/shader_prewarm.rs
+++ b/windows/d3d9/src/shader_prewarm.rs
@@ -9,7 +9,6 @@
 //! about to land in `lib_cache`.
 
 use std::{
-    collections::HashSet,
     fs,
     path::{Path, PathBuf},
     sync::{
@@ -26,6 +25,7 @@ use mtld3d_core::{
     shader_compile_stats::{CompileBucket, Snapshot, format_summary},
 };
 use mtld3d_shared::{MetalHandle, mtl::StageTag, mtl_handle::MTLDeviceKind};
+use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use crate::{
     LOG_TARGET,
@@ -162,7 +162,7 @@ fn run(device_handle: MetalHandle<MTLDeviceKind>, sender: PrewarmSender, stop: &
     // we'd pay `newLibraryWithSource:` cost N times for a key that
     // appeared in both the bundle and a later append.
     let mut deduped: Vec<CacheEntry> = Vec::with_capacity(entries.len());
-    let mut seen = HashSet::with_capacity(entries.len());
+    let mut seen = FxHashSet::with_capacity_and_hasher(entries.len(), FxBuildHasher);
     for entry in entries {
         if seen.insert(entry.key) {
             deduped.push(entry);


### PR DESCRIPTION
Every remaining SipHash user in both workspaces is gone. Eleven files still built std `HashMap`/`HashSet`, which hash with SipHash-1-3, and two content hashes still ran `DefaultHasher` (also SipHash) over byte buffers. `CONTRIBUTING.md` has said "hash maps use `FxHashMap`; content hashing uses xxh3" for a while, but nothing enforced it, so it drifted. This PR migrates the stragglers and makes `make audit` fail on any reintroduction.

Maps and sets move to `rustc_hash::FxHashMap`/`FxHashSet`. The keys everywhere are `u64`s, `MetalHandle`s, ids and small derived-`Hash` structs, so the hasher is one multiply instead of a dozen SipHash rounds per lookup. PE side: `passes.rs` (the frame's seen-RT sets, cascade counters, and the Rule D/E working sets), `perf.rs` (`per_pair_stats`), `shader_cache.rs`, `encoder.rs` (`pass_shader_log_fired`), `cursor.rs` (`DEVICE_INSTANCES`, the cursor cache), `private_data.rs`, `shader_prewarm.rs`. Unix side: the blit and clear-quad pipeline caches and the MetalFX scaler/scratch caches in `upscale.rs`; the unix workspace gains the `rustc-hash` dependency for that. `strip_color_from_no_color_draw_passes` drops its `S: BuildHasher` generic, which only existed so the tests could pass a std map.

The two content hashes move to `xxhash_rust::xxh3::Xxh3`, the hash the tree already uses for `ProgramId` and the shader-cache disk keys. `hash_elements` (vertex declaration identity behind `PipelineKey.vdecl_hash`) and `hash_cursor` (hotspot + dimensions + pixels behind the cursor cache key) both emit a `u64` that is the whole identity, with no `Eq` compare behind it, so they need a real content hash, not a map hasher. Neither value is persisted, so the shader-cache schema version does not change; the only visible effect is that every cursor is a first-time cache miss once on the new build. `windows/d3d9` gains the `xxhash-rust` dependency. The `hash_cursor` doc cited `ProgramId::from_tokens` as its `DefaultHasher` precedent and the `PairShaderId` doc still described a `DefaultHasher` over the FF key; both were stale and now describe what the code does.

Enforcement: `scripts/audit.sh` bans `HashMap`/`HashSet` and `DefaultHasher`/`RandomState` outside comments, in both whole-tree and `--file` mode, and `docs/CONVENTIONS.md` gets the section the findings point at plus two rows in the audit table. Verified the rules bite on a scratch file carrying both (and that comment mentions pass), and that the tree is at zero.

`make check` (fmt, clippy on both workspaces, audit, doc) and `make test-unit` (600 + 121 tests) pass. `make test-e2e-i686` and `make test-e2e-x86_64` both run 165/165 passed, each with one benign `LEAK` line. Not done here: an in-game smoke run; the only observable change is that every cursor misses the cursor cache once on first use with the new key.
