### PR TITLE
Remove the vectored exception handler when d3d9.dll is freed

### DIFF
--- a/windows/d3d9/src/crash.rs
+++ b/windows/d3d9/src/crash.rs
@@ -1,6 +1,16 @@
 //! Always-on PE-side crash diagnostics.
 //!
-//! Installed once from `init_logger()` during `DllMain` `PROCESS_ATTACH`.
+//! Installed once from `init_logger()` during `DllMain` `PROCESS_ATTACH`, and
+//! the vectored handler is removed again on a `PROCESS_DETACH` the process
+//! survives: a VEH registration is a process-wide pointer into this image, and
+//! launchers and benchmarks routinely `LoadLibrary` d3d9, probe the caps and
+//! `FreeLibrary` it before carrying on. Left behind, the registration turns
+//! the process's next exception (C++ throws included) into an instruction
+//! fetch from unmapped memory, which raises the next exception, which reaches
+//! the same stale entry, until the main thread's stack is gone. The panic hook
+//! needs no such care: it lives in this cdylib's own `std` and nothing else in
+//! the process can reach it once the image is gone.
+//!
 //! Two pieces, both diagnostic-only — they print the crumb trail and
 //! delegate termination to the normal SEH / `panic_abort` paths:
 //!
@@ -47,6 +57,8 @@ const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: u32 = 4;
 
 static INSTALLED: AtomicBool = AtomicBool::new(false);
 static D3D9_HMODULE: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
