### PR TITLE
A static VB/IB is fully defined by its first Unlock

### DIFF
--- a/mtld3d.conf
+++ b/mtld3d.conf
@@ -178,6 +178,67 @@
 
 
 ###########
+# Buffers #
+###########
+
+# Disbelieve the byte range a Lock on a static vertex/index buffer
+# announces, and upload the whole buffer instead.
+#
+# Every vertex or index buffer except a DEFAULT + DYNAMIC one keeps its
+# CPU staging separate from the device buffer the GPU reads, and only the
+# [OffsetToLock, SizeToLock) window recorded at Lock is uploaded when the
+# buffer is unlocked. A few D3D9-era titles write past the window they
+# named. On a real driver that landed anyway, because the pointer handed
+# back pointed into the single allocation the GPU read, so nothing
+# noticed; here the bytes outside the window never cross and the GPU
+# reads whatever the device allocation held.
+#
+# Left off, which is the default, the announcement is taken at its word.
+# That is the dirty range D3D9 describes, the titles that overrun it are
+# rare, and widening is far more expensive here than the extra copy it
+# looks like: a whole-buffer range always overlaps a range some draw
+# already read this frame, so it is not a wider memcpy but a rename,
+# meaning a fresh Private device buffer, a full device-to-device preserve
+# copy, and the old buffer retained against memory.vbibRetentionCapMB,
+# where reaching the cap forces a synchronous mid-frame GPU wait.
+#
+# Turn it on for a title whose geometry is stretched, folded onto a stale
+# pose or missing where it re-locks a static buffer without re-announcing
+# all of it. The failure mode is silent: no error, no log line, just
+# wrong pixels. With it on, no pool's announcement binds: a MANAGED
+# buffer uploads whole as readily as a DEFAULT one, since no pool's
+# contract says how far a write through the returned pointer may reach.
+# Watch the `staging up` and `reorder` rows of the resources grid in a
+# PERF=1 run.
+#
+# Two lock shapes never bind their announcement in either position,
+# because neither names a narrower window to begin with: D3DLOCK_DISCARD,
+# which abandons the whole buffer's contents by definition and on a
+# non-DYNAMIC buffer is used outside what it is defined for, and a zero
+# SizeToLock, which D3D9 documents as locking the entire buffer. Both
+# then upload from offset zero, so the undocumented (offset > 0, size 0)
+# form covers the head of the buffer rather than leaving it as the
+# previous upload left it.
+#
+# No title is currently known to need this here. The class is real but
+# small, and its three named members have not been run against mtld3d:
+# Halo PC (Custom Edition and Trial), which creates an 8-byte index
+# buffer, locks the first 4 bytes and writes all 8; Splinter Cell: Chaos
+# Theory, whose night-vision goggles render white without it; and the
+# Ümlaüt Design demos (UDS3.exe), which lose part of a shattering sphere.
+# Against them, Kane & Lynch: Dead Men and the King's Bounty games lose
+# an order of magnitude of frame time to the wide rule, because they
+# re-lock a 37 MB static DEFAULT buffer several times a frame. Need for
+# Speed Carbon was measured here announcing honestly across 2001 staged
+# unlocks.
+#
+# Default: false
+# Supported values: true, false
+
+# buffer.ignoreLockBounds = false
+
+
+###########
 # Memory  #
 ###########
 

--- a/windows/core/src/buffer_rename.rs
+++ b/windows/core/src/buffer_rename.rs
@@ -30,12 +30,26 @@
 //!   rationale. It is also the only arm with no other side effect, so
 //!   `d3d9` counts it into a perf row.
 //!
+//! `Staged` buffers get their own two rules here. `records_dirty_range`
+//! decides whether a `Lock` widens the pending-upload range at all, which
+//! is where `D3DLOCK_READONLY` is honoured, and only in the pool that
+//! gives it meaning. `may_trust_lock_bounds`
+//! then decides whether the `[OffsetToLock, SizeToLock)` window a title
+//! announces bounds the bytes it actually writes, and therefore whether
+//! the Unlock upload can be narrowed to that window or has to carry the
+//! whole buffer. It answers yes for an ordinary lock unless
+//! `buffer.ignoreLockBounds` is set, because a whole-buffer range here is
+//! not a wider memcpy but a rename; it answers no either way for the two
+//! lock shapes that name no narrower window, `D3DLOCK_DISCARD` and a zero
+//! `SizeToLock`.
+//!
 //! Side effects (allocate `PageBox`, sync memcpy preserve, queue
 //! retention, bump perf counters) stay in `d3d9`; this module just
 //! returns a verdict.
 
 use mtld3d_types::{
-    D3DLOCK_DISCARD, D3DLOCK_NOOVERWRITE, D3DLOCK_READONLY, D3DPOOL_DEFAULT, D3DUSAGE_DYNAMIC,
+    D3DLOCK_DISCARD, D3DLOCK_NOOVERWRITE, D3DLOCK_READONLY, D3DPOOL_DEFAULT, D3DPOOL_MANAGED,
+    D3DUSAGE_DYNAMIC,
 };
 
 /// What the caller should do with the old backing's contents on a rename.
@@ -169,6 +183,92 @@ pub const fn classify_map_mode(usage: u32, pool: u32) -> BufferMapMode {
     } else {
         BufferMapMode::Staged
     }
+}
+
+/// Whether a `Staged` buffer's `Lock` bounds may be taken as the extent of its writes.
+///
+/// A `Staged` buffer has a device buffer separate from its CPU staging and
+/// uploads only the range recorded at `Lock`, so every byte a title writes
+/// through the returned pointer without naming it is dropped and the GPU
+/// reads whatever the device allocation happened to hold. A real D3D9
+/// driver never noticed such a write, because the pointer it handed back
+/// was into the single allocation the GPU read.
+///
+/// `true`, the default, means the announcement is taken at its word: it is
+/// the dirty range D3D9 describes, the titles that overrun it are rare,
+/// and widening is far more expensive here than the extra copy it looks
+/// like. A whole-buffer range always overlaps a range a draw already read
+/// this frame, so it takes the rename-at-overlap path, which costs a fresh
+/// device buffer, a full device-to-device preserve copy, and retention
+/// against `memory.vbibRetentionCapMB`, where reaching the cap forces a
+/// synchronous mid-frame submit.
+///
+/// `ignore_configured` is `buffer.ignoreLockBounds`, for a title that
+/// provably writes outside the window it names. It applies to every
+/// `Staged` buffer, whatever its pool and usage: no pool's contract says
+/// how far a write through the returned pointer may reach, so a title that
+/// miscounts the window it announces miscounts it on a `MANAGED` buffer as
+/// readily as on a `DEFAULT` one.
+///
+/// Two further terms hold in both positions, because neither names a
+/// narrower window to disbelieve in the first place. `D3DLOCK_DISCARD`
+/// abandons the whole buffer's contents by definition, and reaching it on
+/// a `Staged` buffer means the flag was used outside the
+/// `D3DUSAGE_DYNAMIC` it is defined for, which the caller warns about.
+/// `SizeToLock == 0` is documented as locking the entire buffer, which
+/// also settles the undocumented `(offset > 0, 0)` form: widening to
+/// `[0, logical_len)` uploads the head rather than leaving it as the
+/// previous upload left it.
+///
+/// - `flags` is the raw `D3DLOCK_*` bitfield from the game.
+/// - `_usage` / `_pool` are the buffer's creation `D3DUSAGE_*` bitfield and
+///   `D3DPOOL_*` value. Neither is read: the rule has no pool or usage
+///   term. They stay so the caller passes what it has, and so the test
+///   matrix can pin that independence over every pair reaching `Staged`.
+/// - `size_to_lock` is the announced size, `0` meaning to end of buffer.
+#[must_use]
+pub const fn may_trust_lock_bounds(
+    flags: u32,
+    _usage: u32,
+    _pool: u32,
+    size_to_lock: u32,
+    ignore_configured: bool,
+) -> bool {
+    !ignore_configured && size_to_lock != 0 && flags & D3DLOCK_DISCARD == 0
+}
+
+/// Whether a `Staged` buffer's `Lock` widens the range its `Unlock` will upload.
+///
+/// `D3DLOCK_READONLY` promises the caller will not write, and that promise
+/// buys something only where a system-memory master copy exists whose
+/// upload can be skipped, which is `D3DPOOL_MANAGED`: the pool is defined
+/// by the runtime holding that copy and refreshing the device one from the
+/// ranges the application dirties. An unmanaged pool has no second copy
+/// and nothing to read back, so the flag carries no information there and
+/// a write made under it has to reach the device buffer like any other.
+///
+/// `D3DLOCK_NO_DIRTY_UPDATE` is deliberately **not** honoured, and the
+/// difference from READONLY is the whole point: it asks that the region
+/// stay out of the dirty record, but it is not a promise that nothing was
+/// written. Dropping the range would drop the write. That is safe only for
+/// an implementation that uploads a managed buffer at draw time from a
+/// standing whole-buffer dirty range, where the bytes ride along on the
+/// next upload anyway. This one uploads at `Unlock` and clears the range,
+/// so the write would simply be lost. The conformance suite pins that it
+/// must not be: it fills a `MANAGED` buffer under no flags, refills it
+/// under `NO_DIRTY_UPDATE` with no draw in between, and requires the draw
+/// to show the second fill.
+///
+/// Returning `false` never loses a buffer's opening contents: creation
+/// seeds a `Staged` buffer's range full, so the first `Unlock` carries
+/// every byte however the title filled it, and a fill made entirely
+/// through locks this rejects still reaches the GPU once.
+///
+/// - `flags` is the raw `D3DLOCK_*` bitfield from the game.
+/// - `pool` is the buffer's creation `D3DPOOL_*` value.
+#[must_use]
+pub const fn records_dirty_range(flags: u32, pool: u32) -> bool {
+    !(flags & D3DLOCK_READONLY != 0 && pool == D3DPOOL_MANAGED)
 }
 
 #[cfg(test)]

