### PR TITLE
Built-in app profiles, and one for GTA IV

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,10 @@ Each of these rots silently when it is left for later:
   cache key serves stale MSL, and the result looks like a rendering bug.
 - A new config key ships with its dispatch arm, its unit test, and its entry in
   the `mtld3d.conf` sample with the default and a short why.
+- A new built-in app profile ships with the rationale for every key it sets, a
+  test that resolves it from the version strings the shipped binary actually
+  carries, and its row in the README profile table. A profile that pins no
+  version field is not a profile, it is a name collision waiting to happen.
 - A new `Clone` or `Copy` derive updates `scripts/derive_inventory.txt`
   (`scripts/audit.sh --update-derives`).
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,18 @@ User-facing runtime options live in the optional `mtld3d.conf`, read once at
 restart. The sample in the repo root documents every option, its default, and
 the `MTLD3D_CONFIG` environment override that beats the file.
 
+Below both sits a third layer: a handful of games need options nobody should
+have to discover, so mtld3d ships built-in profiles for them. A profile is
+matched on the executable name plus the version resource its vendor linked in,
+so it follows the game wherever it is installed and never fires on an unrelated
+program of the same name. It only supplies starting values, and both the file
+and the environment override it key by key.
+`RUST_LOG=mtld3d::d3d9=info` names the profile that matched.
+
+| Profile | Application | What it sets and why |
+|---|---|---|
+| `gta-iv` | Grand Theft Auto IV | `adapter.spoof=amd`, because the renderer branches on the reported vendor and stalls in its own identifier parsing on the NVIDIA identity. `caps.dfFormats=false`, because with the DF fourccs advertised it picks a mixed DF24 plus INTZ depth path that no hardware of its era offered. `query.flushImmediate=false`, because its occlusion culling needs real pixel counts rather than an immediate answer. `depth.aliasSameSize=true`, because its late alpha, sky and glow passes z-test one INTZ depth texture against scene depth rendered into a same-size sibling. |
+
 Every crate logs via `log` + `env_logger`. All targets sit under `mtld3d::*`
 and `env_logger` matches by `::`-separated prefix, so `RUST_LOG=mtld3d=warn` is
 the single switch for the whole project; narrow it per target, for example

--- a/mtld3d.conf
+++ b/mtld3d.conf
@@ -24,6 +24,15 @@
 # (env wins on conflict); unset keys keep their file (or default) value.
 # Example:
 #   MTLD3D_CONFIG="color.hdr.enable=false;cursor.scale=2"
+#
+# A few games need options no user should have to discover, so mtld3d
+# ships built-in profiles for them: an application matched by the version
+# resource its vendor linked into the executable gets that profile's keys
+# as its starting point. A profile is the weakest layer, below this file
+# and below `MTLD3D_CONFIG`, so any single key it sets can be taken back
+# without losing the rest. `RUST_LOG=mtld3d::d3d9=info` prints which
+# profile matched, followed by every resolved option. See the README for
+# the profiles that ship and what each one is for.
 
 
 ##########

--- a/unix/shared/src/identity.rs
+++ b/unix/shared/src/identity.rs
@@ -14,6 +14,11 @@
 //! Every cdylib logs both on load. A crash report then names the debug archive
 //! that resolves it, instead of leaving us to fingerprint the build from
 //! indirect evidence.
+//!
+//! `version_blob` answers the other identity question, and about a different
+//! image: who the host application is. It hands back the raw `VS_VERSIONINFO`
+//! resource of a mapped PE, which is where a built-in app profile reads the
+//! vendor's own `CompanyName` and `ProductName` from.
 
 /// Release identity, stamped by `build.rs` from `git describe --tags --always`.
 ///
@@ -22,6 +27,8 @@
 pub const BUILD: &str = env!("MTLD3D_BUILD");
 
 pub use platform::image_id;
