### PR TITLE
Export the D3DPERF_* family from d3d9.dll

### DIFF
--- a/windows/d3d9/d3d9.def
+++ b/windows/d3d9/d3d9.def
@@ -1,4 +1,11 @@
 LIBRARY D3D9.DLL
 EXPORTS
     Direct3DCreate9 @2
+    D3DPERF_BeginEvent @3
+    D3DPERF_EndEvent @4
+    D3DPERF_GetStatus @5
+    D3DPERF_QueryRepeatFrame @6
+    D3DPERF_SetMarker @7
+    D3DPERF_SetOptions @8
+    D3DPERF_SetRegion @9
     Direct3DShaderValidatorCreate9 @16

--- a/windows/d3d9/src/lib.rs
+++ b/windows/d3d9/src/lib.rs
@@ -152,6 +152,60 @@ pub extern "system" fn direct3d_shader_validator_create9() -> *mut c_void {
     shader_validator::create()
 }
 
+// The `D3DPERF_*` family: PIX event markers a game emits around its draw
+// groups. Without a profiler attached the real d3d9.dll does nothing and
+// reports no nesting, no repeat-frame request and no attached tool, which is
+// the complete behaviour here too. They are exported because engines resolve
+// the whole family by name in one table and treat a missing entry as a broken
+// d3d9.dll: an in-game overlay SDK refuses to initialise when any of them
+// resolves to null, even though the game itself renders fine.
+
+/// `D3DPERF_BeginEvent`: opens a PIX event; returns the nesting level.
+///
+/// Logged once so a game that emits PIX markers is visible in triage; the
+/// markers are not forwarded to a Metal capture.
+#[unsafe(export_name = "D3DPERF_BeginEvent")]
+pub extern "system" fn d3dperf_begin_event(_color: u32, _name: *const u16) -> i32 {
+    mtld3d_shared::log_once_info!(
+        target: LOG_TARGET,
+        "D3DPERF_BeginEvent: PIX event markers not forwarded (no profiler)"
+    );
+    0
+}
+
+/// `D3DPERF_EndEvent`: closes a PIX event; returns the nesting level.
+#[unsafe(export_name = "D3DPERF_EndEvent")]
+#[must_use]
+pub const extern "system" fn d3dperf_end_event() -> i32 {
+    0
+}
+
+/// `D3DPERF_SetMarker`: a single PIX marker, not forwarded.
+#[unsafe(export_name = "D3DPERF_SetMarker")]
+pub const extern "system" fn d3dperf_set_marker(_color: u32, _name: *const u16) {}
+
+/// `D3DPERF_SetRegion`: a PIX region marker, not forwarded.
+#[unsafe(export_name = "D3DPERF_SetRegion")]
+pub const extern "system" fn d3dperf_set_region(_color: u32, _name: *const u16) {}
+
+/// `D3DPERF_QueryRepeatFrame`: `FALSE`, no profiler asks for a frame replay.
+#[unsafe(export_name = "D3DPERF_QueryRepeatFrame")]
+#[must_use]
+pub const extern "system" fn d3dperf_query_repeat_frame() -> i32 {
+    0
+}
+
+/// `D3DPERF_SetOptions`: profiler permission flags, nothing to apply them to.
+#[unsafe(export_name = "D3DPERF_SetOptions")]
+pub const extern "system" fn d3dperf_set_options(_options: u32) {}
+
+/// `D3DPERF_GetStatus`: `0`, no profiler attached.
+#[unsafe(export_name = "D3DPERF_GetStatus")]
+#[must_use]
+pub const extern "system" fn d3dperf_get_status() -> u32 {
+    0
+}
+
 // Wires up the PE-side `env_logger` for this cdylib, then fires a
 // one-shot `InitLogger` thunk so the unix .so registers its own
 // (each cdylib has its own `log` crate statics). Runs from DllMain