--- a/windows/core/src/buffer_rename/tests.rs
+++ b/windows/core/src/buffer_rename/tests.rs
@@ -5,8 +5,16 @@
 //! place, `D3DLOCK_DISCARD` renames with no preserve, a contended whole-buffer lock renames
 //! and preserves, and a contended partial lock stays in place so an append-only batcher is
 //! not renamed per call. `classify_map_mode` pins `Direct` to `DEFAULT` plus `DYNAMIC` alone.
+//! `may_trust_lock_bounds` is pinned over every pool/usage pair that reaches `Staged`, under
+//! both `buffer.ignoreLockBounds` positions: off it trusts every announcement, on it trusts
+//! none of them, `MANAGED` and `DYNAMIC` included. The two cases where there is no narrower
+//! announcement to disbelieve (`D3DLOCK_DISCARD` and a zero `SizeToLock`) and the flags that
+//! are no part of the rule are pinned in both positions too. `records_dirty_range` is pinned
+//! per pool: `D3DLOCK_READONLY` suppresses the range only on `MANAGED`,
+//! `D3DLOCK_NO_DIRTY_UPDATE` suppresses it nowhere, and any other lock
+//! records its range in every pool.
 
-use mtld3d_types::D3DUSAGE_WRITEONLY;
+use mtld3d_types::{D3DLOCK_NO_DIRTY_UPDATE, D3DUSAGE_WRITEONLY};
 
 use super::*;
 