+#[cfg(target_family = "windows")]
+pub use platform::version_blob;
 
 #[cfg(target_family = "windows")]
 mod platform {
@@ -41,8 +48,26 @@ mod platform {
     const NUM_RVA_PE32: usize = 0x5c;
     /// Offset of `NumberOfRvaAndSizes` within a PE32+ optional header.
     const NUM_RVA_PE32_PLUS: usize = 0x6c;
+    /// Offset of `SizeOfImage` within an optional header, PE32 and PE32+ alike.
+    const SIZE_OF_IMAGE: usize = 0x38;
     /// Index of the debug directory among the data directories.
     const DIRECTORY_DEBUG: usize = 6;
+    /// Index of the resource directory among the data directories.
+    const DIRECTORY_RESOURCE: usize = 2;
+    /// Size of one data directory entry: an RVA and a size, both dwords.
+    const DIRECTORY_ENTRY_SIZE: usize = 8;
+    /// `RT_VERSION`, the resource type of a `VS_VERSIONINFO` blob.
+    const RT_VERSION: u32 = 16;
+    /// Size of one `IMAGE_RESOURCE_DIRECTORY`, after which its entries start.
+    const RESOURCE_DIRECTORY_SIZE: usize = 16;
+    /// Size of one `IMAGE_RESOURCE_DIRECTORY_ENTRY`: a name and an offset.
+    const RESOURCE_ENTRY_SIZE: usize = 8;
+    /// Offset of `NumberOfNamedEntries` within an `IMAGE_RESOURCE_DIRECTORY`.
+    const NAMED_ENTRIES: usize = 12;
+    /// Offset of `NumberOfIdEntries` within an `IMAGE_RESOURCE_DIRECTORY`.
+    const ID_ENTRIES: usize = 14;
+    /// High bit of a resource entry's offset: the child is another directory.
+    const SUBDIRECTORY: u32 = 0x8000_0000;
     /// Size of one `IMAGE_DEBUG_DIRECTORY` entry.
     const DEBUG_ENTRY_SIZE: usize = 28;
     /// `IMAGE_DEBUG_TYPE_CODEVIEW`, the entry pointing at the PDB record.
@@ -67,38 +92,69 @@ mod platform {
         if base == 0 {
             return None;
         }
-        // SAFETY: `base` is a loaded image, so its DOS header is mapped and
-        // `e_lfanew` is the dword at `+0x3c`.
-        let nt = base + unsafe { read_u32(base + E_LFANEW) } as usize;
-        // SAFETY: `nt` is the NT header the DOS stub points at, mapped in the
-        // same image; the optional header magic is the word at `+0x18`.
-        let magic = unsafe { read_u16(nt + OPTIONAL_HEADER) };
-        // The data directories follow `NumberOfRvaAndSizes`, whose offset in
-        // the optional header differs between PE32 and PE32+ (the wider image
-        // base and the four larger reserve/commit fields push it out by 0x10).
-        let num_rva_offset = match magic {
-            MAGIC_PE32 => NUM_RVA_PE32,
-            MAGIC_PE32_PLUS => NUM_RVA_PE32_PLUS,
-            _ => return None,
-        };
-        let num_rva_at = nt + OPTIONAL_HEADER + num_rva_offset;
-        // SAFETY: within the optional header of a mapped image.
-        let num_rva = unsafe { read_u32(num_rva_at) } as usize;
-        if num_rva <= DIRECTORY_DEBUG {
-            return None;
-        }
-        // Each data directory entry is an RVA/size pair of dwords.
-        let entry = num_rva_at + 4 + DIRECTORY_DEBUG * 8;
-        // SAFETY: entry `DIRECTORY_DEBUG` exists, per the `num_rva` check.
-        let dir_rva = unsafe { read_u32(entry) } as usize;
-        // SAFETY: the size dword follows the RVA in the same entry.
-        let dir_size = unsafe { read_u32(entry + 4) } as usize;
-        if dir_rva == 0 || dir_size < DEBUG_ENTRY_SIZE {
+        // SAFETY: `base` is a loaded image, per the contract.
+        let (dir_rva, dir_size) = unsafe { data_directory(base, DIRECTORY_DEBUG) }?;
+        if dir_size < DEBUG_ENTRY_SIZE {
             return None;
         }
         // SAFETY: the debug directory RVA points into a mapped section (the
         // linker places the record in `.rdata`), and `dir_size` is its extent.
         unsafe { codeview_guid(base, base + dir_rva, dir_size / DEBUG_ENTRY_SIZE) }
+    }
+
+    /// The raw `VS_VERSIONINFO` resource of a mapped image, as UTF-16 units.
+    ///
+    /// Returns `None` when the image carries no version resource, which is
+    /// normal: only vendors that set the linker's resource fields have one.
+    /// Every read is bounded by the image's own `SizeOfImage`, so a malformed
+    /// resource tree yields `None` rather than a wild read.
+    ///
+    /// Reading the mapped image keeps this free of imports. The obvious
+    /// alternative, `version.dll`, is one of the DLL names game mods install
+    /// proxies under, and so is the `d3d9.dll` this code ships as, so calling it
+    /// would route our startup through whatever a modded install dropped beside
+    /// the executable.
+    ///
+    /// # Safety
+    ///
+    /// `module` must be the `HMODULE` of an image the loader has mapped, so
+    /// that its headers and every section its `SizeOfImage` covers are readable.
+    #[must_use]
+    pub unsafe fn version_blob(module: *mut c_void) -> Option<Vec<u16>> {
+        let base = module as usize;
+        if base == 0 {
+            return None;
+        }
+        // SAFETY: `base` is a loaded image, per the contract.
+        let (res, _) = unsafe { data_directory(base, DIRECTORY_RESOURCE) }?;
+        // SAFETY: same image, so its optional header is mapped.
+        let size = unsafe { image_size(base) }?;
+        let img = Image { base, size };
+
+        // Three levels, by the resource tree's fixed shape: type, then name,
+        // then language. Only the type is looked up by id; a version resource
+        // carries one name and one language in practice, and taking the first
+        // of each is what the loader's own `FindResource` fallback settles on.
+        // SAFETY: `img` bounds every read to the mapped image.
+        let by_name = unsafe { img.subdirectory(res, res, RT_VERSION) }?;
+        // SAFETY: as above.
+        let (by_language, is_dir) = unsafe { img.first_child(res, by_name) }?;
+        if !is_dir {
+            return None;
+        }
+        // SAFETY: as above.
+        let (leaf, is_dir) = unsafe { img.first_child(res, by_language) }?;
+        if is_dir {
+            return None;
+        }
+
+        // `IMAGE_RESOURCE_DATA_ENTRY`: the blob's own RVA, then its size.
+        // SAFETY: as above.
+        let data = unsafe { img.u32(leaf) }? as usize;
+        // SAFETY: the size dword follows the RVA in the same entry.
+        let size = unsafe { img.u32(leaf + 4) }? as usize;
+        // SAFETY: as above.
+        unsafe { img.utf16(data, size) }
     }
 
     /// Scan the debug directory for the `CodeView` entry and format its GUID.
@@ -153,6 +209,175 @@ mod platform {
             let _ = write!(out, "{byte:02X}");
         }
         out
+    }
+
+    /// One data directory's RVA and size.
+    ///
+    /// `None` when the image declares no entry at `index`, or when the entry is
+    /// empty.
+    ///
+    /// # Safety
+    ///
+    /// `base` must be the load base of a mapped image.
+    const unsafe fn data_directory(base: usize, index: usize) -> Option<(usize, usize)> {
+        // SAFETY: a loaded image has its DOS header mapped, and `e_lfanew` is
+        // the dword at `+0x3c`.
+        let nt = base + unsafe { read_u32(base + E_LFANEW) } as usize;
+        // SAFETY: `nt` is the NT header the DOS stub points at, mapped in the
+        // same image; the optional header magic is the word at `+0x18`.
+        let magic = unsafe { read_u16(nt + OPTIONAL_HEADER) };
+        // The data directories follow `NumberOfRvaAndSizes`, whose offset in
+        // the optional header differs between PE32 and PE32+ (the wider image
+        // base and the four larger reserve/commit fields push it out by 0x10).
+        let num_rva_offset = match magic {
+            MAGIC_PE32 => NUM_RVA_PE32,
+            MAGIC_PE32_PLUS => NUM_RVA_PE32_PLUS,
+            _ => return None,
+        };
+        let num_rva_at = nt + OPTIONAL_HEADER + num_rva_offset;
+        // SAFETY: within the optional header of a mapped image.
+        let num_rva = unsafe { read_u32(num_rva_at) } as usize;
+        if num_rva <= index {
+            return None;
+        }
+        let entry = num_rva_at + 4 + index * DIRECTORY_ENTRY_SIZE;
+        // SAFETY: entry `index` exists, per the `num_rva` check.
+        let rva = unsafe { read_u32(entry) } as usize;
+        // SAFETY: the size dword follows the RVA in the same entry.
+        let size = unsafe { read_u32(entry + 4) } as usize;
+        if rva == 0 {
+            return None;
+        }
+        Some((rva, size))
+    }
+
+    /// The extent a mapped image covers, from its own `SizeOfImage`.
+    ///
+    /// # Safety
+    ///
+    /// `base` must be the load base of a mapped image.
+    unsafe fn image_size(base: usize) -> Option<usize> {
+        // SAFETY: a loaded image has its DOS header mapped.
+        let nt = base + unsafe { read_u32(base + E_LFANEW) } as usize;
+        // SAFETY: `nt` is the mapped NT header.
+        let size = unsafe { read_u32(nt + OPTIONAL_HEADER + SIZE_OF_IMAGE) } as usize;
+        (size != 0).then_some(size)
+    }
+
+    /// A mapped image, with every read bounded by its own extent.
+    ///
+    /// Resource walking follows offsets the image itself supplies, and the
+    /// image here is the host application's rather than our own, so a bound is
+    /// the difference between "no version resource" and a fault in someone's
+    /// game.
+    struct Image {
+        base: usize,
+        size: usize,
+    }
+
+    impl Image {
+        /// The address of `len` bytes at `off`, or `None` if they leave the image.
+        const fn at(&self, off: usize, len: usize) -> Option<usize> {
+            match off.checked_add(len) {
+                Some(end) if end <= self.size => self.base.checked_add(off),
+                _ => None,
+            }
+        }
+
+        /// Read a bounded `u16` at image offset `off`.
+        ///
+        /// # Safety
+        ///
+        /// `self` must describe a mapped image.
+        unsafe fn u16(&self, off: usize) -> Option<u16> {
+            let addr = self.at(off, 2)?;
+            // SAFETY: `at` placed two readable bytes at `addr`.
+            Some(unsafe { read_u16(addr) })
+        }
+
+        /// Read a bounded `u32` at image offset `off`.
+        ///
+        /// # Safety
+        ///
+        /// `self` must describe a mapped image.
+        unsafe fn u32(&self, off: usize) -> Option<u32> {
+            let addr = self.at(off, 4)?;
+            // SAFETY: `at` placed four readable bytes at `addr`.
+            Some(unsafe { read_u32(addr) })
+        }
+
+        /// Read `bytes` bytes at image offset `off` as UTF-16 units.
+        ///
+        /// # Safety
+        ///
+        /// `self` must describe a mapped image.
+        unsafe fn utf16(&self, off: usize, bytes: usize) -> Option<Vec<u16>> {
+            let mut out = Vec::with_capacity(bytes / 2);
+            for i in 0..bytes / 2 {
+                // SAFETY: each offset is bounds-checked by `u16` in turn.
+                out.push(unsafe { self.u16(off + i * 2) }?);
+            }
+            Some(out)
+        }
+
+        /// The sub-directory of the entry with numeric id `id`.
+        ///
+        /// `res` is the resource directory's RVA, which every entry offset
+        /// inside the tree is relative to.
+        ///
+        /// # Safety
+        ///
+        /// `self` must describe a mapped image.
+        unsafe fn subdirectory(&self, res: usize, dir: usize, id: u32) -> Option<usize> {
+            // SAFETY: bounded reads on a mapped image.
+            let count = unsafe { self.entry_count(dir) }?;
+            for i in 0..count {
+                let entry = dir + RESOURCE_DIRECTORY_SIZE + i * RESOURCE_ENTRY_SIZE;
+                // SAFETY: as above.
+                let name = unsafe { self.u32(entry) }?;
+                // SAFETY: the offset dword follows the name in the same entry.
+                let offset = unsafe { self.u32(entry + 4) }?;
+                // A numeric id (high bit clear) that matches, pointing at a
+                // sub-directory (high bit of the offset set).
+                if name == id && offset & SUBDIRECTORY != 0 {
+                    return res.checked_add((offset & !SUBDIRECTORY) as usize);
+                }
+            }
+            None
+        }
+
+        /// The first entry of a resource directory.
+        ///
+        /// Reports where its child sits, and whether that child is another
+        /// directory rather than a leaf.
+        ///
+        /// # Safety
+        ///
+        /// `self` must describe a mapped image.
+        unsafe fn first_child(&self, res: usize, dir: usize) -> Option<(usize, bool)> {
+            // SAFETY: bounded reads on a mapped image.
+            if unsafe { self.entry_count(dir) }? == 0 {
+                return None;
+            }
+            // SAFETY: as above; the offset dword is the second half of the
+            // first entry.
+            let offset = unsafe { self.u32(dir + RESOURCE_DIRECTORY_SIZE + 4) }?;
+            let child = res.checked_add((offset & !SUBDIRECTORY) as usize)?;
+            Some((child, offset & SUBDIRECTORY != 0))
+        }
+
+        /// How many entries a resource directory holds, named and id-keyed.
+        ///
+        /// # Safety
+        ///
+        /// `self` must describe a mapped image.
+        unsafe fn entry_count(&self, dir: usize) -> Option<usize> {
+            // SAFETY: bounded reads on a mapped image.
+            let named = usize::from(unsafe { self.u16(dir + NAMED_ENTRIES) }?);
+            // SAFETY: as above.
+            let ids = usize::from(unsafe { self.u16(dir + ID_ENTRIES) }?);
+            named.checked_add(ids)
+        }
     }
 
     /// Read a `u16` at `addr` without assuming alignment.

--- a/windows/core/src/app_profile.rs
+++ b/windows/core/src/app_profile.rs
@@ -1,0 +1,175 @@
+//! Built-in per-application configuration profiles.
+//!
+//! A few games need an option set no user should have to discover: an adapter
+//! identity their engine branches on, a capability they must not be told about,
+//! an era-driver behaviour their renderer was written against. A profile carries
+//! those values for one executable so the game runs correctly out of the box.
+//!
+//! A profile is the weakest configuration layer. `mtld3d.conf` and
+//! `MTLD3D_CONFIG` both beat it key by key, so a user can take one option back
+//! without losing the rest of the profile.
+//!
+//! A profile is keyed by the version resource the vendor linked into the image,
+//! not by a path, so it follows the game wherever it is installed and cannot
+//! catch an unrelated program that happens to share a file name.
+//!
+//! Pure logic: the PE side supplies the executable's name and the raw
+//! `VS_VERSIONINFO` blob, so everything here is host-testable.
+
+use log::info;
+
+use super::LOG_TARGET;
+
+/// The profiles mtld3d ships.
+///
+/// Every entry pins at least one version-resource field, so a rule can never
+/// fire on a same-named program from someone else.
+static PROFILES: &[AppProfile] = &[
+    // Grand Theft Auto IV. Its renderer branches on the reported adapter
+    // vendor, and the ATI identity is the one whose paths it completes; the
+    // NVIDIA identity stalls in the game's own identifier parsing. It also
+    // picks a mixed DF24 plus INTZ depth path when the DF fourccs are
+    // advertised, which no hardware of its era offered together, so the depth
+    // formats stay hidden. Its occlusion culling needs real pixel counts
+    // rather than an immediate answer, otherwise every query reads as fully
+    // visible. And its late alpha, sky and glow passes z-test one INTZ depth
+    // texture against scene depth rendered into a same-size sibling, which
+    // only works where equal-size depth surfaces share one allocation.
+    AppProfile {
+        name: "gta-iv",
+        exe: "GTAIV.exe",
+        company: Some("Rockstar Games"),
+        product: Some("Grand Theft Auto IV"),
+        original_filename: None,
+        settings: "adapter.spoof=amd;caps.dfFormats=false;\
+                   query.flushImmediate=false;depth.aliasSameSize=true",
+    },
+];
+
+/// One built-in profile: what it matches, and the options it sets.
+///
+/// The options are held in `MTLD3D_CONFIG` syntax rather than as typed fields,
+/// so a profile flows through the same per-entry decode as a user's file and
+/// every present and future key is available to one without new code.
+pub struct AppProfile {
+    name: &'static str,
+    exe: &'static str,
+    company: Option<&'static str>,
+    product: Option<&'static str>,
+    original_filename: Option<&'static str>,
+    settings: &'static str,
+}
+
+impl AppProfile {
+    /// The profile's name, as the log prints it.
+    #[must_use]
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// The profile's options, semicolon-separated `key=value` entries.
+    #[must_use]
+    pub const fn settings(&self) -> &'static str {
+        self.settings
+    }
+
+    /// Whether this profile applies to `id`.
+    ///
+    /// The executable name has to match, case-insensitively. Each version field
+    /// the profile pins is an additional case-insensitive substring test, so
+    /// `Rockstar Games` also matches a `CompanyName` of `Rockstar Games, Inc.`.
+    fn matches(&self, id: &AppIdentity) -> bool {
+        id.exe.eq_ignore_ascii_case(self.exe)
+            && field_matches(self.company, &id.company)
+            && field_matches(self.product, &id.product)
+            && field_matches(self.original_filename, &id.original_filename)
+    }
+}
+
+/// Who the running application is.
+///
+/// The executable's file name, plus the three `VS_VERSIONINFO` strings a vendor
+/// sets at link time. The version strings are empty when the image carries no
+/// version resource, which leaves it matchable by name alone.
+pub struct AppIdentity {
+    exe: String,
+    company: String,
+    product: String,
+    original_filename: String,
+}
+
+impl AppIdentity {
+    /// Build an identity from the executable's name and its version resource.
+    ///
+    /// `version_blob` is the raw `RT_VERSION` resource as UTF-16 units, or
+    /// `None` for an image that has none.
+    #[must_use]
+    pub fn new(exe: String, version_blob: Option<&[u16]>) -> Self {
+        let runs = version_blob.map(utf16_runs).unwrap_or_default();
+        Self {
+            exe,
+            company: value_after(&runs, "CompanyName"),
+            product: value_after(&runs, "ProductName"),
+            original_filename: value_after(&runs, "OriginalFilename"),
+        }
+    }
+}
+
+/// The built-in profile for this application, if it has one.
+///
+/// Logs the outcome either way: which profile took effect, or that none did.
+/// Both answers are the first thing to establish when a game behaves
+/// differently than its options say it should.
+#[must_use]
+pub fn lookup(id: &AppIdentity) -> Option<&'static AppProfile> {
+    let profile = PROFILES.iter().find(|p| p.matches(id));
+    match profile {
+        Some(p) => info!(
+            target: LOG_TARGET,
+            "app profile: {} matched {} ({}, {})", p.name, id.exe, id.company, id.product
+        ),
+        None => info!(target: LOG_TARGET, "app profile: none for {}", id.exe),
+    }
+    profile
+}
+
+/// Whether an optional substring constraint holds, case-insensitively.
+///
+/// A profile that leaves the field unset places no constraint at all.
+fn field_matches(constraint: Option<&str>, actual: &str) -> bool {
+    constraint.is_none_or(|want| {
+        actual
+            .to_ascii_lowercase()
+            .contains(&want.to_ascii_lowercase())
+    })
+}
+
+/// The value a `VS_VERSIONINFO` string entry carries under `key`.
+///
+/// A `String` entry stores a NUL-terminated key immediately followed, after
+/// padding, by its value, so the value is the run after the key's. The key is
+/// matched as a run *suffix* because each entry starts with three header words
+/// (`wLength`, `wValueLength`, `wType`) that sit right against the key text and
+/// decode as part of that run; the value that follows has no such header and so
+/// is a clean run.
+fn value_after(runs: &[String], key: &str) -> String {
+    runs.iter()
+        .position(|run| run.ends_with(key))
+        .and_then(|i| runs.get(i + 1))
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// Split a UTF-16 buffer into its NUL-separated runs, dropping empty ones.
+///
+/// Decoding is lossy: the blob is vendor data, and one bad unit in an unrelated
+/// entry must not cost us the fields we came for.
+fn utf16_runs(blob: &[u16]) -> Vec<String> {
+    blob.split(|&unit| unit == 0)
+        .filter(|run| !run.is_empty())
+        .map(String::from_utf16_lossy)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/windows/core/src/app_profile/tests.rs
+++ b/windows/core/src/app_profile/tests.rs
@@ -1,0 +1,189 @@
+use super::{AppIdentity, AppProfile, PROFILES, lookup};
+use crate::config::{AdapterSpoof, CursorScale, parse};
+
+/// The three fields read out of the shipped `GTAIV.exe`.
+const GTA_IV: [(&str, &str); 3] = [
+    ("CompanyName", "Rockstar Games"),
+    ("ProductName", "Grand Theft Auto IV"),
+    ("OriginalFilename", "GTAIV.exe"),
+];
+
+/// Encode string entries the way a real `VS_VERSIONINFO` holds them.
+///
+/// Each entry is preceded by its three header words (`wLength`,
+/// `wValueLength`, `wType`), which sit directly against the key text with no
+/// separator, so the key decodes as part of that run. Reproducing that here is
+/// the point of the fixture: a decoder that looks for an exact `CompanyName`
+/// run finds nothing in a real image.
+fn blob(entries: &[(&str, &str)]) -> Vec<u16> {
+    let mut out = Vec::new();
+    for (key, value) in entries {
+        out.extend_from_slice(&[0x0040, 0x000f, 0x0001]);
+        out.extend(key.encode_utf16());
+        out.push(0);
+        out.extend(value.encode_utf16());
+        out.push(0);
+    }
+    out
+}
+
+#[test]
+fn the_version_fields_decode_past_the_entry_headers() {
+    let id = AppIdentity::new("GTAIV.exe".to_owned(), Some(&blob(&GTA_IV)));
+    assert_eq!(id.company, "Rockstar Games");
+    assert_eq!(id.product, "Grand Theft Auto IV");
+    assert_eq!(id.original_filename, "GTAIV.exe");
+}
+
+#[test]
+fn an_image_without_a_version_resource_has_empty_fields() {
+    let id = AppIdentity::new("GTAIV.exe".to_owned(), None);
+    assert!(id.company.is_empty());
+    assert!(id.product.is_empty());
+    assert!(id.original_filename.is_empty());
+}
+
+#[test]
+fn the_gta_iv_profile_matches_the_real_binarys_resource() {
+    let id = AppIdentity::new("GTAIV.exe".to_owned(), Some(&blob(&GTA_IV)));
+    assert_eq!(lookup(&id).map(AppProfile::name), Some("gta-iv"));
+    // The name is matched case-insensitively: a launcher may spell it either way.
+    let shouting = AppIdentity::new("gtaiv.exe".to_owned(), Some(&blob(&GTA_IV)));
+    assert_eq!(lookup(&shouting).map(AppProfile::name), Some("gta-iv"));
+}
+
+#[test]
+fn a_pinned_field_is_a_substring_test() {
+    let suffixed = blob(&[
+        ("CompanyName", "Rockstar Games, Inc."),
+        ("ProductName", "Grand Theft Auto IV Complete Edition"),
+    ]);
+    let id = AppIdentity::new("GTAIV.exe".to_owned(), Some(&suffixed));
+    assert_eq!(lookup(&id).map(AppProfile::name), Some("gta-iv"));
+}
+
+#[test]
+fn an_unrelated_program_of_the_same_name_is_left_alone() {
+    let nameless = AppIdentity::new("GTAIV.exe".to_owned(), None);
+    assert!(lookup(&nameless).is_none());
+    let other = blob(&[
+        ("CompanyName", "Somebody Else"),
+        ("ProductName", "Grand Theft Auto IV"),
+    ]);
+    let id = AppIdentity::new("GTAIV.exe".to_owned(), Some(&other));
+    assert!(lookup(&id).is_none());
+}
+
+#[test]
+fn an_unprofiled_game_resolves_to_nothing() {
+    let id = AppIdentity::new(
+        "Morrowind.exe".to_owned(),
+        Some(&blob(&[("CompanyName", "Bethesda Softworks")])),
+    );
+    assert!(lookup(&id).is_none());
+}
+
+#[test]
+fn every_profile_is_uniquely_named_and_pins_a_version_field() {
+    for profile in PROFILES {
+        assert!(!profile.name.is_empty(), "a profile has no name");
+        assert!(!profile.exe.is_empty(), "{} has no exe", profile.name);
+        assert!(
+            profile.company.is_some()
+                || profile.product.is_some()
+                || profile.original_filename.is_some(),
+            "{} matches on its executable alone",
+            profile.name
+        );
+    }
+    let mut names: Vec<&str> = PROFILES.iter().map(|p| p.name).collect();
+    names.sort_unstable();
+    let count = names.len();
+    names.dedup();
+    assert_eq!(names.len(), count, "duplicate profile name");
+}
+
+#[test]
+fn no_two_profiles_can_match_the_same_application() {
+    for (i, profile) in PROFILES.iter().enumerate() {
+        // The widest identity this profile accepts: its own pins, nothing else.
+        let mut entries: Vec<(&str, &str)> = Vec::new();
+        if let Some(company) = profile.company {
+            entries.push(("CompanyName", company));
+        }
+        if let Some(product) = profile.product {
+            entries.push(("ProductName", product));
+        }
+        if let Some(original) = profile.original_filename {
+            entries.push(("OriginalFilename", original));
+        }
+        let id = AppIdentity::new(profile.exe.to_owned(), Some(&blob(&entries)));
+        for (j, other) in PROFILES.iter().enumerate() {
+            assert!(
+                i == j || !other.matches(&id),
+                "{} and {} both match one application",
+                profile.name,
+                other.name
+            );
+        }
+    }
+}
+
+#[test]
+fn the_gta_iv_profile_resolves_to_the_options_it_names() {
+    let id = AppIdentity::new("GTAIV.exe".to_owned(), Some(&blob(&GTA_IV)));
+    let profile = lookup(&id).expect("the profile matches its own fixture");
+    let cfg = parse(Some(profile), "", None);
+    // A typo in a profile's settings string would leave every default in place,
+    // so these four assertions are what pins the key spellings.
+    assert_eq!(cfg.adapter_spoof, AdapterSpoof::Amd);
+    assert!(!cfg.df_formats);
+    assert!(!cfg.query_flush_immediate);
+    assert!(cfg.depth_alias_same_size);
+}
+
+/// A profile that sets two unrelated options, for the precedence cases.
+const PROBE: AppProfile = AppProfile {
+    name: "probe",
+    exe: "probe.exe",
+    company: Some("Probe"),
+    product: None,
+    original_filename: None,
+    settings: "cursor.scale=4;present.maxFps=30",
+};
+
+#[test]
+fn a_profile_beats_the_defaults() {
+    let cfg = parse(Some(&PROBE), "", None);
+    assert_eq!(cfg.cursor_scale, CursorScale::Fixed(4));
+    assert_eq!(cfg.present_max_fps, 30);
+}
+
+#[test]
+fn the_file_beats_a_profile_key_by_key() {
+    let cfg = parse(Some(&PROBE), "cursor.scale = 2\n", None);
+    assert_eq!(cfg.cursor_scale, CursorScale::Fixed(2));
+    // The key the file said nothing about keeps the profile's value.
+    assert_eq!(cfg.present_max_fps, 30);
+}
+
+#[test]
+fn the_env_beats_both() {
+    let cfg = parse(
+        Some(&PROBE),
+        "cursor.scale = 2\n",
+        Some("cursor.scale=8;present.maxFps=0"),
+    );
+    assert_eq!(cfg.cursor_scale, CursorScale::Fixed(8));
+    assert_eq!(cfg.present_max_fps, 0);
+}
+
+#[test]
+fn a_malformed_profile_entry_does_not_derail_the_rest() {
+    let broken = AppProfile {
+        settings: "bogusKey=whatever;no equals sign;present.maxFps=45",
+        ..PROBE
+    };
+    let cfg = parse(Some(&broken), "", None);
+    assert_eq!(cfg.present_max_fps, 45);
+}

--- a/windows/core/src/config.rs
+++ b/windows/core/src/config.rs
@@ -9,6 +9,8 @@
 use log::info;
 use mtld3d_shared::{log_once_warn, mtl::ColorSpacePolicy};
 
+use crate::app_profile::AppProfile;
+
 /// Resolved runtime configuration.
 ///
 /// One instance built at startup from the user's `mtld3d.conf` (or
@@ -221,24 +223,38 @@ impl Default for Mtld3dConfig {
     }
 }
 
-/// Parse `mtld3d.conf` source text into a [`Mtld3dConfig`].
+/// Resolve the three configuration layers into a [`Mtld3dConfig`].
 ///
-/// An optional `MTLD3D_CONFIG` env-var override is applied on top.
+/// Weakest first: the [`Default`] values, then the built-in
+/// [`AppProfile`] for this application if it has one, then the
+/// `mtld3d.conf` body, then the `MTLD3D_CONFIG` env override. A key set
+/// by a later layer wins, so a user can always take one option back
+/// from a profile without losing the rest of it.
 ///
 /// `file_src` is the file body (newline-separated `key = value`),
 /// `env_override` is the env-var body (semicolon-separated
-/// `key=value`). Both flow through the same per-entry decode; env
-/// segments are applied after file lines so env wins on conflict.
-/// Missing keys keep their [`Default`] value.
+/// `key=value`), and a profile's settings use the env form. All three
+/// flow through the same per-entry decode. Missing keys keep the value
+/// the layer below left.
 ///
 /// Unrecognised keys, malformed entries, and unparseable values fire
 /// `log_once_warn!` (tagged with `mtld3d.conf line N` for file input,
-/// `MTLD3D_CONFIG` for env input) so a typo doesn't silently no-op, then
-/// parsing continues. The pure-string interface keeps the parser
-/// host-testable.
+/// `MTLD3D_CONFIG` for env input, and the profile's name for a profile)
+/// so a typo doesn't silently no-op, then parsing continues. The
+/// pure-string interface keeps the parser host-testable.
 #[must_use]
-pub fn parse(file_src: &str, env_override: Option<&str>) -> Mtld3dConfig {
+pub fn parse(
+    profile: Option<&AppProfile>,
+    file_src: &str,
+    env_override: Option<&str>,
+) -> Mtld3dConfig {
     let mut cfg = Mtld3dConfig::default();
+    if let Some(profile) = profile {
+        let source = format!("app profile '{}'", profile.name());
+        for segment in profile.settings().split(';') {
+            apply_line(&mut cfg, segment, &source, None);
+        }
+    }
     for (lineno, raw_line) in file_src.lines().enumerate() {
         apply_line(&mut cfg, raw_line, "mtld3d.conf", Some(lineno));
     }

--- a/windows/core/src/config/tests.rs
+++ b/windows/core/src/config/tests.rs
@@ -5,6 +5,9 @@
 //! env segments winning in that order, and malformed or unknown entries keeping the previous
 //! value instead of derailing the rest of the input. Per-value shapes (MiB caps, decimal
 //! render scale and its bounds, hex id lists, quoted strings) get their own cases.
+//!
+//! Every case here passes no app profile; the profile layer and its precedence against these
+//! two live in `app_profile/tests.rs`, where a profile can be built.
 
 use mtld3d_shared::mtl::ColorSpacePolicy;
 
@@ -12,7 +15,7 @@ use super::{AdapterSpoof, CursorScale, Mtld3dConfig, parse};
 
 #[test]
 fn empty_input_returns_defaults() {
-    assert_eq!(parse("", None), Mtld3dConfig::default());
+    assert_eq!(parse(None, "", None), Mtld3dConfig::default());
 }
 
 #[test]
@@ -39,7 +42,7 @@ fn defaults_match_documented_values() {
 /// streaming pool from the advertised figure will commit until it does.
 #[test]
 fn vram_budget_defaults_to_a_ceiling_only_on_a_32_bit_guest() {
-    let d = parse("", None);
+    let d = parse(None, "", None);
     if cfg!(target_pointer_width = "32") {
         assert_eq!(d.vram_budget_cap_bytes, 1024 * 1024 * 1024);
     } else {
@@ -53,24 +56,25 @@ fn vram_budget_defaults_to_a_ceiling_only_on_a_32_bit_guest() {
 #[test]
 fn vram_budget_parses_as_mib_and_zero_lifts_the_ceiling() {
     assert_eq!(
-        parse("memory.vramBudgetMB = 512\n", None).vram_budget_cap_bytes,
+        parse(None, "memory.vramBudgetMB = 512\n", None).vram_budget_cap_bytes,
         512 * 1024 * 1024
     );
     assert_eq!(
-        parse("memory.vramBudgetMB = 0\n", None).vram_budget_cap_bytes,
+        parse(None, "memory.vramBudgetMB = 0\n", None).vram_budget_cap_bytes,
         0
     );
 }
 
 #[test]
 fn pagebox_pool_cap_parses_as_mib() {
-    let cfg = parse("memory.pageboxPoolCapMB = 96\n", None);
+    let cfg = parse(None, "memory.pageboxPoolCapMB = 96\n", None);
     assert_eq!(cfg.pagebox_pool_cap_bytes, 96 * 1024 * 1024);
 }
 
 #[test]
 fn pagebox_pool_cap_zero_disables() {
     let cfg = parse(
+        None,
         "memory.pageboxPoolCapMB = 96\nmemory.pageboxPoolCapMB = 0\n",
         None,
     );
@@ -79,43 +83,52 @@ fn pagebox_pool_cap_zero_disables() {
 
 #[test]
 fn pagebox_pool_cap_garbage_keeps_default() {
-    let cfg = parse("memory.pageboxPoolCapMB = lots\n", None);
+    let cfg = parse(None, "memory.pageboxPoolCapMB = lots\n", None);
     assert_eq!(cfg.pagebox_pool_cap_bytes, 128 * 1024 * 1024);
 }
 
 #[test]
 fn present_max_fps_positive_integer_parses() {
-    let cfg = parse("present.maxFps = 60\n", None);
+    let cfg = parse(None, "present.maxFps = 60\n", None);
     assert_eq!(cfg.present_max_fps, 60);
 }
 
 #[test]
 fn present_max_fps_zero_means_uncapped() {
-    let cfg = parse("present.maxFps = 60\npresent.maxFps = 0\n", None);
+    let cfg = parse(None, "present.maxFps = 60\npresent.maxFps = 0\n", None);
     assert_eq!(cfg.present_max_fps, 0);
 }
 
 #[test]
 fn present_max_fps_garbage_keeps_default() {
-    let cfg = parse("present.maxFps = fast\n", None);
+    let cfg = parse(None, "present.maxFps = fast\n", None);
     assert_eq!(cfg.present_max_fps, 0);
 }
 
 #[test]
 fn render_scale_float_becomes_a_percentage() {
-    assert_eq!(parse("render.scale = 0.5\n", None).render_scale_percent, 50);
     assert_eq!(
-        parse("render.scale = 0.75\n", None).render_scale_percent,
+        parse(None, "render.scale = 0.5\n", None).render_scale_percent,
+        50
+    );
+    assert_eq!(
+        parse(None, "render.scale = 0.75\n", None).render_scale_percent,
         75
     );
-    assert_eq!(parse("render.scale = 1\n", None).render_scale_percent, 100);
+    assert_eq!(
+        parse(None, "render.scale = 1\n", None).render_scale_percent,
+        100
+    );
 }
 
 #[test]
 fn render_scale_accepts_its_exact_bounds() {
-    assert_eq!(parse("render.scale = 0.01\n", None).render_scale_percent, 1);
     assert_eq!(
-        parse("render.scale = 1.0\n", None).render_scale_percent,
+        parse(None, "render.scale = 0.01\n", None).render_scale_percent,
+        1
+    );
+    assert_eq!(
+        parse(None, "render.scale = 1.0\n", None).render_scale_percent,
         100
     );
 }
@@ -136,7 +149,7 @@ fn render_scale_out_of_range_keeps_default() {
         "render.scale = half\n",
     ] {
         assert_eq!(
-            parse(src, None).render_scale_percent,
+            parse(None, src, None).render_scale_percent,
             100,
             "{src:?} must keep the default"
         );
@@ -145,60 +158,60 @@ fn render_scale_out_of_range_keeps_default() {
 
 #[test]
 fn query_flush_immediate_round_trips_false() {
-    let cfg = parse("query.flushImmediate = false\n", None);
+    let cfg = parse(None, "query.flushImmediate = false\n", None);
     assert!(!cfg.query_flush_immediate);
 }
 
 #[test]
 fn query_flush_immediate_round_trips_true() {
-    let cfg = parse("query.flushImmediate = true\n", None);
+    let cfg = parse(None, "query.flushImmediate = true\n", None);
     assert!(cfg.query_flush_immediate);
 }
 
 #[test]
 fn depth_alias_same_size_defaults_off_and_round_trips() {
-    let cfg = parse("", None);
+    let cfg = parse(None, "", None);
     assert!(!cfg.depth_alias_same_size);
-    let cfg = parse("depth.aliasSameSize = true\n", None);
+    let cfg = parse(None, "depth.aliasSameSize = true\n", None);
     assert!(cfg.depth_alias_same_size);
 }
 
 #[test]
 fn cursor_scale_auto_keyword_case_insensitive() {
-    let cfg = parse("cursor.scale = Auto\n", None);
+    let cfg = parse(None, "cursor.scale = Auto\n", None);
     assert_eq!(cfg.cursor_scale, CursorScale::Auto);
 }
 
 #[test]
 fn cursor_scale_positive_integer_parses_to_fixed() {
-    let cfg = parse("cursor.scale = 3\n", None);
+    let cfg = parse(None, "cursor.scale = 3\n", None);
     assert_eq!(cfg.cursor_scale, CursorScale::Fixed(3));
 }
 
 #[test]
 fn cursor_scale_zero_keeps_default() {
-    let cfg = parse("cursor.scale = 0\n", None);
+    let cfg = parse(None, "cursor.scale = 0\n", None);
     assert_eq!(cfg.cursor_scale, CursorScale::Auto);
 }
 
 #[test]
 fn cursor_scale_garbage_keeps_default() {
-    let cfg = parse("cursor.scale = jumbo\n", None);
+    let cfg = parse(None, "cursor.scale = jumbo\n", None);
     assert_eq!(cfg.cursor_scale, CursorScale::Auto);
 }
 
 #[test]
 fn color_space_accepts_both_policies_case_insensitive() {
-    let cfg = parse("color.space = accurate\n", None);
+    let cfg = parse(None, "color.space = accurate\n", None);
     assert_eq!(cfg.color_space, ColorSpacePolicy::Accurate);
 
-    let cfg = parse("color.space = PASSTHROUGH\n", None);
+    let cfg = parse(None, "color.space = PASSTHROUGH\n", None);
     assert_eq!(cfg.color_space, ColorSpacePolicy::Passthrough);
 }
 
 #[test]
 fn color_space_unknown_value_keeps_default() {
-    let cfg = parse("color.space = vivid\n", None);
+    let cfg = parse(None, "color.space = vivid\n", None);
     assert_eq!(cfg.color_space, ColorSpacePolicy::Passthrough);
 }
 
@@ -211,7 +224,7 @@ fn comments_and_blank_lines_are_skipped() {
         color.hdr.enable = true\n\
         # debug.capsAll = true\n\
     ";
-    let cfg = parse(src, None);
+    let cfg = parse(None, src, None);
     assert!(cfg.hdr_enable);
     assert!(!cfg.caps_all);
 }
@@ -219,6 +232,7 @@ fn comments_and_blank_lines_are_skipped() {
 #[test]
 fn boolean_keys_round_trip_both_values() {
     let cfg = parse(
+        None,
         "debug.capsAll = true\ncolor.hdr.enable = false\nshaderCache.enable = false\n",
         None,
     );
@@ -229,57 +243,69 @@ fn boolean_keys_round_trip_both_values() {
 
 #[test]
 fn booleans_are_case_insensitive() {
-    let cfg = parse("debug.capsAll = TRUE\ncolor.hdr.enable = False\n", None);
+    let cfg = parse(
+        None,
+        "debug.capsAll = TRUE\ncolor.hdr.enable = False\n",
+        None,
+    );
     assert!(cfg.caps_all);
     assert!(!cfg.hdr_enable);
 }
 
 #[test]
 fn whitespace_around_equals_is_tolerated() {
-    let cfg = parse("  debug.capsAll=true  \ncolor.hdr.enable\t=\ttrue\n", None);
+    let cfg = parse(
+        None,
+        "  debug.capsAll=true  \ncolor.hdr.enable\t=\ttrue\n",
+        None,
+    );
     assert!(cfg.caps_all);
     assert!(cfg.hdr_enable);
 }
 
 #[test]
 fn quoted_string_value_preserves_inner_whitespace() {
-    let cfg = parse("debug.bytecodeDumpDir = \" /tmp/x \"\n", None);
+    let cfg = parse(None, "debug.bytecodeDumpDir = \" /tmp/x \"\n", None);
     assert_eq!(cfg.bytecode_dump_dir, " /tmp/x ");
 }
 
 #[test]
 fn unquoted_string_value_is_trimmed() {
-    let cfg = parse("debug.bytecodeDumpDir = /tmp/x\n", None);
+    let cfg = parse(None, "debug.bytecodeDumpDir = /tmp/x\n", None);
     assert_eq!(cfg.bytecode_dump_dir, "/tmp/x");
 }
 
 #[test]
 fn empty_string_disables_bytecode_dump() {
-    let cfg = parse("debug.bytecodeDumpDir =\n", None);
+    let cfg = parse(None, "debug.bytecodeDumpDir =\n", None);
     assert!(cfg.bytecode_dump_dir.is_empty());
 }
 
 #[test]
 fn hex_list_parses_with_and_without_0x_prefix() {
-    let cfg = parse("debug.skipShaders = 0xabc, def, 0x12345\n", None);
+    let cfg = parse(None, "debug.skipShaders = 0xabc, def, 0x12345\n", None);
     assert_eq!(cfg.skip_shaders, vec![0xabc, 0xdef, 0x1_2345]);
 }
 
 #[test]
 fn hex_list_drops_unparseable_entries_silently() {
-    let cfg = parse("debug.skipShaders = abc, gggg, def,, , 0\n", None);
+    let cfg = parse(None, "debug.skipShaders = abc, gggg, def,, , 0\n", None);
     assert_eq!(cfg.skip_shaders, vec![0xabc, 0xdef, 0]);
 }
 
 #[test]
 fn unknown_key_does_not_corrupt_other_assignments() {
-    let cfg = parse("bogusKey = whatever\ncolor.hdr.enable = true\n", None);
+    let cfg = parse(None, "bogusKey = whatever\ncolor.hdr.enable = true\n", None);
     assert!(cfg.hdr_enable);
 }
 
 #[test]
 fn missing_equals_line_is_skipped() {
-    let cfg = parse("not a key value pair\ncolor.hdr.enable = true\n", None);
+    let cfg = parse(
+        None,
+        "not a key value pair\ncolor.hdr.enable = true\n",
+        None,
+    );
     assert!(cfg.hdr_enable);
 }
 
@@ -288,25 +314,29 @@ fn non_boolean_value_keeps_default() {
     // Canary is a key that defaults to `false`, so a parser that
     // wrongly assigned `true` on garbage would fail here; with a
     // `true`-defaulting key the two outcomes are indistinguishable.
-    let cfg = parse("debug.capsAll = maybe\n", None);
+    let cfg = parse(None, "debug.capsAll = maybe\n", None);
     assert!(!cfg.caps_all, "default must be preserved");
 }
 
 #[test]
 fn later_assignment_wins() {
-    let cfg = parse("debug.capsAll = false\ndebug.capsAll = true\n", None);
+    let cfg = parse(None, "debug.capsAll = false\ndebug.capsAll = true\n", None);
     assert!(cfg.caps_all);
 }
 
 #[test]
 fn env_override_after_file_wins() {
-    let cfg = parse("color.hdr.enable = false\n", Some("color.hdr.enable=true"));
+    let cfg = parse(
+        None,
+        "color.hdr.enable = false\n",
+        Some("color.hdr.enable=true"),
+    );
     assert!(cfg.hdr_enable);
 }
 
 #[test]
 fn env_override_merges_with_file() {
-    let cfg = parse("cursor.scale = 2\n", Some("color.hdr.enable=true"));
+    let cfg = parse(None, "cursor.scale = 2\n", Some("color.hdr.enable=true"));
     assert_eq!(cfg.cursor_scale, CursorScale::Fixed(2));
     assert!(cfg.hdr_enable);
 }
@@ -325,7 +355,7 @@ fn env_override_supports_all_keys() {
         ;memory.pageboxPoolCapMB=96\
         ;present.maxFps=72\
         ;render.scale=0.5";
-    let cfg = parse("", Some(env));
+    let cfg = parse(None, "", Some(env));
     assert!(cfg.caps_all);
     assert!(cfg.hdr_enable);
     assert_eq!(cfg.color_space, ColorSpacePolicy::Accurate);
@@ -342,58 +372,58 @@ fn env_override_supports_all_keys() {
 
 #[test]
 fn env_override_empty_segments_skipped() {
-    let cfg = parse("", Some(";;color.hdr.enable=true;;"));
+    let cfg = parse(None, "", Some(";;color.hdr.enable=true;;"));
     assert!(cfg.hdr_enable);
 }
 
 #[test]
 fn env_override_lists_keep_comma_separator() {
-    let from_file = parse("debug.skipShaders = 0xabc, 0xdef\n", None);
-    let from_env = parse("", Some("debug.skipShaders=0xabc,0xdef"));
+    let from_file = parse(None, "debug.skipShaders = 0xabc, 0xdef\n", None);
+    let from_env = parse(None, "", Some("debug.skipShaders=0xabc,0xdef"));
     assert_eq!(from_file.skip_shaders, from_env.skip_shaders);
     assert_eq!(from_env.skip_shaders, vec![0xabc, 0xdef]);
 }
 
 #[test]
 fn env_override_unknown_key_keeps_other_assignments() {
-    let cfg = parse("", Some("bogus.key=foo;color.hdr.enable=true"));
+    let cfg = parse(None, "", Some("bogus.key=foo;color.hdr.enable=true"));
     assert!(cfg.hdr_enable);
 }
 
 #[test]
 fn env_override_none_matches_file_only() {
     let src = "debug.capsAll = true\ncursor.scale = 3\n";
-    assert_eq!(parse(src, None), parse(src, Some("")));
+    assert_eq!(parse(None, src, None), parse(None, src, Some("")));
 }
 
 #[test]
 fn adapter_spoof_parses_all_values() {
     assert_eq!(
-        parse("adapter.spoof = nvidia\n", None).adapter_spoof,
+        parse(None, "adapter.spoof = nvidia\n", None).adapter_spoof,
         AdapterSpoof::Nvidia
     );
     assert_eq!(
-        parse("adapter.spoof = AMD\n", None).adapter_spoof,
+        parse(None, "adapter.spoof = AMD\n", None).adapter_spoof,
         AdapterSpoof::Amd
     );
     assert_eq!(
-        parse("adapter.spoof = ati\n", None).adapter_spoof,
+        parse(None, "adapter.spoof = ati\n", None).adapter_spoof,
         AdapterSpoof::Amd
     );
     assert_eq!(
-        parse("adapter.spoof = none\n", None).adapter_spoof,
+        parse(None, "adapter.spoof = none\n", None).adapter_spoof,
         AdapterSpoof::None
     );
 }
 
 #[test]
 fn adapter_spoof_rejects_unknown_vendor() {
-    let cfg = parse("adapter.spoof = matrox\n", None);
+    let cfg = parse(None, "adapter.spoof = matrox\n", None);
     assert_eq!(cfg.adapter_spoof, AdapterSpoof::None, "default preserved");
 }
 
 #[test]
 fn df_formats_defaults_on_and_parses_off() {
-    assert!(parse("", None).df_formats);
-    assert!(!parse("caps.dfFormats = false\n", None).df_formats);
+    assert!(parse(None, "", None).df_formats);
+    assert!(!parse(None, "caps.dfFormats = false\n", None).df_formats);
 }

--- a/windows/core/src/lib.rs
+++ b/windows/core/src/lib.rs
@@ -11,6 +11,7 @@
 /// logs to `"mtld3d::perf"`.
 const LOG_TARGET: &str = "mtld3d::d3d9";
 
+pub mod app_profile;
 pub mod buffer_rename;
 pub mod caps;
 pub mod config;

--- a/windows/d3d9/src/config.rs
+++ b/windows/d3d9/src/config.rs
@@ -1,19 +1,30 @@
 //! Process-wide [`Mtld3dConfig`] resolved once on first access via [`LazyLock`].
 //!
-//! The lookup runs `std::env::current_exe()` → strip basename → join
-//! `mtld3d.conf`; a missing file is fine and yields defaults. See
-//! `mtld3d.conf` at the repo root for the user-facing sample with
-//! documented keys and defaults.
+//! Three lookups feed it. The built-in [`AppProfile`] for this application, if
+//! it has one, comes from the executable's name plus the version resource of the
+//! image the loader mapped. The optional `mtld3d.conf` is
+//! `std::env::current_exe()` -> strip basename -> join `mtld3d.conf`; a missing
+//! file is fine. The `MTLD3D_CONFIG` env var, when set, beats both. See
+//! `mtld3d.conf` at the repo root for the user-facing sample with documented
+//! keys and defaults.
 //!
 //! Touched once at the top of `Direct3DCreate9` so option resolution
 //! and the per-key info log fire early in the process lifecycle.
 
-use std::{path::PathBuf, sync::LazyLock};
+use std::{ffi::c_void, path::PathBuf, ptr, sync::LazyLock};
 
 use log::info;
-use mtld3d_core::config::{Mtld3dConfig, log_options, parse};
+use mtld3d_core::{
+    app_profile::{AppIdentity, AppProfile},
+    config::{Mtld3dConfig, log_options, parse},
+};
+use mtld3d_shared::identity::version_blob;
 
 use crate::LOG_TARGET;
+
+unsafe extern "system" {
+    fn GetModuleHandleA(module_name: *const u8) -> *mut c_void;
+}
 
 /// Resolved config.
 ///
@@ -25,13 +36,32 @@ fn load() -> Mtld3dConfig {
     let env_override = std::env::var("MTLD3D_CONFIG")
         .ok()
         .filter(|s| !s.trim().is_empty());
+    let profile = app_profile();
     let file_src = read_conf_file();
     if env_override.is_some() {
         info!(target: LOG_TARGET, "mtld3d.conf: applying MTLD3D_CONFIG overrides");
     }
-    let cfg = parse(file_src.as_deref().unwrap_or(""), env_override.as_deref());
+    let cfg = parse(
+        profile,
+        file_src.as_deref().unwrap_or(""),
+        env_override.as_deref(),
+    );
     log_options(&cfg);
     cfg
+}
+
+/// The built-in profile for the executable this library was loaded into.
+fn app_profile() -> Option<&'static AppProfile> {
+    let exe = std::env::current_exe().ok()?;
+    let name = exe.file_name()?.to_string_lossy().into_owned();
+    // A null module name asks for the main image, which is the executable the
+    // profile matches on rather than this DLL.
+    // SAFETY: the call takes a null name and returns the main image's handle.
+    let main = unsafe { GetModuleHandleA(ptr::null()) };
+    // SAFETY: `main` is a handle the loader owns, so the image behind it is
+    // mapped for the life of the process.
+    let blob = unsafe { version_blob(main) };
+    mtld3d_core::app_profile::lookup(&AppIdentity::new(name, blob.as_deref()))
 }
 
 fn read_conf_file() -> Option<String> {


### PR DESCRIPTION
## Symptom

GTA IV only renders correctly with `MTLD3D_CONFIG="adapter.spoof=amd;caps.dfFormats=false;query.flushImmediate=false;depth.aliasSameSize=true"`. Nothing in the repository says so, so the game runs wrong for anyone who has not been told: the renderer stalls in its own adapter-identifier parsing, or picks a depth path no hardware of its era offered, or culls against occlusion answers that always read fully visible. Those four values are backend behaviour, not a user preference, and they were being carried by a launcher's per-process environment table, which only helps the people using that launcher.

## Root cause

There was no layer below `mtld3d.conf` to put them in. Options resolve from defaults, then the file, then the env override, and all three are the user's to write. An option set that a specific game needs to be correct had nowhere to live except in whatever started the process.

## The fix

A profile layer under the file. `windows/core/src/app_profile.rs` holds a static table of profiles; each pins an executable name plus any of `CompanyName`, `ProductName`, `OriginalFilename`, and carries its options as one semicolon-separated `key=value` string in `MTLD3D_CONFIG` syntax. That string flows through the existing per-entry decode, so there is no new dispatch code and every key, present and future, is available to a profile for free. Resolution order becomes defaults, profile, `mtld3d.conf`, `MTLD3D_CONFIG`, so any single key a profile sets can be taken back without losing the rest of it.

Matching needs the version resource of the running executable. `unix/shared/src/identity.rs` already walked a mapped PE for the CodeView debug record, so the resource directory is the same walk one data-directory index over: its data-directory lookup is now shared between the two entry points, and the resource levels (type 16, then first name, then first language) descend through a view bounded by the image's own `SizeOfImage`. That bound matters here in a way it did not for `image_id`, because the image is the host game's rather than ours, so a malformed resource tree has to resolve to "no version resource" instead of a fault in someone's game. The blob-to-strings half is pure logic in `app_profile` and host-tested, including the part that is easy to get wrong: each `String` entry's three header words (`wLength`, `wValueLength`, `wType`) sit directly against the key text with no separator, so the key has to be matched as a run suffix and the value taken as the next run.

The one profile that ships is `gta-iv`, on `GTAIV.exe` plus `Rockstar Games` and `Grand Theft Auto IV`, with the reason for each of its four keys in the table entry and in the README table.

## Alternatives considered

**`version.dll`, i.e. `GetFileVersionInfoSizeW` + `VerQueryValueW`.** Fewer lines, and the OS does the parsing. Rejected because `version.dll` is one of the standard DLL names game mods install proxies under, and so is the `d3d9.dll` this ships as. Importing it would route our startup through whatever proxy a modded install dropped beside the executable, at our timing rather than the game's, and a bug there would look like ours. It also re-reads the executable from disk and parses that, rather than looking at the image the loader actually mapped.

**Matching on the executable name alone.** Simplest, and rejected: any `GTAIV.exe` would inherit the profile. Every profile pins at least one version field, and a test enforces it.

**Typed fields on the profile instead of a settings string.** Each new key would then need profile plumbing as well as its dispatch arm. The string form reuses the decode that already exists, and a typo in it is caught by the test that resolves the profile's four values.

**A config key to switch profiles off.** Not added. A profile is the weakest layer already, so both the file and the environment can override any part of it individually, which is a finer instrument than an on/off switch.

## Verification

`make check` clean. `make test` clean, judged by grepping per-test results rather than the summary: 736 host unit tests, 125 in the unix workspace, 260 e2e on i686 and 260 on x86_64, no `FAIL` lines, with only the pre-existing benign `LEAK` on `buffer_getters_roundtrip`. No conformance or e2e behaviour changes, since nothing in the render path moved and the e2e harness pins its own `MTLD3D_CONFIG`, which still beats a profile.

What a reviewer should look at: the resolution order in `config::parse`, the bound on every read in the resource walk, and `app_profile/tests.rs`, where the GTA IV case is driven from the exact strings the shipped `GTAIV.exe` (1.2.0.59) carries and asserts the four options it must resolve to, so a misspelled key fails rather than silently leaving a default.

Not verified here: the game itself, which needs a bundle build carrying this. Behaviour should be identical to a launch with the environment override set, which is how the four values were established.