### PR TITLE
Cap the video memory a 32-bit guest is told it has (Need for Speed Carbon stops losing geometry)

### DIFF
--- a/mtld3d.conf
+++ b/mtld3d.conf
@@ -166,6 +166,24 @@
 
 # memory.vbibRetentionCapMB = 512
 
+# Ceiling on the video memory GetAvailableTextureMem advertises (MiB).
+#
+# An engine of this era sizes its texture and streaming pools from what
+# that call reports, then commits against the figure. A 32-bit guest runs
+# out of process address space long before a unified-memory Mac runs out
+# of GPU memory, and what fails at that point is a Metal command buffer,
+# out of memory, whose rendering is discarded: geometry and textures go
+# missing rather than an allocation returning an error the title could
+# handle.
+#
+# 0 lifts the ceiling. The default caps a 32-bit guest and leaves a
+# 64-bit one alone.
+#
+# Default: 1024 on a 32-bit guest, 0 on 64-bit
+# Supported values: non-negative integer (MiB; 0 = no ceiling)
+
+# memory.vramBudgetMB = 1024
+
 # PageBox recycle pool cap (MiB).
 #
 # Every contended Lock of a DYNAMIC vertex/index buffer allocates a

--- a/windows/core/src/config.rs
+++ b/windows/core/src/config.rs
@@ -92,6 +92,17 @@ pub struct Mtld3dConfig {
     /// run out (the A/B baseline arm). Default: 512 MiB. File key:
     /// `memory.vbibRetentionCapMB` (value in MiB).
     pub vbib_retention_cap_bytes: u64,
+    /// Ceiling for the figure `GetAvailableTextureMem` advertises.
+    ///
+    /// `0` lifts the ceiling.
+    ///
+    /// An engine of this era sizes its texture and streaming pools off that
+    /// figure and commits against it, so on a 32-bit guest an unrestricted
+    /// report invites a title past the process address space. What fails then
+    /// is a Metal command buffer, out of memory, whose rendering is discarded.
+    /// Default: 1 GiB on a 32-bit guest, no ceiling on 64-bit. File key:
+    /// `memory.vramBudgetMB` (value in MiB).
+    pub vram_budget_cap_bytes: u64,
     /// Byte cap for the `PageBox` recycle pool. `0` = pool disabled.
     ///
     /// VB/IB `PageBox`es retired by the encoder's retention drain are
@@ -151,6 +162,14 @@ impl Default for Mtld3dConfig {
             skip_shaders: Vec::new(),
             query_flush_immediate: true,
             vbib_retention_cap_bytes: 512 * 1024 * 1024,
+            // The 32-bit address space is the ceiling that matters, not the
+            // GPU's memory: a unified-memory Mac has far more than a D3D9
+            // title can use, while the guest process runs out first.
+            vram_budget_cap_bytes: if cfg!(target_pointer_width = "32") {
+                1024 * 1024 * 1024
+            } else {
+                0
+            },
             pagebox_pool_cap_bytes: 128 * 1024 * 1024,
             present_max_fps: 0,
             render_scale_percent: 100,
@@ -253,6 +272,11 @@ pub fn log_options(cfg: &Mtld3dConfig) {
     );
     info!(
         target: crate::LOG_TARGET,
+        "config: memory.vramBudgetMB = {}",
+        cfg.vram_budget_cap_bytes / (1024 * 1024)
+    );
+    info!(
+        target: crate::LOG_TARGET,
         "config: memory.pageboxPoolCapMB = {}",
         cfg.pagebox_pool_cap_bytes / (1024 * 1024)
     );
@@ -293,6 +317,9 @@ fn apply(cfg: &mut Mtld3dConfig, source: &str, key: &str, value: &str) {
         "query.flushImmediate" => assign_bool(source, key, value, &mut cfg.query_flush_immediate),
         "memory.vbibRetentionCapMB" => {
             assign_cap_mb(source, key, value, &mut cfg.vbib_retention_cap_bytes);
+        }
+        "memory.vramBudgetMB" => {
+            assign_cap_mb(source, key, value, &mut cfg.vram_budget_cap_bytes);
         }
         "memory.pageboxPoolCapMB" => {
             assign_cap_mb(source, key, value, &mut cfg.pagebox_pool_cap_bytes);

--- a/windows/core/src/config/tests.rs
+++ b/windows/core/src/config/tests.rs
@@ -32,6 +32,36 @@ fn defaults_match_documented_values() {
     assert_eq!(d.render_scale_percent, 100);
 }
 
+/// The advertised video-memory ceiling defaults by guest width.
+///
+/// A 32-bit guest runs out of process address space long before a
+/// unified-memory Mac runs out of GPU memory, and an engine that sizes its
+/// streaming pool from the advertised figure will commit until it does.
+#[test]
+fn vram_budget_defaults_to_a_ceiling_only_on_a_32_bit_guest() {
+    let d = parse("", None);
+    if cfg!(target_pointer_width = "32") {
+        assert_eq!(d.vram_budget_cap_bytes, 1024 * 1024 * 1024);
+    } else {
+        assert_eq!(
+            d.vram_budget_cap_bytes, 0,
+            "a 64-bit guest keeps no ceiling"
+        );
+    }
+}
+
+#[test]
+fn vram_budget_parses_as_mib_and_zero_lifts_the_ceiling() {
+    assert_eq!(
+        parse("memory.vramBudgetMB = 512\n", None).vram_budget_cap_bytes,
+        512 * 1024 * 1024
+    );
+    assert_eq!(
+        parse("memory.vramBudgetMB = 0\n", None).vram_budget_cap_bytes,
+        0
+    );
+}
+
 #[test]
 fn pagebox_pool_cap_parses_as_mib() {
     let cfg = parse("memory.pageboxPoolCapMB = 96\n", None);

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -2921,12 +2921,23 @@ extern "system" fn device_get_available_texture_mem(this: *mut c_void) -> u32 {
     // value visibly decreases as the app allocates GPU resources, while
     // staying generous enough never to starve a real workload. 2 GiB budget
     // (fits u32; well above any title's needs).
+    //
+    // `memory.vramBudgetMB` lowers that ceiling, and defaults to doing so on a
+    // 32-bit guest. An engine of this era sizes its streaming pool from what
+    // this call reports, so an unrestricted figure invites a title to commit
+    // past the process address space; what fails then is not an allocation it
+    // could handle but a Metal command buffer, out of memory, whose rendering
+    // is discarded.
     const VRAM_BUDGET: u64 = 2 * 1024 * 1024 * 1024;
+    let budget = match crate::config::CONFIG.vram_budget_cap_bytes {
+        0 => VRAM_BUDGET,
+        cap => VRAM_BUDGET.min(cap),
+    };
     let _timer = device_timer(this, DeviceSubCategory::Misc);
     // SAFETY: vtable thunk; `this` is *mut Direct3DDevice9 per IDirect3DDevice9 ABI.
     let used = (unsafe { InPtr::<Direct3DDevice9>::opt(this) })
         .map_or(0, |obj| obj.inner().vram_bytes_used.load(Ordering::Acquire));
-    u32::try_from(VRAM_BUDGET.saturating_sub(used).min(u64::from(u32::MAX))).unwrap_or(u32::MAX)
+    u32::try_from(budget.saturating_sub(used).min(u64::from(u32::MAX))).unwrap_or(u32::MAX)
 }
 
 extern "system" fn device_evict_managed_resources(this: *mut c_void) -> i32 {


### PR DESCRIPTION
## Symptom

Need for Speed Carbon loses geometry and textures partway into a scene, and
the log says why:

    submit_frame: command buffer for frame seq=2616 failed on the GPU
    (code 8: Insufficient Memory (kIOGPUCommandBufferCallbackErrorOutOfMemory));
    its rendering was discarded, so a queued present showed undefined memory

Nothing failed that the title could see. `CreateTexture` kept returning
`D3D_OK`, no allocation reported an error, and the frames that survived looked
right; the ones that did not simply had holes in them.

## Cause

`GetAvailableTextureMem` reported a flat 2 GiB budget minus live DEFAULT-pool
bytes. An engine of this era sizes its texture and streaming pools from that
figure and then commits against it, so the report is not advisory: it is an
instruction. A 32-bit guest has nowhere near 2 GiB of address space to spare
once its own code, its heap, its own copies of the assets, Wine's structures
and this layer's mirrors are in it, and a unified-memory Mac has far more GPU
memory than a 2006 title can use, so the reported figure was measuring the
wrong resource entirely. What ran out was the process, and what failed was a
Metal command buffer rather than an allocation the title could have handled.

## Fix

`memory.vramBudgetMB` caps the advertised figure, defaulting to 1 GiB on a
32-bit guest and to no ceiling at all on 64-bit, so nothing changes for a
64-bit title. `0` lifts the ceiling.

## Considered alternatives

- **Reporting the truthful unified-memory answer.** There isn't one, and 0
  drives era engines into recreate-every-frame fallbacks.
- **Evicting or making allocations purgeable under pressure.** That treats the
  symptom as GPU-memory exhaustion, which it is not: the machine has memory to
  spare. The ceiling is the guest's address space, and the only lever that
  reaches it is what the title is told before it commits.
- **A per-title override with no default.** It would leave every 32-bit
  streaming title broken until someone wrote a config file for it.
- **Reporting the budget minus a larger reserve instead of a hard cap.** The
  running DEFAULT-pool subtraction already does that, and it did not help: the
  pressure comes from MANAGED assets the counter does not see.

## Verification

`make check` and `make test`: 710 + 125 host unit tests, 240 e2e tests on both
architectures.

Measured in the title, same scene, only the reported figure changing:
2 GiB gives frames failing with the error above; 1 GiB gives zero. The
frequency is not visible in the log on its own, since that warning is
`log_once_warn_by!` keyed on the error code and fires once per code however
many command buffers abort; the counts above come from keying it per frame
temporarily.

The new unit test is checked against the code it pins: giving the 64-bit arm a
non-zero default fails it, and only it.

## Found while here, not fixed

Four further divergences turned up while tracking this down, each confirmed
against the source but none of them the cause of what I was chasing. Filing
them here rather than acting on them, since each wants its own change:

- A `Staged` VB/IB uploads only the byte range the title announced at `Lock`,
  into a `StorageModePrivate` buffer Metal never zeroes and the warmup path
  skips. Any byte written but not announced is read as recycled VRAM. Carbon
  happens to announce honestly (measured: 2001 staged unlocks, none wrote
  outside), so it does not bite here, but a title that locks a small window
  and writes past it would get garbage geometry with nothing logged.
- `plan_lock` hands back a pointer into memory a queued draw may still be
  reading, on the `NOOVERWRITE`/`READONLY` arm and on the partial-contended
  arm, and the safety decision reads `coherent_seq`, which the GPU completion
  handler writes. So the same call can decide differently between runs.
  Measured 5001 calls in Carbon, none of them contended on those arms.
- A mid-frame `Clear` folds into a whole-attachment `loadAction = Clear`,
  ignoring the viewport, when the target has not been an attachment since the
  last mid-frame flush. The viewport-coverage check is reachable only for a
  colour-only `Clear(NULL)`; a combined `Clear(TARGET | ZBUFFER)` bypasses it,
  and the depth side has no coverage predicate at all. Measured 27001 folds in
  Carbon, none over-clearing, because its viewport always covers.
- `vb_unlock` clears the dirty range as soon as it queues the upload, and
  neither completion handler inspects `status()` before booking the frame
  retired, so a command buffer that aborts loses those bytes permanently
  rather than for a frame. Directly relevant to the symptom above: the first
  failure is what makes the rest of the run wrong.