--- a/windows/tests/COVERAGE.md
+++ b/windows/tests/COVERAGE.md
@@ -30,6 +30,7 @@ windows-msvc; the host-native `mtld3d-core`/`mtld3d-shared` unit tests run too).
 | `state_block.rs` | Capture/Apply (ALL); VERTEXSTATE restores FVF; PIXELSTATE restores sampler; Begin/EndStateBlock recording. |
 | `query.rs` | EVENT fence; OCCLUSION sample count; TIMESTAMP contract. |
 | `resource_misc.rs` | Factory refcount; `QueryInterface` → E_NOINTERFACE; `GetType`; no-op PreLoad/SetPriority; `GetAvailableTextureMem`; `EvictManagedResources`; `GetDevice`/`SetClipPlane` stubs; `ValidateDevice` → S_OK (single-pass valid); `SetGammaRamp` no-op. |
+| `d3dperf.rs` | The seven `D3DPERF_*` exports resolved by `GetProcAddress` the way an engine's d3d9 loader does (no harness, so a missing export is a test failure rather than a link error), and the no-profiler contract: `BeginEvent`/`EndEvent` report no nesting, `QueryRepeatFrame` is `FALSE`, `GetStatus` is `0`, the marker and option setters are no-ops. An in-game overlay SDK refuses to initialise when any is missing. |
 | `unload.rs` | `LoadLibrary` → `Direct3DCreate9` → `Release` → `FreeLibrary`, then a continuable exception raised with a resuming handler appended at the end of the chain: proves the unloaded image left no vectored exception handler behind (no harness: its `raw-dylib` import would keep the module mapped). |
 
 ## Documented limitations / stubs pinned by tests

--- a/windows/tests/tests/d3dperf.rs
+++ b/windows/tests/tests/d3dperf.rs
@@ -1,0 +1,107 @@
+//! The `D3DPERF_*` exports resolve by name and act like a d3d9 with no profiler.
+//!
+//! Engines resolve the PIX marker family from `d3d9.dll` in one table and treat
+//! a `NULL` entry as a broken Direct3D: an in-game overlay SDK refuses to
+//! initialise when any of the seven is missing, while the game itself renders
+//! fine. The test resolves every one the way an engine does (`GetProcAddress`
+//! on the loaded module, not a static import) and pins the no-profiler
+//! contract: no nesting, no repeat-frame request, no status bits.
+//!
+//! No shared harness: the point is the export table, and the harness's
+//! `raw-dylib` link would make a missing export a link error rather than a
+//! test failure.
+
+use core::ffi::{c_char, c_void};
+
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn LoadLibraryA(name: *const c_char) -> *mut c_void;
+    fn FreeLibrary(module: *mut c_void) -> i32;
+    fn GetProcAddress(module: *mut c_void, name: *const c_char) -> *mut c_void;
+}
+
+type EventFn = unsafe extern "system" fn(u32, *const u16) -> i32;
+type MarkerFn = unsafe extern "system" fn(u32, *const u16);
+type NoArgI32Fn = unsafe extern "system" fn() -> i32;
+type NoArgU32Fn = unsafe extern "system" fn() -> u32;
+type SetOptionsFn = unsafe extern "system" fn(u32);
+
+const D3DCOLOR_WHITE: u32 = 0xFFFF_FFFF;
+const NAME: [u16; 4] = [b'p' as u16, b'i' as u16, b'x' as u16, 0];
+
+fn resolve(lib: *mut c_void, name: &'static core::ffi::CStr) -> *mut c_void {
+    // SAFETY: `lib` is a live module handle and the name is NUL-terminated.
+    let addr = unsafe { GetProcAddress(lib, name.as_ptr()) };
+    assert!(
+        !addr.is_null(),
+        "GetProcAddress({})",
+        name.to_str().unwrap_or("?")
+    );
+    addr
+}
+
+#[test]
+fn d3dperf_family_resolves_and_reports_no_profiler() {
+    // SAFETY: plain kernel32 call with a NUL-terminated name.
+    let lib = unsafe { LoadLibraryA(c"d3d9.dll".as_ptr()) };
+    assert!(!lib.is_null(), "LoadLibrary(d3d9.dll)");
+
+    // Every name in the table the game walks; a missing one fails here rather
+    // than as a NULL the game trips over later.
+    let names = [
+        c"D3DPERF_BeginEvent",
+        c"D3DPERF_EndEvent",
+        c"D3DPERF_SetMarker",
+        c"D3DPERF_SetRegion",
+        c"D3DPERF_QueryRepeatFrame",
+        c"D3DPERF_SetOptions",
+        c"D3DPERF_GetStatus",
+    ];
+    let addrs = names.map(|name| resolve(lib, name));
+
+    // SAFETY: each export has the documented d3d9 signature for its name.
+    let begin: EventFn = unsafe { core::mem::transmute(addrs[0]) };
+    // SAFETY: as above.
+    let end: NoArgI32Fn = unsafe { core::mem::transmute(addrs[1]) };
+    // SAFETY: as above.
+    let set_marker: MarkerFn = unsafe { core::mem::transmute(addrs[2]) };
+    // SAFETY: as above.
+    let set_region: MarkerFn = unsafe { core::mem::transmute(addrs[3]) };
+    // SAFETY: as above.
+    let query_repeat_frame: NoArgI32Fn = unsafe { core::mem::transmute(addrs[4]) };
+    // SAFETY: as above.
+    let set_options: SetOptionsFn = unsafe { core::mem::transmute(addrs[5]) };
+    // SAFETY: as above.
+    let get_status: NoArgU32Fn = unsafe { core::mem::transmute(addrs[6]) };
+
+    // A nested begin/end pair: without a profiler no nesting is reported.
+    // SAFETY: the resolved export with a live NUL-terminated wide name.
+    let outer = unsafe { begin(D3DCOLOR_WHITE, NAME.as_ptr()) };
+    // SAFETY: as above.
+    let inner = unsafe { begin(D3DCOLOR_WHITE, NAME.as_ptr()) };
+    // SAFETY: the resolved argument-less export.
+    let after_inner = unsafe { end() };
+    // SAFETY: as above.
+    let after_outer = unsafe { end() };
+    assert_eq!(
+        (outer, inner, after_inner, after_outer),
+        (0, 0, 0, 0),
+        "no profiler: no nesting is reported"
+    );
+
+    // SAFETY: the resolved export with a live NUL-terminated wide name.
+    unsafe { set_marker(D3DCOLOR_WHITE, NAME.as_ptr()) };
+    // SAFETY: as above.
+    unsafe { set_region(D3DCOLOR_WHITE, NAME.as_ptr()) };
+    // SAFETY: the resolved export with the documented flags argument.
+    unsafe { set_options(0) };
+    // SAFETY: the resolved argument-less export.
+    let repeat = unsafe { query_repeat_frame() };
+    assert_eq!(repeat, 0, "no profiler asks for a frame replay");
+    // SAFETY: as above.
+    let status = unsafe { get_status() };
+    assert_eq!(status, 0, "no profiler is attached");
+
+    // SAFETY: balancing the LoadLibrary above.
+    assert_ne!(unsafe { FreeLibrary(lib) }, 0, "FreeLibrary(d3d9.dll)");
+}