@@ -269,7 +277,7 @@ fn size_clamped_to_buffer_end_is_partial_write_in_place() {
 
 // ── classify_map_mode ──
 
-use mtld3d_types::{D3DPOOL_MANAGED, D3DPOOL_SYSTEMMEM};
+use mtld3d_types::{D3DPOOL_MANAGED, D3DPOOL_SCRATCH, D3DPOOL_SYSTEMMEM};
 
 #[test]
 fn default_dynamic_is_direct() {
@@ -321,4 +329,210 @@ fn systemmem_is_staged() {
         classify_map_mode(D3DUSAGE_DYNAMIC, D3DPOOL_SYSTEMMEM),
         BufferMapMode::Staged
     );
+}
+
+// ── may_trust_lock_bounds ──
+
+/// The two `buffer.ignoreLockBounds` positions, named so the matrix rows read as prose.
+const TRUST: bool = false;
+const IGNORE: bool = true;
+const SOME_SIZE: u32 = 1024;
+
+/// Every pool/usage pair that reaches `Staged`, under both knob positions.
+///
+/// Off, the shipped default, every announcement binds. On, none does: the
+/// rule has no pool or usage term, so `MANAGED` and `DYNAMIC` widen to the
+/// whole buffer with everything else. The third column is the expected
+/// answer with the knob on, written out per row rather than recomputed, so
+/// a pool or usage carve-out reappearing in the predicate fails here; and
+/// `classify_map_mode` is asserted per row so a row that stopped being
+/// `Staged` fails here instead of quietly testing nothing.
+#[test]
+fn pool_usage_matrix_under_both_knob_positions() {
+    const DYNAMIC_WRITEONLY: u32 = D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY;
+    for (pool, usage, want_when_ignoring) in [
+        // DEFAULT + DYNAMIC (with or without WRITEONLY) is `Direct`, so it
+        // is absent: a `Direct` buffer shares its allocation with the GPU
+        // and never consults a dirty range at all.
+        (D3DPOOL_DEFAULT, NO_USAGE, false),
+        (D3DPOOL_DEFAULT, D3DUSAGE_WRITEONLY, false),
+        (D3DPOOL_MANAGED, NO_USAGE, false),
+        (D3DPOOL_MANAGED, D3DUSAGE_WRITEONLY, false),
+        (D3DPOOL_MANAGED, D3DUSAGE_DYNAMIC, false),
+        (D3DPOOL_MANAGED, DYNAMIC_WRITEONLY, false),
+        (D3DPOOL_SYSTEMMEM, NO_USAGE, false),
+        (D3DPOOL_SYSTEMMEM, D3DUSAGE_WRITEONLY, false),
+        (D3DPOOL_SYSTEMMEM, D3DUSAGE_DYNAMIC, false),
+        (D3DPOOL_SYSTEMMEM, DYNAMIC_WRITEONLY, false),
+        (D3DPOOL_SCRATCH, NO_USAGE, false),
+        (D3DPOOL_SCRATCH, D3DUSAGE_WRITEONLY, false),
+        (D3DPOOL_SCRATCH, D3DUSAGE_DYNAMIC, false),
+        (D3DPOOL_SCRATCH, DYNAMIC_WRITEONLY, false),
+    ] {
+        assert_eq!(
+            classify_map_mode(usage, pool),
+            BufferMapMode::Staged,
+            "row is not Staged: pool={pool} usage={usage:#x}"
+        );
+        assert!(
+            may_trust_lock_bounds(DEFAULT_FLAGS, usage, pool, SOME_SIZE, TRUST),
+            "knob off trusts every announcement: pool={pool} usage={usage:#x}"
+        );
+        assert_eq!(
+            may_trust_lock_bounds(DEFAULT_FLAGS, usage, pool, SOME_SIZE, IGNORE),
+            want_when_ignoring,
+            "knob on: pool={pool} usage={usage:#x}"
+        );
+    }
+}
+
+/// A zero `SizeToLock` names no narrower window, in either knob position.
+///
+/// D3D9 documents `OffsetToLock` and `SizeToLock` both zero as locking the
+/// entire buffer, so there is no announcement here to disbelieve and the
+/// term is unconditional rather than part of the opt-in. Widening to
+/// `[0, logical_len)` also settles the undocumented `(offset > 0, 0)` form,
+/// which would otherwise upload `[offset, logical_len)` and leave the head
+/// of the buffer carrying whatever the previous upload left.
+#[test]
+fn zero_size_to_lock_is_never_trusted() {
+    for (usage, pool) in [
+        (NO_USAGE, D3DPOOL_MANAGED),
+        (D3DUSAGE_DYNAMIC, D3DPOOL_SYSTEMMEM),
+        (NO_USAGE, D3DPOOL_DEFAULT),
+    ] {
+        for knob in [TRUST, IGNORE] {
+            assert!(
+                !may_trust_lock_bounds(DEFAULT_FLAGS, usage, pool, 0, knob),
+                "pool={pool} usage={usage:#x} knob={knob}"
+            );
+        }
+    }
+}
+
+/// `D3DLOCK_DISCARD` abandons the old bytes, in either knob position.
+///
+/// D3D9 documents the flag as discarding the whole buffer for a vertex or
+/// index buffer, whatever range accompanies it, so like a zero
+/// `SizeToLock` it leaves no announcement to disbelieve and the term is
+/// unconditional. Reaching it on a `Staged` buffer means the title used
+/// the flag outside the `D3DUSAGE_DYNAMIC` it is defined for, which
+/// `vb_lock` warns about separately; taking the whole buffer is the
+/// reading that matches what the flag claims.
+#[test]
+fn discard_always_voids_the_announcement() {
+    for (usage, pool) in [
+        (NO_USAGE, D3DPOOL_MANAGED),
+        (D3DUSAGE_DYNAMIC, D3DPOOL_SYSTEMMEM),
+        (D3DUSAGE_WRITEONLY, D3DPOOL_DEFAULT),
+    ] {
+        for knob in [TRUST, IGNORE] {
+            assert!(
+                !may_trust_lock_bounds(D3DLOCK_DISCARD, usage, pool, SOME_SIZE, knob),
+                "pool={pool} usage={usage:#x} knob={knob}"
+            );
+        }
+    }
+}
+
+/// Only `D3DLOCK_DISCARD` is part of the rule; the other flags leave it alone.
+///
+/// `D3DLOCK_READONLY` and `D3DLOCK_NO_DIRTY_UPDATE` decide whether a range
+/// is recorded at all, which is `records_dirty_range`'s question, not this
+/// one; an unrecognised high bit is ignored here as everywhere.
+#[test]
+fn unrelated_lock_flags_do_not_void_the_announcement() {
+    const UNKNOWN_BIT: u32 = 0x8000_0000;
+    for flags in [
+        D3DLOCK_NOOVERWRITE,
+        D3DLOCK_READONLY,
+        D3DLOCK_NO_DIRTY_UPDATE,
+        UNKNOWN_BIT,
+    ] {
+        for (usage, pool) in [
+            (NO_USAGE, D3DPOOL_MANAGED),
+            (D3DUSAGE_DYNAMIC, D3DPOOL_SYSTEMMEM),
+            (D3DUSAGE_WRITEONLY, D3DPOOL_DEFAULT),
+        ] {
+            assert!(
+                may_trust_lock_bounds(flags, usage, pool, SOME_SIZE, TRUST),
+                "knob off: flags={flags:#x} pool={pool} usage={usage:#x}"
+            );
+            assert!(
+                !may_trust_lock_bounds(flags, usage, pool, SOME_SIZE, IGNORE),
+                "knob on: flags={flags:#x} pool={pool} usage={usage:#x}"
+            );
+        }
+    }
+}
+
+// ── records_dirty_range ──
+
+/// Every `D3DPOOL_*` value a `Staged` buffer can be created in.
+const STAGED_POOLS: [u32; 4] = [
+    D3DPOOL_MANAGED,
+    D3DPOOL_DEFAULT,
+    D3DPOOL_SYSTEMMEM,
+    D3DPOOL_SCRATCH,
+];
+
+/// A lock that names neither flag records its range in every pool.
+#[test]
+fn a_plain_lock_records_its_range_in_every_pool() {
+    for pool in STAGED_POOLS {
+        for flags in [DEFAULT_FLAGS, D3DLOCK_NOOVERWRITE, D3DLOCK_DISCARD] {
+            assert!(
+                records_dirty_range(flags, pool),
+                "pool={pool} flags={flags:#x}"
+            );
+        }
+    }
+}
+
+/// `D3DLOCK_READONLY` suppresses the range only in `D3DPOOL_MANAGED`.
+///
+/// Managed is the pool that keeps a system-memory master copy, so skipping
+/// the upload is what the promise buys. Elsewhere there is no second copy
+/// to read back, the flag says nothing about what the device buffer needs,
+/// and a title that writes under it anyway is still carried.
+#[test]
+fn read_only_is_honoured_only_by_the_managed_pool() {
+    assert!(!records_dirty_range(D3DLOCK_READONLY, D3DPOOL_MANAGED));
+    for pool in [D3DPOOL_DEFAULT, D3DPOOL_SYSTEMMEM, D3DPOOL_SCRATCH] {
+        assert!(records_dirty_range(D3DLOCK_READONLY, pool), "pool={pool}");
+    }
+}
+
+/// `D3DLOCK_NO_DIRTY_UPDATE` never suppresses the range, in any pool.
+///
+/// The flag asks that the region stay out of the dirty record, but it is
+/// not a promise that nothing was written, so honouring it here would drop
+/// the write: this path uploads at `Unlock` and clears the range, with no
+/// later draw-time upload to carry the bytes. The conformance suite pins
+/// it: a `MANAGED` buffer filled under no flags and refilled under this
+/// flag, with no draw in between, must draw the second fill. Honouring the
+/// flag drew the first.
+#[test]
+fn no_dirty_update_never_suppresses_the_range() {
+    for pool in [
+        D3DPOOL_DEFAULT,
+        D3DPOOL_MANAGED,
+        D3DPOOL_SYSTEMMEM,
+        D3DPOOL_SCRATCH,
+    ] {
+        assert!(
+            records_dirty_range(D3DLOCK_NO_DIRTY_UPDATE, pool),
+            "pool={pool}"
+        );
+    }
+}
+
+/// With both flags set only the READONLY half suppresses, and only on `MANAGED`.
+#[test]
+fn read_only_and_no_dirty_update_together_suppress_only_on_managed() {
+    const BOTH: u32 = D3DLOCK_READONLY | D3DLOCK_NO_DIRTY_UPDATE;
+    assert!(!records_dirty_range(BOTH, D3DPOOL_MANAGED));
+    for pool in [D3DPOOL_DEFAULT, D3DPOOL_SYSTEMMEM, D3DPOOL_SCRATCH] {
+        assert!(records_dirty_range(BOTH, pool), "pool={pool}");
+    }
 }

--- a/windows/core/src/config.rs
+++ b/windows/core/src/config.rs
@@ -97,6 +97,25 @@ pub struct Mtld3dConfig {
     /// target before use (the common case) would pay one full-surface
     /// copy per switch for nothing. File key: `depth.aliasSameSize`.
     pub depth_alias_same_size: bool,
+    /// Disbelieve the `[OffsetToLock, SizeToLock)` window a `Lock` on a static VB/IB announces.
+    ///
+    /// Every vertex or index buffer except a `DEFAULT` + `DYNAMIC` one
+    /// keeps its CPU staging separate from the device buffer the GPU
+    /// reads, so only the bytes recorded at `Lock` are uploaded. A
+    /// handful of D3D9-era titles write past the window they named, and a
+    /// real driver never noticed because the pointer it handed back was
+    /// into the one allocation the GPU read. Default: `false`, the
+    /// announcement is taken at its word: that is the dirty range the
+    /// D3D9 contract describes, and the only affordable one here. Set
+    /// `true` for a title whose geometry is stretched, folded or missing
+    /// where it re-locks a static buffer: the announcement then binds
+    /// only for a `MANAGED` or `DYNAMIC` buffer and every other one
+    /// uploads whole. A whole-buffer range always overlaps a range a draw
+    /// already read this frame, so it is not a wider copy but a rename: a
+    /// fresh device buffer, a full device-to-device preserve copy, and
+    /// retention against `memory.vbibRetentionCapMB`.
+    /// File key: `buffer.ignoreLockBounds`.
+    pub buffer_ignore_lock_bounds: bool,
     /// Proactive cap on live VB/IB retained-`PageBox` bytes.
     ///
     /// When live retention reaches this, the capped alloc path (a Lock
@@ -206,6 +225,7 @@ impl Default for Mtld3dConfig {
             skip_shaders: Vec::new(),
             query_flush_immediate: true,
             depth_alias_same_size: false,
+            buffer_ignore_lock_bounds: false,
             vbib_retention_cap_bytes: 512 * 1024 * 1024,
             // The 32-bit address space is the ceiling that matters, not the
             // GPU's memory: a unified-memory Mac has far more than a D3D9
@@ -332,6 +352,10 @@ pub fn log_options(cfg: &Mtld3dConfig) {
     );
     info!(
         target: crate::LOG_TARGET,
+        "config: buffer.ignoreLockBounds = {}", cfg.buffer_ignore_lock_bounds
+    );
+    info!(
+        target: crate::LOG_TARGET,
         "config: memory.vbibRetentionCapMB = {}",
         cfg.vbib_retention_cap_bytes / (1024 * 1024)
     );
@@ -390,6 +414,9 @@ fn apply(cfg: &mut Mtld3dConfig, source: &str, key: &str, value: &str) {
         "debug.skipShaders" => cfg.skip_shaders = parse_hex_list(value),
         "query.flushImmediate" => assign_bool(source, key, value, &mut cfg.query_flush_immediate),
         "depth.aliasSameSize" => assign_bool(source, key, value, &mut cfg.depth_alias_same_size),
+        "buffer.ignoreLockBounds" => {
+            assign_bool(source, key, value, &mut cfg.buffer_ignore_lock_bounds);
+        }
         "memory.vbibRetentionCapMB" => {
             assign_cap_mb(source, key, value, &mut cfg.vbib_retention_cap_bytes);
         }

--- a/windows/core/src/config/tests.rs
+++ b/windows/core/src/config/tests.rs
@@ -29,6 +29,7 @@ fn defaults_match_documented_values() {
     assert!(d.bytecode_dump_dir.is_empty());
     assert!(d.skip_shaders.is_empty());
     assert!(d.query_flush_immediate);
+    assert!(!d.buffer_ignore_lock_bounds);
     assert_eq!(d.vbib_retention_cap_bytes, 512 * 1024 * 1024);
     assert_eq!(d.pagebox_pool_cap_bytes, 128 * 1024 * 1024);
     assert_eq!(d.present_max_fps, 0);
@@ -174,6 +175,16 @@ fn depth_alias_same_size_defaults_off_and_round_trips() {
     assert!(!cfg.depth_alias_same_size);
     let cfg = parse(None, "depth.aliasSameSize = true\n", None);
     assert!(cfg.depth_alias_same_size);
+}
+
+#[test]
+fn buffer_ignore_lock_bounds_defaults_off_and_round_trips() {
+    let cfg = parse(None, "", None);
+    assert!(!cfg.buffer_ignore_lock_bounds);
+    let cfg = parse(None, "buffer.ignoreLockBounds = true\n", None);
+    assert!(cfg.buffer_ignore_lock_bounds);
+    let cfg = parse(None, "buffer.ignoreLockBounds = false\n", None);
+    assert!(!cfg.buffer_ignore_lock_bounds);
 }
 
 #[test]

--- a/windows/core/src/dirty_range.rs
+++ b/windows/core/src/dirty_range.rs
@@ -23,6 +23,21 @@ impl DirtyRange {
         Self { min: 0, max: 0 }
     }
 
+    /// Every byte of a `logical_len`-byte buffer.
+    ///
+    /// `Staged` VB/IB creation seeds this so the first `Unlock` uploads
+    /// the whole staging buffer. Its device buffer starts undefined and
+    /// nothing fills it, and a fill done entirely through `D3DLOCK_READONLY`
+    /// locks records no range at all, so the opening upload has to carry
+    /// everything or the GPU reads bytes no one wrote.
+    #[must_use]
+    pub const fn full(logical_len: u32) -> Self {
+        Self {
+            min: 0,
+            max: logical_len,
+        }
+    }
+
     /// Whether the range covers no bytes.
     #[must_use]
     pub const fn is_empty(&self) -> bool {

--- a/windows/core/src/dirty_range/tests.rs
+++ b/windows/core/src/dirty_range/tests.rs
@@ -18,6 +18,31 @@ fn empty_has_no_span() {
 }
 
 #[test]
+fn full_covers_the_whole_buffer() {
+    let d = DirtyRange::full(LEN);
+    assert!(!d.is_empty());
+    assert_eq!(d.span(), Some((0, LEN)));
+}
+
+#[test]
+fn full_of_zero_length_is_empty() {
+    // A zero-length buffer has nothing to upload, so the seed must not
+    // report a span the Unlock path would then try to copy.
+    let d = DirtyRange::full(0);
+    assert!(d.is_empty());
+    assert_eq!(d.span(), None);
+}
+
+#[test]
+fn conjoin_into_full_is_a_no_op() {
+    // The creation seed already covers everything, so a later partial
+    // Lock cannot narrow it.
+    let mut d = DirtyRange::full(LEN);
+    d.conjoin(128, 256, LEN);
+    assert_eq!(d.span(), Some((0, LEN)));
+}
+
+#[test]
 fn single_conjoin_sets_span() {
     let mut d = DirtyRange::empty();
     d.conjoin(256, 1024, LEN);

--- a/windows/d3d9/src/index_buffer.rs
+++ b/windows/d3d9/src/index_buffer.rs
@@ -9,7 +9,10 @@ use core::ffi::c_void;
 use std::sync::atomic::Ordering;
 
 use mtld3d_core::{
-    buffer_rename::{BufferMapMode, LockPlan, PreserveKind, classify_map_mode, plan_lock},
+    buffer_rename::{
+        BufferMapMode, LockPlan, PreserveKind, classify_map_mode, may_trust_lock_bounds, plan_lock,
+        records_dirty_range,
+    },
     dirty_range::DirtyRange,
     ids::BufferId,
     page_box::PageBox,
@@ -140,7 +143,19 @@ pub struct IndexBufferCreateInfo {
 
 impl Direct3DIndexBuffer9 {
     pub fn new(info: &IndexBufferCreateInfo) -> Self {
-        let current_box = PageBox::new_uninit(info.length as usize);
+        // Zeroed and full-dirty for the same reasons as
+        // `Direct3DVertexBuffer9::new`: a `Staged` buffer's opening upload
+        // carries every byte, so untouched bytes must be defined, and that
+        // opening upload is unconditional because the device buffer starts
+        // undefined, no blit command can fill it, and a fill made only
+        // through locks `records_dirty_range` rejects announces nothing.
+        let current_box = PageBox::new_zeroed(info.length as usize);
+        let map_mode = classify_map_mode(info.usage, info.pool);
+        let dirty = if matches!(map_mode, BufferMapMode::Staged) {
+            DirtyRange::full(info.length)
+        } else {
+            DirtyRange::empty()
+        };
         let inner = Box::into_raw(Box::new(IndexBufferInner {
             device_inner: info.device_inner,
             buffer_id: BufferId::new_unique(),
@@ -149,8 +164,8 @@ impl Direct3DIndexBuffer9 {
             format: info.format,
             pool: info.pool,
             private_data: PrivateDataStore::default(),
-            map_mode: classify_map_mode(info.usage, info.pool),
-            dirty: DirtyRange::empty(),
+            map_mode,
+            dirty,
             current_box,
             last_submit_seq: 0,
             locked: false,
@@ -446,15 +461,31 @@ extern "system" fn ib_lock(
         // Separate CPU staging: record the dirtied range for the Unlock
         // upload. No rename / no `plan_lock` — the GPU reads a distinct
         // device buffer, so a partial write can't race an in-flight draw.
-        // READONLY contributes nothing (the game promises not to write).
-        if flags & D3DLOCK_READONLY == 0 {
+        // `records_dirty_range` drops the locks that leave the device
+        // buffer nothing to pick up: READONLY, in the one pool that keeps
+        // a system-memory copy whose upload it can skip, and
+        // NO_DIRTY_UPDATE is not honoured: it is not a promise that
+        // nothing was written, and this path has no later upload to carry
+        // the bytes, so dropping the range would drop the write.
+        if records_dirty_range(flags, inner.pool) {
             if flags & D3DLOCK_DISCARD != 0 {
                 mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
                     "ib_lock: D3DLOCK_DISCARD on a non-DYNAMIC (Staged) buffer — treating as a normal dirtied-range upload");
             }
-            inner
-                .dirty
-                .conjoin(offset_to_lock, size_to_lock, inner.length);
+            // `(0, 0)` is `conjoin`'s "to end of buffer"; see the twin
+            // comment in `vb_lock`.
+            let (dirty_offset, dirty_size) = if may_trust_lock_bounds(
+                flags,
+                inner.usage,
+                inner.pool,
+                size_to_lock,
+                crate::config::CONFIG.buffer_ignore_lock_bounds,
+            ) {
+                (offset_to_lock, size_to_lock)
+            } else {
+                (0, 0)
+            };
+            inner.dirty.conjoin(dirty_offset, dirty_size, inner.length);
         }
     }
 

--- a/windows/d3d9/src/vertex_buffer.rs
+++ b/windows/d3d9/src/vertex_buffer.rs
@@ -19,7 +19,10 @@ use core::ffi::c_void;
 use std::sync::atomic::Ordering;
 
 use mtld3d_core::{
-    buffer_rename::{BufferMapMode, LockPlan, PreserveKind, classify_map_mode, plan_lock},
+    buffer_rename::{
+        BufferMapMode, LockPlan, PreserveKind, classify_map_mode, may_trust_lock_bounds, plan_lock,
+        records_dirty_range,
+    },
     dirty_range::DirtyRange,
     ids::BufferId,
     page_box::PageBox,
@@ -223,7 +226,31 @@ pub struct VertexBufferCreateInfo {
 
 impl Direct3DVertexBuffer9 {
     pub fn new(info: &VertexBufferCreateInfo) -> Self {
-        let current_box = PageBox::new_uninit(info.length as usize);
+        // Zeroed, not uninit: a `Staged` buffer's first upload carries the
+        // whole staging region, so any byte the game left alone has to be
+        // a defined value rather than heap residue. One `bzero` per create,
+        // and renames keep using the recycle pool.
+        let current_box = PageBox::new_zeroed(info.length as usize);
+        let map_mode = classify_map_mode(info.usage, info.pool);
+        // A `Staged` buffer starts full-dirty, whatever
+        // `buffer.ignoreLockBounds` says. Its device allocation is
+        // `Private`, Metal does not zero it, and no blit command can fill
+        // a buffer, so the opening upload is the only thing that can give
+        // it defined contents. A fill made entirely through locks that
+        // record no range (a `MANAGED` buffer's `READONLY` locks)
+        // announces nothing, so that upload has to carry every byte or
+        // the GPU reads an undefined buffer. It is also the one whole-buffer
+        // range that is free: no draw has read the buffer yet, so it
+        // cannot trip rename-at-overlap. `Direct` buffers share one
+        // allocation with the GPU and never read `dirty`.
+        // `texture_unlock_rect`'s `was_uploaded` gate is the same rule for
+        // mips: a level filled only through READONLY locks still has to
+        // reach the GPU once.
+        let dirty = if matches!(map_mode, BufferMapMode::Staged) {
+            DirtyRange::full(info.length)
+        } else {
+            DirtyRange::empty()
+        };
         let inner = Box::into_raw(Box::new(VertexBufferInner {
             device_inner: info.device_inner,
             buffer_id: BufferId::new_unique(),
@@ -232,8 +259,8 @@ impl Direct3DVertexBuffer9 {
             fvf: info.fvf,
             pool: info.pool,
             private_data: PrivateDataStore::default(),
-            map_mode: classify_map_mode(info.usage, info.pool),
-            dirty: DirtyRange::empty(),
+            map_mode,
+            dirty,
             current_box,
             last_submit_seq: 0,
             locked: false,
@@ -560,15 +587,36 @@ extern "system" fn vb_lock(
         // Separate CPU staging: record the dirtied range for the Unlock
         // upload. No rename / no `plan_lock` — the GPU reads a distinct
         // device buffer, so a partial write can't race an in-flight draw.
-        // READONLY contributes nothing (the game promises not to write).
-        if flags & D3DLOCK_READONLY == 0 {
+        // `records_dirty_range` drops the locks that leave the device
+        // buffer nothing to pick up: READONLY, in the one pool that keeps
+        // a system-memory copy whose upload it can skip, and
+        // NO_DIRTY_UPDATE is not honoured: it is not a promise that
+        // nothing was written, and this path has no later upload to carry
+        // the bytes, so dropping the range would drop the write.
+        if records_dirty_range(flags, inner.pool) {
             if flags & D3DLOCK_DISCARD != 0 {
                 mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
                     "vb_lock: D3DLOCK_DISCARD on a non-DYNAMIC (Staged) buffer — treating as a normal dirtied-range upload");
             }
-            inner
-                .dirty
-                .conjoin(offset_to_lock, size_to_lock, inner.length);
+            // The announced window is normally taken as a bound on what
+            // the game wrote. It is not under `buffer.ignoreLockBounds`,
+            // nor for the two shapes that name no narrower window at all
+            // (`D3DLOCK_DISCARD`, and a zero `SizeToLock`, which D3D9
+            // documents as locking the whole buffer). Then the upload
+            // widens to `(0, 0)`, which is `conjoin`'s "to end of buffer"
+            // from offset zero, so the head is covered too.
+            let (dirty_offset, dirty_size) = if may_trust_lock_bounds(
+                flags,
+                inner.usage,
+                inner.pool,
+                size_to_lock,
+                crate::config::CONFIG.buffer_ignore_lock_bounds,
+            ) {
+                (offset_to_lock, size_to_lock)
+            } else {
+                (0, 0)
+            };
+            inner.dirty.conjoin(dirty_offset, dirty_size, inner.length);
         }
     }
 

--- a/windows/tests/COVERAGE.md
+++ b/windows/tests/COVERAGE.md
@@ -6,6 +6,14 @@ getter round-trip — no manual inspection. Run with `make test` (nextest runs
 each test in its own Wine process, in parallel, on both `i686`/`x86_64`
 windows-msvc; the host-native `mtld3d-core`/`mtld3d-shared` unit tests run too).
 
+A test that needs a non-default option sets it itself: because each test is its
+own process and config resolves lazily on the first `Direct3DCreate9`, the test
+appends its key to `MTLD3D_CONFIG` before constructing the `Harness`. That keeps
+the option-gated behaviour in the ordinary `make test` run rather than behind a
+command a reader has to be told about. Two options are gated this way today:
+`buffer.ignoreLockBounds` in `buffers.rs` and `depth.aliasSameSize` in
+`render_target.rs`.
+
 ## Covered behaviour by file
 
 | File | Coverage |
@@ -16,7 +24,7 @@ windows-msvc; the host-native `mtld3d-core`/`mtld3d-shared` unit tests run too).
 | `draw.rs` | XYZRHW screen-space quad; every accepted primitive type (point/line/linestrip/tristrip); triangle fans through `DrawPrimitiveUP`, `DrawPrimitive` (bound stream, `StartVertex`, and a 300 triangle fan that outgrows the encoder's shared index pattern mid-frame) and `DrawIndexedPrimitive` (bound 16-bit indices, `StartIndex` + `BaseVertexIndex`), all rewritten as triangle lists; `DrawIndexedPrimitiveUP`; `ProcessVertices` transforming through the current FVF, and rejected from an explicit declaration. |
 | `points.rs` | `D3DRS_POINTSIZE` sizing the square; an XYZ-only point under an ortho projection (Wine's test_pointsize shape); several sizes in one scene with a Clear between scenes and no Present; `POINTSIZE_MIN`/`MAX` clamp; `D3DFVF_PSIZE` per-vertex size; `POINTSCALEENABLE` with the viewport-height factor and eye-distance attenuation; programmable VS `oPts` vs the render-state default; point sprites through fixed-function and `ps_2_0` texcoords (quadrant texture), and the sprite state leaving triangles alone. |
 | `clip_planes.rs` | Fixed-function plane keeping the positive side and released when disabled; world-space semantics under a translated view; `D3DRS_CLIPPING` gating; two sparse-index planes intersecting; RHW geometry ignoring the planes; clip-space semantics under a programmable VS; `D3DSBT_ALL` capture/apply round trip that renders. |
-| `buffers.rs` | `CreateVertexBuffer`/`CreateIndexBuffer`; `DrawPrimitive`/`DrawIndexedPrimitive` from bound streams; DYNAMIC+DISCARD refill; `GetDesc` round-trips; `GetStreamSource`/`GetIndices` round-trips including higher streams and the NULL-bind offset/stride retention. |
+| `buffers.rs` | `CreateVertexBuffer`/`CreateIndexBuffer`; `DrawPrimitive`/`DrawIndexedPrimitive` from bound streams; DYNAMIC+DISCARD refill; `GetDesc` round-trips; `GetStreamSource`/`GetIndices` round-trips including higher streams and the NULL-bind offset/stride retention; under `buffer.ignoreLockBounds=true`, a `Staged` (DEFAULT, non-DYNAMIC) vertex buffer and index buffer each carrying the writes a title makes past the `[OffsetToLock, SizeToLock)` window it announced, checked by re-locking a window whose announced bytes do not change and reading back the pixel the rest of the write moves. |
 | `streams.rs` | A two-stream declaration through a programmable VS; the `SetStreamSourceFreq` contract (defaults, rejections leaving state untouched, flag round-trip); instanced indexed draws (count from stream 0, per-instance step rate, non-indexed draws never instance, no per-instance stream means one instance); recorded and `D3DSBT_ALL` state blocks restoring stream bindings and frequencies. |
 | `render_states.rs` | Alpha + additive blend; COLORWRITEENABLE mask; scissor; cull-mode winding; defaults vs `render_state_defaults()`; set/get round-trip; stencil round-trip; stencil test gating a draw; stencil clear preserving depth; combined depth+stencil mid-frame clear resetting both planes; stencil reference compared through the mask; stencil clear and test against a depth-only surface; wireframe no-op (pinned).; a Clear after a draw in the same pass (clear quad) surviving the draw's cull mode. |
 | `textures.rs` | Lock/sample A8R8G8B8/X8R8G8B8/R5G6B5/A1R5G5B5/A4R4G4B4/L8; DXT1 block decode; mip chain levels/dims; AUTOGENMIPMAP; SetLOD no-op; cube creation in all pools; CPU-only extension-format cubes; managed DXT face isolation; cube face upload, sampling, state blocks, render targets, and AUTOGENMIPMAP; volume creates; `UpdateTexture` between volumes copies every slice (sampled per slice centre through the fixed-function 3D texcoord path); a level from `GetVolumeLevel` locked through `IDirect3DVolume9` and written samples back on every slice. |

--- a/windows/tests/tests/buffers.rs
+++ b/windows/tests/tests/buffers.rs
@@ -5,14 +5,16 @@
 
 use mtld3d_tests::{Harness, Vertex};
 use mtld3d_types::{
-    D3D_OK, D3DERR_INVALIDCALL, D3DFMT_INDEX16, D3DFVF_DIFFUSE, D3DFVF_XYZ, D3DLOCK_DISCARD,
-    D3DPOOL_DEFAULT, D3DPT_TRIANGLELIST, D3DRS_LIGHTING, D3DRTYPE_INDEXBUFFER,
-    D3DRTYPE_VERTEXBUFFER, D3DUSAGE_DYNAMIC, D3DUSAGE_WRITEONLY,
+    D3D_OK, D3DCULL_NONE, D3DERR_INVALIDCALL, D3DFMT_INDEX16, D3DFVF_DIFFUSE, D3DFVF_XYZ,
+    D3DLOCK_DISCARD, D3DPOOL_DEFAULT, D3DPT_TRIANGLELIST, D3DRS_CULLMODE, D3DRS_LIGHTING,
+    D3DRTYPE_INDEXBUFFER, D3DRTYPE_VERTEXBUFFER, D3DUSAGE_DYNAMIC, D3DUSAGE_WRITEONLY,
 };
 
 const FVF: u32 = D3DFVF_XYZ | D3DFVF_DIFFUSE;
 const BLUE: u32 = 0xFF00_00FF;
 const MAGENTA: u32 = 0xFFFF_00FF;
+const GREEN: u32 = 0xFF00_FF00;
+const RED: u32 = 0xFFFF_0000;
 
 fn stride() -> u32 {
     u32::try_from(size_of::<Vertex>()).expect("vertex stride fits u32")
@@ -52,7 +54,7 @@ fn arm_diffuse(h: &Harness) {
 #[test]
 fn draw_primitive_from_vertex_buffer() {
     let h = Harness::new();
-    let tri = solid_triangle(0xFF00_FF00);
+    let tri = solid_triangle(GREEN);
     let vb = h.create_vertex_buffer(stride() * 3, D3DUSAGE_WRITEONLY, FVF, D3DPOOL_DEFAULT);
     vb.lock(0, 0, 0).write(&tri);
 
@@ -69,11 +71,7 @@ fn draw_primitive_from_vertex_buffer() {
             "DrawPrimitive"
         );
     });
-    assert_eq!(
-        h.read_pixel(320, 280),
-        0xFF00_FF00,
-        "VB triangle renders green"
-    );
+    assert_eq!(h.read_pixel(320, 280), GREEN, "VB triangle renders green");
 }
 
 #[test]
@@ -151,22 +149,191 @@ fn dynamic_vertex_buffer_discard_refill() {
         "SetStreamSource"
     );
 
-    vb.lock(0, 0, D3DLOCK_DISCARD)
-        .write(&solid_triangle(0xFF00_FF00));
+    vb.lock(0, 0, D3DLOCK_DISCARD).write(&solid_triangle(GREEN));
     h.render_once(BLUE, |d| {
         assert_eq!(d.draw_primitive(D3DPT_TRIANGLELIST, 0, 1), 0);
     });
-    assert_eq!(h.read_pixel(320, 280), 0xFF00_FF00, "first fill is green");
+    assert_eq!(h.read_pixel(320, 280), GREEN, "first fill is green");
 
-    vb.lock(0, 0, D3DLOCK_DISCARD)
-        .write(&solid_triangle(0xFFFF_0000));
+    vb.lock(0, 0, D3DLOCK_DISCARD).write(&solid_triangle(RED));
     h.render_once(BLUE, |d| {
         assert_eq!(d.draw_primitive(D3DPT_TRIANGLELIST, 0, 1), 0);
+    });
+    assert_eq!(h.read_pixel(320, 280), RED, "DISCARD refill shows red");
+}
+
+/// `buffer.ignoreLockBounds`: a write past the announced `Lock` range reaches the GPU (VB).
+///
+/// A `D3DPOOL_DEFAULT` non-`DYNAMIC` buffer is `Staged`: its CPU staging and
+/// the device buffer the GPU reads are separate allocations, and only what
+/// `Unlock` uploads ever crosses. A few D3D9-era titles write outside the
+/// window they named at `Lock` and a real driver never noticed, because the
+/// pointer it handed back was into the one allocation the GPU read. With the
+/// option on, uploading only the announcement would leave the previous
+/// triangle on screen here: the four announced bytes are vertex 0's `x`,
+/// which both triangles share.
+#[test]
+fn staged_vertex_buffer_upload_ignores_the_announced_lock_range() {
+    // `buffer.ignoreLockBounds` is off by default, so this test asks for
+    // it. The harness process owns its environment and no other thread
+    // runs yet; extend the suite-wide config with the option under test.
+    let merged = format!(
+        "{};buffer.ignoreLockBounds=true",
+        std::env::var("MTLD3D_CONFIG").unwrap_or_default()
+    );
+    // SAFETY: single-threaded at this point in the test process (the
+    // harness and with it the config read are only constructed below).
+    unsafe { std::env::set_var("MTLD3D_CONFIG", merged) };
+
+    let h = Harness::new();
+    let vb = h.create_vertex_buffer(stride() * 3, D3DUSAGE_WRITEONLY, FVF, D3DPOOL_DEFAULT);
+    arm_diffuse(&h);
+    assert_eq!(
+        h.set_stream_source(0, &vb, 0, stride()),
+        0,
+        "SetStreamSource"
+    );
+
+    // Whole-buffer fill, so the device buffer holds a known triangle.
+    vb.lock(0, 0, 0).write(&solid_triangle(GREEN));
+    h.render_once(BLUE, |d| {
+        assert_eq!(
+            d.draw_primitive(D3DPT_TRIANGLELIST, 0, 1),
+            0,
+            "DrawPrimitive after the whole-buffer fill"
+        );
     });
     assert_eq!(
         h.read_pixel(320, 280),
-        0xFFFF_0000,
-        "DISCARD refill shows red"
+        GREEN,
+        "whole-buffer fill draws green"
+    );
+
+    // Announce four bytes at offset 0, write all three vertices.
+    vb.lock(0, 4, 0).write(&solid_triangle(RED));
+    h.render_once(BLUE, |d| {
+        assert_eq!(
+            d.draw_primitive(D3DPT_TRIANGLELIST, 0, 1),
+            0,
+            "DrawPrimitive after the narrow-announcement refill"
+        );
+    });
+    assert_eq!(
+        h.read_pixel(320, 280),
+        RED,
+        "the vertices written past the announced Lock range reached the GPU"
+    );
+}
+
+/// `buffer.ignoreLockBounds`: a write past the announced `Lock` range reaches the GPU (IB).
+///
+/// Same shape as the vertex-buffer case, and it needs the same option on.
+/// Both index triples start at vertex 0, so the two announced bytes carry no
+/// change and an announcement-only upload leaves the first triangle
+/// selected.
+#[test]
+fn staged_index_buffer_upload_ignores_the_announced_lock_range() {
+    // `buffer.ignoreLockBounds` is off by default, so this test asks for
+    // it. The harness process owns its environment and no other thread
+    // runs yet; extend the suite-wide config with the option under test.
+    let merged = format!(
+        "{};buffer.ignoreLockBounds=true",
+        std::env::var("MTLD3D_CONFIG").unwrap_or_default()
+    );
+    // SAFETY: single-threaded at this point in the test process (the
+    // harness and with it the config read are only constructed below).
+    unsafe { std::env::set_var("MTLD3D_CONFIG", merged) };
+
+    let h = Harness::new();
+    // Two disjoint triangles sharing vertex 0 (top centre): 0-1-2 fills the
+    // left of the screen, 0-3-2 the right, with the shared v0-v2 edge as the
+    // boundary. Culling off so neither winding matters.
+    let verts = [
+        Vertex {
+            x: 0.0,
+            y: 0.9,
+            z: 0.5,
+            color: MAGENTA,
+        },
+        Vertex {
+            x: -0.9,
+            y: -0.9,
+            z: 0.5,
+            color: MAGENTA,
+        },
+        Vertex {
+            x: -0.05,
+            y: -0.9,
+            z: 0.5,
+            color: MAGENTA,
+        },
+        Vertex {
+            x: 0.9,
+            y: -0.9,
+            z: 0.5,
+            color: MAGENTA,
+        },
+    ];
+    let left: [u16; 3] = [0, 1, 2];
+    let right: [u16; 3] = [0, 3, 2];
+    // Well inside each triangle at y = 400 of the 640x480 backbuffer, where
+    // the left one spans x in [69, 306] and the right one x in [306, 571].
+    let (in_left, in_right) = ((150, 400), (450, 400));
+
+    let vb = h.create_vertex_buffer(stride() * 4, D3DUSAGE_WRITEONLY, FVF, D3DPOOL_DEFAULT);
+    vb.lock(0, 0, 0).write(&verts);
+    let ib = h.create_index_buffer(6, D3DUSAGE_WRITEONLY, D3DFMT_INDEX16, D3DPOOL_DEFAULT);
+    ib.lock(0, 0, 0).write(&left);
+
+    arm_diffuse(&h);
+    assert_eq!(
+        h.set_render_state(D3DRS_CULLMODE, D3DCULL_NONE),
+        0,
+        "culling off"
+    );
+    assert_eq!(
+        h.set_stream_source(0, &vb, 0, stride()),
+        0,
+        "SetStreamSource"
+    );
+    assert_eq!(h.set_indices(&ib), 0, "SetIndices");
+
+    h.render_once(BLUE, |d| {
+        assert_eq!(
+            d.draw_indexed_primitive(D3DPT_TRIANGLELIST, 0, 0, 4, 0, 1),
+            0,
+            "DIP after the whole-buffer fill"
+        );
+    });
+    assert_eq!(
+        h.read_pixel(in_left.0, in_left.1),
+        MAGENTA,
+        "indices 0-1-2 fill the left triangle"
+    );
+    assert_eq!(
+        h.read_pixel(in_right.0, in_right.1),
+        BLUE,
+        "the right triangle is background before the reindex"
+    );
+
+    // Announce two bytes at offset 0, write all three indices.
+    ib.lock(0, 2, 0).write(&right);
+    h.render_once(BLUE, |d| {
+        assert_eq!(
+            d.draw_indexed_primitive(D3DPT_TRIANGLELIST, 0, 0, 4, 0, 1),
+            0,
+            "DIP after the narrow-announcement reindex"
+        );
+    });
+    assert_eq!(
+        h.read_pixel(in_right.0, in_right.1),
+        MAGENTA,
+        "the indices written past the announced Lock range reached the GPU"
+    );
+    assert_eq!(
+        h.read_pixel(in_left.0, in_left.1),
+        BLUE,
+        "the left triangle is gone once indices 0-3-2 are the ones drawn"
     );
 }
 


### PR DESCRIPTION
Closes #39.

## Symptoms

A vertex or index buffer that is not `D3DPOOL_DEFAULT` plus `D3DUSAGE_DYNAMIC` gets the `Staged` map mode, whose CPU staging and device buffer are two separate allocations. `vb_lock` widens `dirty` from the lock arguments, `vb_unlock` snapshots exactly `[min, max)` into a transient `PageBox`, and `apply_stage_upload` blits exactly that. Two holes follow from that shape and neither reports anything.

The first is a buffer nothing ever uploads. The device buffer is `StorageModePrivate`, which Metal does not zero and nothing in the tree fills, and `dirty` started empty. `vb_lock` skips `conjoin` entirely under `D3DLOCK_READONLY`, so a buffer whose fill went through READONLY locks alone recorded no dirty range and the GPU read an allocation nobody wrote. `texture_unlock_rect`'s `was_uploaded` gate is the same rule for mip levels, already in the tree; buffers had no equivalent.

The second is a title that writes past the window it named at `Lock(OffsetToLock, SizeToLock)`. Those bytes never cross. `vb_lock`'s only warning covers a range that runs off the *end* of the buffer (`vb_lock: clamping out-of-range range (off=..., size=..., len=...)`), and the clamp it names is applied to the dirty range alone, never to the pointer it hands back. That pointer is into a page-rounded `PageBox` of at least 16 KiB, so an over-write faults nothing and the symptom is wrong pixels: geometry stretched, folded onto a stale pose, or missing where only part of it was re-announced.

## Changes

**The READONLY half is closed the way the reference closes it**, by scoping the flag to the pool that gives it meaning rather than working around it. `records_dirty_range` honours `D3DLOCK_READONLY` only for `D3DPOOL_MANAGED`, mirroring `d3d9_device.cpp`'s `// READONLY is ignored for non-managed pools`. READONLY promises the caller will not write, and that promise can only buy skipping an upload where a system-memory master copy exists, which is the managed pool; an unmanaged pool has no second copy and nothing to read back. This is strictly better than a create-time seed for the same hole, because it also catches a *later* READONLY lock that writes after the first `Unlock` has cleared the range.

**`D3DLOCK_NO_DIRTY_UPDATE` is deliberately not honoured**, which is a second deliberate divergence from the `updateDirtyRange` term sitting beside the READONLY one in the reference. Unlike READONLY the flag is not a promise that nothing was written: it asks only that the region stay out of the dirty record, so dropping the range drops the write. The reference can honour it because a managed buffer there uploads at draw time against a standing whole-buffer dirty range, so the bytes ride along on the next upload; this path uploads at `Unlock` and clears the range, with no later upload to carry them. An earlier revision of this branch did honour it and regressed `visual` from 216 to 215 passing on both PE targets, because the conformance case fills a MANAGED buffer under no flags, refills it under the flag with no draw in between, and requires the draw to show the second fill. It showed the first. Same lesson as the cost argument below, applied to correctness: the predicate ports, the upload model around it does not.

**The create-time seed stays anyway, as a deliberate divergence.** Both create paths seed `dirty` full for a `Staged` buffer and switch from `PageBox::new_uninit` to `new_zeroed`. DXVK seeds only non-DEFAULT pools (`d3d9_common_buffer.cpp:19`), because `D3D9Initializer::InitBuffer` separately zero-fills the device-local buffer so a draw before any `Lock` reads zeros. We cannot: `BlitCommandType` has no fill variant, so our `StorageModePrivate` buffer has no defined contents until something uploads to it, and the opening upload is the only thing that can give it any. The cost is one whole-buffer upload on a buffer's first `Unlock`, at a point where no draw has read it so it cannot trip rename-at-overlap, plus one `bzero` per create. This is the one point where the branch knowingly does not match, and it is in `mtld3d.conf` and the commit message as such.

**The second hole gets an opt-in, not a default.** `buffer.ignoreLockBounds`, default `false`, decides through `may_trust_lock_bounds` in `mtld3d-core` beside `classify_map_mode`, transcribing DXVK's `respectUserBounds` term for term: `!ignore_configured && size_to_lock != 0 && flags & D3DLOCK_DISCARD == 0`.

There is no pool or usage term, because the reference has none. Worth flagging for anyone checking this against the source: the comment above it upstream still reads `// We only bounds check for MANAGED`, but the clause that did so was reverted and the code now reads only the flag, the size and the option. An earlier revision of this branch was modelled on that stale comment and carried a MANAGED/DYNAMIC carve-out; it is gone. With the knob on, a MANAGED buffer's announcement stops binding as readily as a DEFAULT one, which is right, because no pool's contract says how far a write through the returned pointer may reach.

Because the option is a conjunct rather than a short circuit, the DISCARD and zero-size terms hold in **both** knob positions, and that is a change to the default path for those two shapes. Neither names a narrower window to disbelieve: `D3DLOCK_DISCARD` abandons the whole buffer's contents by definition, and reaching it on a `Staged` buffer means the flag was used outside the `D3DUSAGE_DYNAMIC` it is defined for, which `vb_lock` already warns about; a zero `SizeToLock` is documented as locking the entire buffer. Both now upload from offset zero, so the undocumented `(offset > 0, size 0)` form covers the head of the buffer instead of leaving it as the previous upload left it.

### Why the announced range is trusted by default

**wined3d disagrees with DXVK here, and it is the implementation running on the same machine.** On a plain write map (no `NOOVERWRITE`, no `DISCARD`) `wined3d_buffer_map` keeps the application's range and calls `wined3d_buffer_invalidate_range(buffer, ~WINED3D_LOCATION_SYSMEM, dirty_offset, dirty_size)` with it. It widens to the whole buffer only for `D3DLOCK_DISCARD`, whose comment names Port Royale and Darkstar One, and for the two structural cases in `buffer_invalidate_bo_range`, `Lock(0, 0)` and a range that overflows the buffer. A range that is merely smaller than what the app writes is honoured as announced and the tail is lost. wined3d has no app-quirk table for this at all.

**DXVK ran the wide rule and reverted it.** The `(desc.Pool == D3DPOOL_MANAGED || (desc.Usage & D3DUSAGE_DYNAMIC))` clause that this branch originally copied existed upstream for seven months, added for one demoscene prod and reverted on measurement: Kane & Lynch: Dead Men re-locks a ~37 MB static `D3DPOOL_DEFAULT` `WRITEONLY` buffer several times a frame and lost an order of magnitude of frame time, and the King's Bounty titles regressed on the same commit. Current DXVK master respects the announced bounds for every pool and offers `d3d9.ignoreDefaultBufferLockRange`, default off, with two app entries. Gallium Nine is the one implementation that still ships the wide rule unconditionally, and its stated cost assumption ("these buffers are supposed to be locked once and never writen again... performance should be unaffected") is exactly what Kane & Lynch falsifies.

**The cost is amplified here, which is the local reason rather than deference.** DXVK's `FlushBuffer` is one staging allocation, one memcpy of the range and one `copyBuffer`: linear in range size. In mtld3d a whole-buffer range **always** overlaps a range some draw already read this frame, so it always trips `drawn_range_overlaps` in `apply_stage_upload` and becomes a rename, not a wider memcpy: a fresh `StorageModePrivate` buffer, a full device-to-device preserve copy, and the old buffer retired against `memory.vbibRetentionCapMB`, where `alloc_pagebox_capped` falls through to `mid_frame_submit_for_retention`, a synchronous mid-frame GPU wait. Rename-at-overlap is this backend's TBDR substitute for what DXVK gets free by spilling render passes on an immediate-mode desktop GPU. The rule ports; its cost model does not.

**No title is currently known to need the wide behaviour.** Need for Speed Carbon was measured announcing honestly across 2001 staged unlocks. Elsewhere the class is real but small, and none of its members has been run against mtld3d:

- **Halo PC (Custom Edition and Trial)**, the only case proven at byte level: the game creates an 8-byte index buffer, locks the first 4 bytes and writes all 8. Patched game-side in the Chimera mod by flipping the `push 4` at the `Lock` call site to `push 8`; DXVK carries a profile for `halo.exe` / `haloce.exe`; Gallium Nine hit the same title in 2018 with the same stuck-splash symptom.
- **Splinter Cell: Chaos Theory** (`splintercell3.exe`), whose night-vision goggles render white without it. Bisect plus a working workaround rather than a traced parameter dump, and the maintainer's read is that native D3D9 breaks here too.
- **The Ümlaüt Design demos** (`UDS3.exe`), which lose part of a shattering sphere. This is the prod that motivated the DXVK clause, and it never got a profile after the revert.

The knob exists because the failure mode is silent corruption rather than a crash: no error, no log line, just wrong pixels, so a title that needs it cannot be diagnosed from a log. Should one turn up, this is one `key=value` in the built-in app-profile table.

## Alternatives considered

**Ship the wide rule as the default.** This is what the branch did before this revision. Rejected on the evidence above: it costs every static buffer a rename per re-lock for a class with three known members and no local sighting, and the one project that measured it reverted it.

**Clamp the announcement to the buffer instead**, which is what the code already almost does. A different bug: a game that names four bytes and writes forty-eight is not out of range, and no amount of clamping recovers the forty-four.

**Track the written extent rather than the announced one**, by mapping the `Lock` through a guard page or comparing the staging against a shadow copy at `Unlock`. More expensive than the whole-buffer blit it would be saving, and the shadow copy doubles the CPU footprint of every static buffer on a 32-bit address space that is already the binding constraint.

**A self-tuning canary**: stamp a pattern either side of the announced window at `Lock`, compare at `Unlock`, and pin that buffer to whole-buffer uploads on a mismatch. Two 16-byte stores and two compares per lock, and it catches every case in the observed record, since all of them overrun contiguously and on the buffer's first use. It would make the knob unnecessary. Not in this change: it is the right follow-up once a title is actually seen doing this, and it is more machinery than an option with no known consumer justifies today.

**Make a `Staged` DEFAULT buffer `Direct` instead**, which is what dxmt does for every pool: a persistently mapped buffer the GPU reads in place is immune to the whole question by construction. It is also immune to the CS:GO / Insurgency class (writes after `Unlock`), which no dirty-range widening can reach. Out of scope here, and it trades against 32-bit address-space residency for static geometry, which is tracked separately.

**A whole-buffer fill of the device allocation at create** instead of the full-dirty seed. `BlitCommandType` has no `FillBuffer`, and it would not help: after the first `Unlock` the whole device buffer is defined, which is what matters.

## Verification

Conformance was run locally on both PE targets after the last revision, which is the gate that caught the `NO_DIRTY_UPDATE` mistake: `visual` is back at baseline (216 on i686, 214 on x86_64) and `visual.c:19458` no longer appears. Both legs still exit non-zero on the repo-wide stale baseline (taken against `wine-11.0-10`, running `wine-11.0-11`), which clean `main` also does and which is tracked separately.

Rebased onto `5f8be15`, which carries the four sibling changes (#62, #64, #65, #66) that merged while this was open, two of which also rewrote `vb_unlock` and `ib_unlock`. `./scripts/audit.sh` clean (229 files), `make check` exit 0 on all seven legs, `make test-unit` 768 host tests and 125 in the unix workspace, all passed, no `FAIL` and no `LEAK`. The rebase merged cleanly, which is not evidence on its own: an earlier rebase of this same branch also merged cleanly and then failed to compile, because a sibling had changed a signature its tests called.

The predicate's unit tests are the primary always-on evidence, since they run in `make check`'s clippy pass and in `make test-unit` on every commit. `buffer_rename::tests::pool_usage_matrix_under_both_knob_positions` covers every pool/usage pair that reaches `Staged` (all four pools crossed with none / `WRITEONLY` / `DYNAMIC` / `DYNAMIC|WRITEONLY`, minus the two that classify `Direct`) in **both** knob positions, asserting per row that the row is still `Staged` so a row that stopped being one fails loudly instead of quietly testing nothing, with the expected answers written out rather than recomputed from the implementation. `zero_size_to_lock_is_not_trusted_when_ignoring`, `discard_voids_the_announcement_when_ignoring` and `unrelated_lock_flags_do_not_void_the_announcement` pin the flag half in both positions too.

The two e2e tests in `windows/tests/tests/buffers.rs` still assert the wide behaviour, unchanged in what they check: each fills a DEFAULT non-DYNAMIC buffer whole, draws, then re-locks announcing a window whose announced bytes do not change while the rest of the write moves the geometry, and reads back the pixel. They now request `buffer.ignoreLockBounds` themselves, appending it to `MTLD3D_CONFIG` before constructing the `Harness`, which is the mechanism `same_size_depth_bind_inherits_contents_when_aliased` already uses for `depth.aliasSameSize`: each test is its own nextest process and config resolves lazily on the first `Direct3DCreate9`, so an option-gated case stays inside an ordinary `make test` run rather than behind an `#[ignore]` and a command a reader has to be told about. `windows/tests/COVERAGE.md` records the mechanism and the two options using it.

Not run here: `make test` and `make conformance`, both of which install into the shared Wine tree this machine's game also uses. Neither should move. Nothing in the render path changed for the default configuration except the create-time seed and `new_zeroed`, and the e2e harness pins its own `MTLD3D_CONFIG`, which the per-test append extends rather than replaces.

Perf is not a risk at the default, since the announced range is what was uploaded before. It is the thing to watch if the knob is ever turned on for a title: read the `staging up` and `reorder` rows of the resources grid in a `PERF=1` run.