+/// The registration `RtlAddVectoredExceptionHandler` handed back, for [`uninstall`].
+static VEH_HANDLE: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
 
 #[repr(C)]
 struct ExceptionRecord {
@@ -68,6 +80,7 @@ type VectoredHandler = extern "system" fn(*mut ExceptionPointers) -> i32;
 
 unsafe extern "system" {
     fn RtlAddVectoredExceptionHandler(first: u32, handler: VectoredHandler) -> *mut c_void;
+    fn RtlRemoveVectoredExceptionHandler(handle: *mut c_void) -> u32;
     fn GetModuleHandleExA(flags: u32, module_name: *const u8, out: *mut *mut c_void) -> i32;
     fn GetStdHandle(handle: u32) -> *mut c_void;
     fn WriteFile(
@@ -98,11 +111,27 @@ pub fn install(d3d9_module: *mut c_void) {
     }
 
     D3D9_HMODULE.store(d3d9_module, Ordering::Release);
-    // SAFETY: kernel32 export; safe to call from DllMain.
-    unsafe {
-        RtlAddVectoredExceptionHandler(1, handler);
-    }
+    // SAFETY: ntdll export; safe to call from DllMain.
+    let veh = unsafe { RtlAddVectoredExceptionHandler(1, handler) };
+    VEH_HANDLE.store(veh, Ordering::Release);
     install_panic_hook();
+}
+
+/// Remove the VEH before the image goes away. Idempotent.
+///
+/// Called from `DllMain` `PROCESS_DETACH` on the path the process survives
+/// (a `FreeLibrary` before any device was created); the real-exit path
+/// terminates the process instead and never gets here.
+pub fn uninstall() {
+    if !INSTALLED.swap(false, Ordering::AcqRel) {
+        return;
+    }
+    let veh = VEH_HANDLE.swap(core::ptr::null_mut(), Ordering::AcqRel);
+    if veh.is_null() {
+        return;
+    }
+    // SAFETY: `veh` is the live registration `install` stored; ntdll export.
+    unsafe { RtlRemoveVectoredExceptionHandler(veh) };
 }
 
 fn install_panic_hook() {

--- a/windows/d3d9/src/lib.rs
+++ b/windows/d3d9/src/lib.rs
@@ -124,6 +124,11 @@ pub extern "system" fn dll_main(instance: *mut c_void, reason: u32, _reserved: *
         // SAFETY: pseudo-handle to current process; exit code 0.
         unsafe { TerminateProcess(proc, 0) };
     }
+    if reason == DLL_PROCESS_DETACH {
+        // A FreeLibrary the process survives: take the process-wide pointers
+        // into this image down with it.
+        crash::uninstall();
+    }
     if reason != DLL_PROCESS_ATTACH {
         return 1;
     }

--- a/windows/tests/COVERAGE.md
+++ b/windows/tests/COVERAGE.md
@@ -27,6 +27,7 @@ windows-msvc; the host-native `mtld3d-core`/`mtld3d-shared` unit tests run too).
 | `state_block.rs` | Capture/Apply (ALL); VERTEXSTATE restores FVF; PIXELSTATE restores sampler; Begin/EndStateBlock recording. |
 | `query.rs` | EVENT fence; OCCLUSION sample count; TIMESTAMP contract. |
 | `resource_misc.rs` | Factory refcount; `QueryInterface` → E_NOINTERFACE; `GetType`; no-op PreLoad/SetPriority; `GetAvailableTextureMem`; `EvictManagedResources`; `GetDevice`/`SetClipPlane` stubs; `ValidateDevice` → S_OK (single-pass valid); `SetGammaRamp` no-op. |
+| `unload.rs` | `LoadLibrary` → `Direct3DCreate9` → `Release` → `FreeLibrary`, then a continuable exception raised with a resuming handler appended at the end of the chain: proves the unloaded image left no vectored exception handler behind (no harness: its `raw-dylib` import would keep the module mapped). |
 
 ## Documented limitations / stubs pinned by tests
 

--- a/windows/tests/tests/unload.rs
+++ b/windows/tests/tests/unload.rs
@@ -1,0 +1,120 @@
+//! `FreeLibrary` must leave no pointer into the unmapped `d3d9.dll` behind.
+//!
+//! Launchers and benchmarks load `d3d9.dll`, probe `Direct3DCreate9` and the
+//! caps, and free it again; the process then carries on. Its next exception
+//! (MFC and the C++ runtime throw as control flow) walks the vectored-handler
+//! chain, and a handler still registered from the unloaded image faults on
+//! instruction fetch. That fault raises the next exception, which reaches the
+//! same stale handler, and the main thread's stack is gone within
+//! milliseconds. 3DMark05 died exactly like this after its capability check.
+//!
+//! The test replays the sequence: load, create, release, free, then raise a
+//! continuable exception with a resuming handler of its own appended at the
+//! END of the chain, so anything left at the front by the unloaded DLL runs
+//! first. With a stale handler the process dies; without one `RaiseException`
+//! returns and the probe flag is set.
+//!
+//! It deliberately does not use the shared harness: that links `d3d9.dll`
+//! through `raw-dylib`, and a static import keeps the module mapped no matter
+//! how often it is freed.
+
+use core::ffi::{c_char, c_void};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn LoadLibraryA(name: *const c_char) -> *mut c_void;
+    fn FreeLibrary(module: *mut c_void) -> i32;
+    fn GetProcAddress(module: *mut c_void, name: *const c_char) -> *mut c_void;
+    fn GetModuleHandleA(name: *const c_char) -> *mut c_void;
+    fn AddVectoredExceptionHandler(first: u32, handler: VectoredHandler) -> *mut c_void;
+    fn RemoveVectoredExceptionHandler(handle: *mut c_void) -> u32;
+    fn RaiseException(code: u32, flags: u32, n_args: u32, args: *const usize);
+}
+
+type VectoredHandler = unsafe extern "system" fn(*mut ExceptionPointers) -> i32;
+type Direct3DCreate9Fn = unsafe extern "system" fn(u32) -> *mut c_void;
+type ReleaseFn = unsafe extern "system" fn(*mut c_void) -> u32;
+
+#[repr(C)]
+struct ExceptionRecord {
+    code: u32,
+    flags: u32,
+    nested: *mut Self,
+    address: *mut c_void,
+    n_params: u32,
+    information: [usize; 15],
+}
+
+#[repr(C)]
+struct ExceptionPointers {
+    record: *mut ExceptionRecord,
+    context: *mut c_void,
+}
+
+const D3D_SDK_VERSION: u32 = 32;
+const EXCEPTION_CONTINUE_SEARCH: i32 = 0;
+const EXCEPTION_CONTINUE_EXECUTION: i32 = -1;
+/// A continuable, application-defined code: nothing else in the process raises it.
+const PROBE_CODE: u32 = 0xE0C0_FFEE;
+/// `IUnknown::Release` vtable slot.
+const RELEASE_SLOT: usize = 2;
+
+static PROBE_SEEN: AtomicBool = AtomicBool::new(false);
+
+unsafe extern "system" fn resume_probe(ep: *mut ExceptionPointers) -> i32 {
+    // SAFETY: the dispatcher hands a valid EXCEPTION_POINTERS for the call.
+    let record = unsafe { (*ep).record };
+    // SAFETY: the record pointer is valid for the handler's duration.
+    if unsafe { (*record).code } != PROBE_CODE {
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+    PROBE_SEEN.store(true, Ordering::Release);
+    EXCEPTION_CONTINUE_EXECUTION
+}
+
+#[test]
+fn exception_after_free_library_survives() {
+    // SAFETY: plain kernel32 call with a NUL-terminated name.
+    let lib = unsafe { LoadLibraryA(c"d3d9.dll".as_ptr()) };
+    assert!(!lib.is_null(), "LoadLibrary(d3d9.dll)");
+    // SAFETY: `lib` is a live module handle and the name is NUL-terminated.
+    let create = unsafe { GetProcAddress(lib, c"Direct3DCreate9".as_ptr()) };
+    assert!(!create.is_null(), "GetProcAddress(Direct3DCreate9)");
+    // SAFETY: the export is `Direct3DCreate9` with the documented signature.
+    let create: Direct3DCreate9Fn = unsafe { core::mem::transmute(create) };
+    // SAFETY: calling the resolved export with the SDK version it accepts.
+    let d3d9 = unsafe { create(D3D_SDK_VERSION) };
+    assert!(!d3d9.is_null(), "Direct3DCreate9 returned null");
+    // SAFETY: a COM object's first word is its vtable pointer.
+    let vtable = unsafe { *d3d9.cast::<*const ReleaseFn>() };
+    // SAFETY: every COM vtable has at least the three IUnknown slots.
+    let slot = unsafe { vtable.add(RELEASE_SLOT) };
+    // SAFETY: slot 2 of a COM vtable is Release, with the signature declared above.
+    let release: ReleaseFn = unsafe { *slot };
+    // SAFETY: releasing the one reference `Direct3DCreate9` handed out.
+    let remaining = unsafe { release(d3d9) };
+    assert_eq!(remaining, 0, "Release of the only IDirect3D9 reference");
+
+    // SAFETY: balancing the LoadLibrary above.
+    assert_ne!(unsafe { FreeLibrary(lib) }, 0, "FreeLibrary(d3d9.dll)");
+    // SAFETY: plain kernel32 lookup by name.
+    let still = unsafe { GetModuleHandleA(c"d3d9.dll".as_ptr()) };
+    assert!(
+        still.is_null(),
+        "d3d9.dll is still mapped after FreeLibrary, so this test cannot prove anything"
+    );
+
+    // SAFETY: appending (first = 0) a handler that stays valid for the test.
+    let handle = unsafe { AddVectoredExceptionHandler(0, resume_probe) };
+    assert!(!handle.is_null(), "AddVectoredExceptionHandler");
+    // SAFETY: a continuable exception (flags 0) with no parameters; the handler
+    // above resumes execution, so the call returns.
+    unsafe { RaiseException(PROBE_CODE, 0, 0, core::ptr::null()) };
+    assert!(
+        PROBE_SEEN.load(Ordering::Acquire),
+        "the resuming handler never ran"
+    );
+    // SAFETY: `handle` came from AddVectoredExceptionHandler above.
+    assert_ne!(unsafe { RemoveVectoredExceptionHandler(handle) }, 0);
+}


### PR DESCRIPTION
## Problem

3DMark05 (#3) died at startup with `err:virtual:virtual_setup_exception stack overflow 896 bytes addr 0x77526e50` on its main thread right after showing its capability dialog. With `WINEDEBUG=+loaddll` the address resolves to RVA 0x46e50 of our `d3d9.dll`, which the PDB names `d3d9::crash::handler`, the vectored exception handler, and the loader trace shows `d3d9.dll` being unloaded just before the fault.

`crash::install` registered the handler from `DllMain` and dropped the handle; nothing ever removed it. 3DMark05 loads d3d9, probes `Direct3DCreate9` and the caps, frees the library and carries on. Its next exception (MFC throws C++ exceptions as control flow) walked the handler chain into the unmapped image, the instruction fetch faulted, that fault dispatched to the same stale entry, and the thread recursed until its 1 MiB stack was gone. Any launcher doing a probe-load/`FreeLibrary` cycle is exposed; WoW's only survives because the re-load lands on the same base.

## Change

Keep the handle `RtlAddVectoredExceptionHandler` returns and remove the registration from `DLL_PROCESS_DETACH` on the path the process survives (no device was ever created). The real-exit path still terminates the process before that and is unchanged. The panic hook needs no such care: it lives in this cdylib's own `std`, nothing else in the process can reach it once the image is gone. Wine never `dlclose`s a builtin's unix library, so the unix-side `sigaction` handlers are not the same class of bug.

## Test

`windows/tests/tests/unload.rs` replays the sequence: `LoadLibrary`, `Direct3DCreate9`, `Release`, `FreeLibrary`, then a continuable exception with a resuming handler appended at the end of the chain so anything left at the front runs first. It deliberately skips the shared harness, whose `raw-dylib` import would keep the module mapped. Before the fix it died with the same `stack overflow` line on both arches; after it passes. `make check` and `make test` are green (1128 passing, both legs). 3DMark05 no longer dies after its dialog; the dialog itself (the caps question) is a separate change.