### PR DESCRIPTION
## Symptoms

GTA IV Complete Edition (Steam) renders on mtld3d but its Social Club SDK reports "Social Club failed to initialize. Error code: 13" and quits after `RgscUi::OnCreateDevice failed`. A relay trace of the game process shows its d3d9 loader resolving `Direct3DCreate9` and then all seven `D3DPERF_*` entry points by name from our d3d9.dll; every one of the seven returns NULL because mtld3d exported only `Direct3DCreate9` and `Direct3DShaderValidatorCreate9`. The real d3d9.dll, wine's and DXVK's all export the family.

## Changes

`d3d9.def` and `lib.rs` export `D3DPERF_BeginEvent`, `D3DPERF_EndEvent`, `D3DPERF_SetMarker`, `D3DPERF_SetRegion`, `D3DPERF_QueryRepeatFrame`, `D3DPERF_SetOptions` and `D3DPERF_GetStatus` with the behaviour of a d3d9 without a profiler attached: no nesting reported, no repeat-frame request, no status bits, markers dropped. `BeginEvent` logs once at info so a game that emits PIX markers is visible in triage.

## Alternatives

Forwarding the markers into a Metal capture as debug groups would be the useful version of these exports; it is not needed to unblock anything and belongs with the F12 capture work.

## Verification

New e2e test `windows/tests/tests/d3dperf.rs` resolves all seven through `GetProcAddress` the way an engine does (no harness, so a missing export is a test failure rather than a link error) and pins the no-profiler contract. `make check` and `make test` pass on both PE arches.

This gap alone did not clear the Social Club error; the QueryInterface fix stacked on top of this branch does.
