### PR TITLE
Route the PE-side log through the unix side

### DIFF
--- a/unix/shared/src/lib.rs
+++ b/unix/shared/src/lib.rs
@@ -19,7 +19,7 @@ pub use commands::{
     CopyBufferToTextureInfo, CopyTextureSubRectInfo, NullTextureKind,
 };
 pub use ffi_boundary::{InPtr, InPtrMut, OutPtr, ValueIn, VtableThis};
-pub use log_filter::init_logger;
+pub use log_filter::{init_logger, init_logger_to};
 pub use mtl_handle::MetalHandle;
 pub use params::{
     AttachMetalLayerParams, BlitTextureToBufferParams, BufferCreateDesc,
@@ -31,7 +31,7 @@ pub use params::{
     ExtraColorDesc, GetDeviceInfoParams, GetTaskFaultsParams, InitLoggerParams, PassDescriptor,
     SetDisplaySyncEnabledParams, StartGpuCaptureParams, StencilFaceParams, StopGpuCaptureParams,
     SubmitFrameParams, TextureCreateDesc, VertexAttrDesc, VertexBufferLayoutDesc,
-    WaitForGpuRetireParams,
+    WaitForGpuRetireParams, WriteLogParams,
 };
 
 #[repr(u32)]
@@ -61,6 +61,7 @@ pub enum Thunks {
     EnsureClearQuadPipeline,
     EnsureBlitPipeline,
     GetTaskFaults,
+    WriteLog,
 }
 
 pub trait Thunk {

--- a/unix/shared/src/log_filter.rs
+++ b/unix/shared/src/log_filter.rs
@@ -11,6 +11,21 @@
 /// all three linkage units. `NO_COLOR=1` opts out — `env_logger` only reads
 /// it under `WriteStyle::Auto`, so we have to pre-resolve the choice here.
 pub fn init_logger() {
+    init(None);
+}
+
+/// Register `env_logger` writing every formatted line into `sink`.
+///
+/// The PE side uses this with a sink that crosses to the unix side: a game a
+/// launcher spawned often has no usable Windows standard handles, so the
+/// default stderr target would discard every line, while the unix side's
+/// stderr is the launcher's log regardless. Filter and style match
+/// [`init_logger`].
+pub fn init_logger_to(sink: Box<dyn std::io::Write + Send + 'static>) {
+    init(Some(sink));
+}
+
+fn init(sink: Option<Box<dyn std::io::Write + Send + 'static>>) {
     let user = std::env::var("RUST_LOG").ok();
     let filter = resolved_log_filter(user.as_deref());
     let style = if std::env::var_os("NO_COLOR").is_some() {
@@ -18,10 +33,12 @@ pub fn init_logger() {
     } else {
         env_logger::WriteStyle::Always
     };
-    let _ = env_logger::Builder::new()
-        .parse_filters(&filter)
-        .write_style(style)
-        .try_init();
+    let mut builder = env_logger::Builder::new();
+    builder.parse_filters(&filter).write_style(style);
+    if let Some(sink) = sink {
+        builder.target(env_logger::Target::Pipe(sink));
+    }
+    let _ = builder.try_init();
 }
 
 fn resolved_log_filter(user: Option<&str>) -> String {

--- a/unix/shared/src/params.rs
+++ b/unix/shared/src/params.rs
@@ -69,6 +69,20 @@ impl Thunk for InitLoggerParams {
     const CODE: u32 = Thunks::InitLogger as u32;
 }
 
+/// One formatted log line from the PE-side logger, for the unix stderr.
+///
+/// `ptr`/`len` describe a byte slice the PE side keeps alive for the call.
+#[repr(C, align(8))]
+pub struct WriteLogParams {
+    pub ptr: u64, // in: *const u8
+    pub len: u32, // in: byte count
+    pub pad0: u32,
+}
+
+impl Thunk for WriteLogParams {
+    const CODE: u32 = Thunks::WriteLog as u32;
+}
+
 #[repr(C, align(8))]
 pub struct GetDeviceInfoParams {
     pub name_ptr: u64,

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -10,7 +10,7 @@ use mtld3d_shared::{
     EnsureBlitPipelineParams, EnsureClearQuadPipelineParams, GetDeviceInfoParams,
     GetTaskFaultsParams, InPtr, InPtrMut, MetalHandle, SetDisplaySyncEnabledParams,
     StartGpuCaptureParams, SubmitFrameParams, TextureCreateDesc, VertexAttrDesc,
-    VertexBufferLayoutDesc, WaitForGpuRetireParams, identity,
+    VertexBufferLayoutDesc, WaitForGpuRetireParams, WriteLogParams, identity,
     mtl::DestroyKind,
     mtl_handle::{MTLBufferKind, MTLTextureKind},
 };
@@ -49,6 +49,32 @@ pub extern "C" fn init_logger_handler(_args: *mut c_void) -> i32 {
         // static.
         metal::declare_latency_critical_activity();
     });
+    STATUS_SUCCESS
+}
+
+/// `WriteLog`: the sink behind the PE-side logger.
+///
+/// Writes the formatted line to this process's unix stderr, the stream wine's
+/// own debug output uses, so d3d9.dll lines land next to the unix side's
+/// whatever Windows standard handles the process was started with (a game a
+/// launcher spawned often has none, and `std::io::stderr` on the PE side
+/// would discard the line).
+pub extern "C" fn write_log_handler(args: *mut c_void) -> i32 {
+    // SAFETY: unix-call handler params; PE side passes *mut WriteLogParams.
+    let Some(params) = (unsafe { InPtrMut::<WriteLogParams>::opt(args) }) else {
+        return -1;
+    };
+    if params.ptr == 0 || params.len == 0 {
+        return STATUS_SUCCESS;
+    }
+    // SAFETY: PE supplied `ptr`/`len` as a byte slice valid for the call
+    // duration; the pointer is non-zero per the check above.
+    let bytes =
+        unsafe { core::slice::from_raw_parts(params.ptr as *const u8, params.len as usize) };
+    let mut stderr = std::io::stderr().lock();
+    if std::io::Write::write_all(&mut stderr, bytes).is_err() {
+        return STATUS_UNSUCCESSFUL;
+    }
     STATUS_SUCCESS
 }
 

--- a/unix/unix/src/lib.rs
+++ b/unix/unix/src/lib.rs
@@ -71,6 +71,7 @@ const fn dispatch(code: Thunks) -> UnixCallFn {
         Thunks::EnsureClearQuadPipeline => arp!(handlers::ensure_clear_quad_pipeline_handler),
         Thunks::EnsureBlitPipeline => arp!(handlers::ensure_blit_pipeline_handler),
         Thunks::GetTaskFaults => arp!(handlers::get_task_faults_handler),
+        Thunks::WriteLog => arp!(handlers::write_log_handler),
     }
 }
 

--- a/windows/d3d9/src/lib.rs
+++ b/windows/d3d9/src/lib.rs
@@ -35,7 +35,7 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use mtld3d_shared::{InitLoggerParams, identity};
+use mtld3d_shared::{InitLoggerParams, WriteLogParams, identity};
 // HRESULT codes live in `mtld3d_types` (shared with the integration-test
 // harness); re-exported under the crate root so every in-crate
 // `use super::{D3D_OK, …}` path stays valid.
@@ -213,7 +213,7 @@ pub const extern "system" fn d3dperf_get_status() -> u32 {
 // dispatcher — DLL load ordering is guaranteed by d3d9.dll's implicit
 // import of `mtld3d_unix_call` from mtld3d.dll.
 fn init_logger(instance: *mut c_void) {
-    mtld3d_shared::init_logger();
+    mtld3d_shared::init_logger_to(Box::new(UnixLogSink));
     log_identity(instance);
     // Latch the d3d9-side perf-tracking gate (`PERF_TRACKING_ENABLED`)
     // from `RUST_LOG`. Per-cdylib because each cdylib has its own
@@ -229,6 +229,37 @@ fn init_logger(instance: *mut c_void) {
     crash::install(instance);
     let mut params = InitLoggerParams { reserved: 0 };
     unix_call(&mut params);
+}
+
+/// The PE-side logger's sink: every formatted line crosses to the unix side.
+///
+/// A game a launcher spawned often has no usable Windows standard handles,
+/// so `std::io::stderr` here would discard the line; the unix side writes it
+/// to the process's unix stderr, the stream wine's own debug output and the
+/// unix side's logger already use. The buffer stays alive for the call and
+/// the unix side never keeps it.
+struct UnixLogSink;
+
+impl std::io::Write for UnixLogSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let Ok(len) = u32::try_from(buf.len()) else {
+            return Err(std::io::ErrorKind::InvalidInput.into());
+        };
+        let mut params = WriteLogParams {
+            ptr: buf.as_ptr() as usize as u64,
+            len,
+            pad0: 0,
+        };
+        if unix_call(&mut params) == 0 {
+            Ok(buf.len())
+        } else {
+            Err(std::io::ErrorKind::Other.into())
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 /// Name this build in the log, as the first line the logger emits.


### PR DESCRIPTION
## Symptoms

For a game that a launcher process spawns (the Rockstar launcher starting GTAIV.exe, for instance), none of d3d9.dll's log lines reach the launcher's log: not the identity line, not the stub warnings that the no-silent-failures convention relies on. The unix side's lines arrive as usual. The PE-side `env_logger` writes to the Windows standard error handle, which such a process does not have; `std::io::stderr` discards the writes.

## Changes

`mtld3d_shared::init_logger_to` registers `env_logger` with a `Target::Pipe` sink. d3d9.dll's sink forwards each formatted line through a new `WriteLog` thunk (`WriteLogParams`: pointer plus `u32` length) and the unix handler writes it to the process's unix stderr, the stream wine's own debug output and the unix logger already use. The unix side keeps `init_logger` unchanged.

## Alternatives

Opening `/dev/fd/2` from the PE side through wine's unix path mapping would avoid the thunk but ties the logger to a filesystem detail and a second file descriptor; the unix-call channel already exists and keeps both sides' lines in one ordered stream.

## Verification

With this installed, an RGL-spawned GTAIV.exe shows its `d3d9.dll ... loaded` line and its warnings in `gamelauncher.log`, which is what located the QueryInterface defect fixed in the next branch of this stack. `make check` and `make test` pass on both PE arches.
