### PR TITLE
Re-issue VB/IB and texture uploads an aborted submit discarded

### DIFF
--- a/scripts/derive_inventory.txt
+++ b/scripts/derive_inventory.txt
@@ -140,6 +140,7 @@ windows/core/src/stretch_rect.rs StretchRegion Clone,Copy,Debug,PartialEq,Eq
 windows/core/src/texture_staging.rs LockAction Debug,Clone,Copy,PartialEq,Eq
 windows/core/src/texture_staging.rs MipShape Debug,Clone,Copy,PartialEq,Eq
 windows/core/src/texture_staging.rs PreserveKind Debug,Clone,Copy,PartialEq,Eq
+windows/core/src/upload_recovery.rs UploadFate Clone,Copy,Debug,PartialEq,Eq
 windows/core/src/visibility.rs QueryStatus Clone,Copy,Debug,PartialEq,Eq
 windows/d3d9/src/cursor.rs CursorFlags Clone,Copy,Debug,Default,PartialEq,Eq
 windows/d3d9/src/device.rs DepthBinding Clone

--- a/unix/shared/src/params.rs
+++ b/unix/shared/src/params.rs
@@ -47,7 +47,7 @@ const _: () = {
     assert!(core::mem::size_of::<AttachMetalLayerParams>() == 64);
     assert!(core::mem::size_of::<CreateBackbufferParams>() == 32);
     assert!(core::mem::size_of::<DestroyCommandQueueParams>() == 48);
-    assert!(core::mem::size_of::<SubmitFrameParams>() == 96);
+    assert!(core::mem::size_of::<SubmitFrameParams>() == 104);
     assert!(core::mem::size_of::<PassDescriptor>() == 168);
 };
 
@@ -209,6 +209,13 @@ impl Thunk for SetDisplaySyncEnabledParams {
 pub struct WaitForGpuRetireParams {
     pub target_seq: u64,       // in
     pub coherent_seq_ptr: u64, // in: PE-side AtomicU64 backing
+    /// Where an aborted command buffer is recorded, mirroring `SubmitFrameParams`.
+    ///
+    /// The wait bumps `coherent_seq` itself so the caller observes the
+    /// advance synchronously, which would otherwise launder a command
+    /// buffer the GPU killed into "retired cleanly". 0 disables the
+    /// check.
+    pub failed_submit_seq_ptr: u64, // in: PE-side AtomicU64 backing
 }
 
 impl Thunk for WaitForGpuRetireParams {
@@ -674,6 +681,19 @@ pub struct SubmitFrameParams {
     /// `coherent_seq_ptr`, which tracks full-frame (draw) retirement for
     /// VB/IB.
     pub upload_coherent_seq_ptr: u64, // in: *const AtomicU64 (PE heap, stable)
+    /// Highest submit seq whose command buffer the GPU aborted.
+    ///
+    /// Both completion handlers `fetch_max` `submit_seq` into
+    /// `*(failed_submit_seq_ptr as *const AtomicU64)` when the command
+    /// buffer reaches `MTLCommandBufferStatus::Error`. Deliberately a
+    /// second counter rather than a gate on `coherent_seq`: an aborted
+    /// command buffer *is* finished with its source memory, so withholding
+    /// the retirement bump would pin every seq-gated queue behind a seq
+    /// that never retires and deadlock `wait_for_gpu_retire`. Retirement
+    /// for lifetime and retirement for success are separate facts, and the
+    /// PE side needs both to tell an upload it can free from one it must
+    /// re-issue. 0 before the frame is stamped.
+    pub failed_submit_seq_ptr: u64, // in: *const AtomicU64 (PE heap, stable)
     /// Nanoseconds spent in `nextDrawable()`, 0 outside a `PERF=1` build.
     ///
     /// Nanoseconds, not cycles, because this is the one duration that crosses

--- a/unix/shared/src/params/tests.rs
+++ b/unix/shared/src/params/tests.rs
@@ -60,9 +60,9 @@ fn blit_texture_to_buffer_layout() {
 #[test]
 fn wait_for_gpu_retire_layout() {
     use super::WaitForGpuRetireParams;
-    // 2 * u64 = 16
+    // 3 * u64 = 24
     assert_eq!(core::mem::align_of::<WaitForGpuRetireParams>(), 8);
-    assert_eq!(core::mem::size_of::<WaitForGpuRetireParams>(), 16);
+    assert_eq!(core::mem::size_of::<WaitForGpuRetireParams>(), 24);
 }
 
 #[test]
@@ -83,9 +83,10 @@ fn frame_param_layouts_match_wow64() {
     //   + 8 passes_ptr + 4 pass_count + 4 _pad1
     //   + 8 present_layer + 8 present_texture
     //   + 8 submit_seq + 8 coherent_seq_ptr + 8 upload_coherent_seq_ptr
+    //   + 8 failed_submit_seq_ptr
     //   + 8 drawable_wait_ns + 8 present_view
-    //   = 96
-    assert_eq!(core::mem::size_of::<SubmitFrameParams>(), 96);
+    //   = 104
+    assert_eq!(core::mem::size_of::<SubmitFrameParams>(), 104);
 
     // CreateTexturesBatchParams:
     //   8 device_handle + 4 count + 4 _pad0 + 8 descs_ptr + 8 handles_out_ptr = 32

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -210,7 +210,11 @@ pub extern "C" fn wait_for_gpu_retire_handler(args: *mut c_void) -> i32 {
     let Some(params) = (unsafe { InPtr::<WaitForGpuRetireParams>::opt(args.cast()) }) else {
         return -1;
     };
-    metal::wait_for_gpu_retire(params.target_seq, params.coherent_seq_ptr);
+    metal::wait_for_gpu_retire(
+        params.target_seq,
+        params.coherent_seq_ptr,
+        params.failed_submit_seq_ptr,
+    );
     STATUS_SUCCESS
 }
 

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -177,7 +177,13 @@ fn register_presented_probe(
 /// atomic ourselves: the completion handler may not have fired yet (it
 /// runs on Metal's own dispatch queue), and our caller needs to observe
 /// `coherent_seq >= target_seq` on return.
-pub fn wait_for_gpu_retire(target_seq: u64, coherent_seq_ptr: u64) {
+///
+/// Bumping `coherent_seq` by hand is also why this has to inspect the
+/// status: a command buffer the GPU killed is finished, so the bump is
+/// right, but recording it as retired and nothing else would hide the
+/// abort from the PE-side upload recovery that the completion handlers
+/// feed. `failed_submit_seq_ptr` gets the same `fetch_max` they do.
+pub fn wait_for_gpu_retire(target_seq: u64, coherent_seq_ptr: u64, failed_submit_seq_ptr: u64) {
     if coherent_seq_ptr == 0 || target_seq == 0 {
         return;
     }
@@ -204,7 +210,53 @@ pub fn wait_for_gpu_retire(target_seq: u64, coherent_seq_ptr: u64) {
     mtld3d_shared::crumb!("gpuretirebeg", target_seq, atomic.load(Ordering::Acquire));
     cmdbuf.waitUntilCompleted();
     mtld3d_shared::crumb!("gpuretireend", target_seq);
+    // Record the abort before the retirement bump: both stores are
+    // `Release`, so a PE-side `Acquire` load of `coherent_seq` that sees
+    // this seq is guaranteed to see the failure too.
+    if let Some((code, desc)) = record_failed_submit(&cmdbuf, target_seq, failed_submit_seq_ptr) {
+        mtld3d_shared::crumb!("gpuretirecberr", target_seq);
+        mtld3d_shared::log_once_warn_by!(
+            target: LOG_TARGET,
+            key: code,
+            "wait_for_gpu_retire: command buffer for frame seq={target_seq} failed on the \
+             GPU (code {code}: {desc}); everything it carried was discarded",
+        );
+    }
     atomic.fetch_max(target_seq, Ordering::Release);
+}
+
+/// `fetch_max` an aborted command buffer's seq into the PE-side failed-submit counter.
+///
+/// Returns the Metal error's `(code, localizedDescription)` when the
+/// command buffer failed, so the caller can name it in its own tripwire,
+/// and `None` when it completed normally. A `failed_submit_seq_ptr` of 0
+/// (a frame stamped before the atomic was wired) records nothing and
+/// still reports the error.
+fn record_failed_submit(
+    cb: &ProtocolObject<dyn MTLCommandBuffer>,
+    seq: u64,
+    failed_submit_seq_ptr: u64,
+) -> Option<(u64, String)> {
+    if cb.status() != MTLCommandBufferStatus::Error {
+        return None;
+    }
+    if failed_submit_seq_ptr != 0 {
+        // SAFETY: the PE side allocated an `Arc<AtomicU64>` and passed its
+        // pointer. The Arc is kept alive for the device's lifetime, and all
+        // command buffers that reference it are drained on device teardown
+        // before the Arc drops.
+        let atomic = unsafe { &*(failed_submit_seq_ptr as *const AtomicU64) };
+        atomic.fetch_max(seq, Ordering::Release);
+    }
+    Some(cb.error().map_or_else(
+        || (0, String::new()),
+        |e| {
+            (
+                e.code().unsigned_abs() as u64,
+                e.localizedDescription().to_string(),
+            )
+        },
+    ))
 }
 
 // SubmitFrame breadcrumb probes via `mtld3d_shared::crumb!()`. Each
@@ -288,6 +340,7 @@ pub fn submit_frame(params: &mut SubmitFrameParams) -> bool {
                 params.blit_commands_need_encoder != 0,
                 params.submit_seq,
                 params.upload_coherent_seq_ptr,
+                params.failed_submit_seq_ptr,
             ) {
                 return false;
             }
@@ -524,6 +577,7 @@ pub fn submit_frame(params: &mut SubmitFrameParams) -> bool {
         let atomic_ptr = usize::try_from(params.coherent_seq_ptr)
             .expect("PE wire pointer fits host address space (unix is 64-bit)");
         let seq = params.submit_seq;
+        let failed_seq_ptr = params.failed_submit_seq_ptr;
         let handler = RcBlock::new(
             move |cb_ptr: core::ptr::NonNull<ProtocolObject<dyn MTLCommandBuffer>>| {
                 // Tripwire: a command buffer the GPU rejected discards every
@@ -538,17 +592,12 @@ pub fn submit_frame(params: &mut SubmitFrameParams) -> bool {
                 // SAFETY: Metal invokes the block with the completed command
                 // buffer; the pointer is valid for the handler's duration.
                 let cb = unsafe { cb_ptr.as_ref() };
-                if cb.status() == MTLCommandBufferStatus::Error {
+                // The failure is recorded before the retirement bump below:
+                // both stores are `Release`, so a PE-side `Acquire` load of
+                // `coherent_seq` that observes this seq observes the failure
+                // too, and the upload recovery never reads a stale "clean".
+                if let Some((code, desc)) = record_failed_submit(cb, seq, failed_seq_ptr) {
                     mtld3d_shared::crumb!("submit:cberr", seq);
-                    let (code, desc) = cb.error().map_or_else(
-                        || (0, String::new()),
-                        |e| {
-                            (
-                                e.code().unsigned_abs() as u64,
-                                e.localizedDescription().to_string(),
-                            )
-                        },
-                    );
                     mtld3d_shared::log_once_warn_by!(
                         target: LOG_TARGET,
                         key: code,
@@ -607,6 +656,7 @@ fn submit_upload_cmd_buf(
     need_encoder: bool,
     submit_seq: u64,
     upload_coherent_seq_ptr: u64,
+    failed_submit_seq_ptr: u64,
 ) -> bool {
     mtld3d_shared::crumb!("submit:upcmdbuf");
     let Some(upload_cb) = queue.commandBuffer() else {
@@ -624,8 +674,31 @@ fn submit_upload_cmd_buf(
         let atomic_ptr = usize::try_from(upload_coherent_seq_ptr)
             .expect("PE wire pointer fits host address space (unix is 64-bit)");
         let seq = submit_seq;
+        let failed_seq_ptr = failed_submit_seq_ptr;
         let handler = RcBlock::new(
-            move |_cb: core::ptr::NonNull<ProtocolObject<dyn MTLCommandBuffer>>| {
+            move |cb_ptr: core::ptr::NonNull<ProtocolObject<dyn MTLCommandBuffer>>| {
+                // Tripwire: this command buffer carries every frame-leading
+                // blit, so an abort here loses texture uploads and `Staged`
+                // VB/IB dirty-range copies rather than rendering. Nothing
+                // in the API stream ever re-announces them, so the loss is
+                // permanent unless the PE side replays it: record the seq
+                // before the retirement bump (both `Release`, so a reader
+                // that sees the retirement sees the failure) and let the
+                // encoder's upload-recovery queues re-issue.
+                //
+                // SAFETY: Metal invokes the block with the completed command
+                // buffer; the pointer is valid for the handler's duration.
+                let cb = unsafe { cb_ptr.as_ref() };
+                if let Some((code, desc)) = record_failed_submit(cb, seq, failed_seq_ptr) {
+                    mtld3d_shared::crumb!("submit:upcberr", seq);
+                    mtld3d_shared::log_once_warn_by!(
+                        target: LOG_TARGET,
+                        key: code,
+                        "submit_frame: upload command buffer for frame seq={seq} failed on \
+                         the GPU (code {code}: {desc}); every texture and VB/IB upload it \
+                         carried was discarded and will be re-issued",
+                    );
+                }
                 // SAFETY: the PE side allocated an `Arc<AtomicU64>` and
                 // passed its pointer. The Arc is kept alive for the
                 // device's lifetime, and all command buffers that

--- a/windows/core/src/lib.rs
+++ b/windows/core/src/lib.rs
@@ -42,5 +42,6 @@ pub mod storage_policy;
 pub mod streams;
 pub mod stretch_rect;
 pub mod texture_staging;
+pub mod upload_recovery;
 pub mod visibility;
 pub mod vs_draw;

--- a/windows/core/src/upload_recovery.rs
+++ b/windows/core/src/upload_recovery.rs
@@ -1,0 +1,273 @@
+//! Seq-gated replay of uploads whose command buffer the GPU aborted.
+//!
+//! Every upload (a `Staged` VB/IB dirty-range copy, a texture mip blit) is
+//! encoded into a command buffer, and its source memory is freed once that
+//! buffer retires. Retirement is not success: a command buffer the driver
+//! killed reaches `MTLCommandBufferStatus::Error`, discards every encode it
+//! carried, and still runs its completion handler. Freeing on retirement
+//! alone therefore loses the upload for the rest of the run, because the
+//! layer never re-announces a region on its own and a title that fills
+//! static geometry once at load time never announces it again.
+//!
+//! This queue separates the two facts. An entry is released only when the
+//! GPU both retired its seq (`coherent_seq`) and did not fail at or after
+//! it (`failed_seq`); otherwise the caller re-issues the copy and hands the
+//! entry back through [`UploadRecoveryQueue::requeue`] under the new
+//! frame's seq. Pure bookkeeping: no Metal handles, no blit shapes, so the
+//! whole ordering contract is host-testable.
+
+use std::collections::VecDeque;
+
+use rustc_hash::FxHashSet;
+
+/// Aborted submits one upload is replayed across before it is abandoned.
+///
+/// Each replay keeps the upload's source memory alive for another frame,
+/// which counts against `memory.vbibRetentionCapMB`; retrying without a
+/// bound would pin that cap under a GPU that keeps failing and force a
+/// synchronous mid-frame GPU wait on every allocation. Three covers the
+/// case this queue exists for, a single transient abort, and turns a
+/// permanent GPU failure back into bounded memory.
+pub const MAX_REISSUE_ATTEMPTS: u8 = 3;
+
+/// What [`UploadRecoveryQueue::settle`] decided about one drained upload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UploadFate {
+    /// Its submit retired and did not fail: free the payload.
+    Released,
+    /// Its submit was aborted: re-issue the copy, then [`UploadRecoveryQueue::requeue`] it.
+    Reissue,
+    /// Aborted more than [`MAX_REISSUE_ATTEMPTS`] times: free the payload and warn.
+    Abandoned,
+}
+
+/// One upload the GPU has not acknowledged yet.
+///
+/// `key` names the destination the upload writes (a `BufferId` for a
+/// `Staged` VB/IB, a `TextureId` for a mip blit). It only has to be
+/// consistent within one queue: its job is to group the entries whose
+/// replay order relative to each other matters. `payload` is whatever the
+/// caller needs to re-issue the copy.
+pub struct PendingUpload<T> {
+    key: u64,
+    seq: u64,
+    attempts: u8,
+    payload: T,
+}
+
+impl<T> PendingUpload<T> {
+    /// The destination this upload writes.
+    #[must_use]
+    pub const fn key(&self) -> u64 {
+        self.key
+    }
+
+    /// Replays this entry has already been through.
+    #[must_use]
+    pub const fn attempts(&self) -> u8 {
+        self.attempts
+    }
+
+    /// Borrow what the caller needs to re-issue the copy.
+    #[must_use]
+    pub const fn payload(&self) -> &T {
+        &self.payload
+    }
+
+    /// Take the payload, consuming the entry.
+    #[must_use]
+    pub fn into_payload(self) -> T {
+        self.payload
+    }
+}
+
+/// Uploads awaiting a GPU acknowledgement, ordered by submit seq.
+///
+/// Entries go in at the seq of the frame whose command buffer carries
+/// their copy and come out of the front once that seq has retired.
+/// [`Self::requeue`] pushes a replayed entry to the back under the new
+/// frame's strictly larger seq, so the queue stays non-decreasing in seq
+/// and the front-gated drain stays correct.
+///
+/// Replay order: a replayed copy writes bytes that a later, successful
+/// copy to the same key may have superseded, so re-issuing one entry in
+/// isolation can leave a stale range sitting on top of a fresh one.
+/// [`Self::settle`] therefore pulls in every queued entry sharing a key
+/// with an aborted one, including entries whose own submit has not
+/// retired yet, and hands them back in seq order. Replaying a copy whose
+/// original is still in flight writes the same bytes twice, which costs a
+/// blit and changes nothing.
+pub struct UploadRecoveryQueue<T> {
+    pending: VecDeque<PendingUpload<T>>,
+}
+
+impl<T> UploadRecoveryQueue<T> {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            pending: VecDeque::new(),
+        }
+    }
+
+    /// Uploads currently awaiting acknowledgement.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.pending.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    /// Record an upload just encoded into the frame submitting as `seq`.
+    ///
+    /// `seq` must not go backwards across calls: the steady-state drain
+    /// gates on the front entry alone, so an out-of-order push would
+    /// strand later entries behind it. Every producer stamps the encoder's
+    /// current submit seq, which only advances.
+    pub fn push(&mut self, key: u64, seq: u64, payload: T) {
+        debug_assert!(
+            self.pending.back().is_none_or(|back| back.seq <= seq),
+            "upload recovery queue must stay non-decreasing in seq",
+        );
+        self.pending.push_back(PendingUpload {
+            key,
+            seq,
+            attempts: 0,
+            payload,
+        });
+    }
+
+    /// Re-queue an entry the caller has just re-issued, under `reissue_seq`.
+    ///
+    /// Lands at the back, which is what keeps the queue monotonic:
+    /// `reissue_seq` is the frame being built, so it exceeds every seq
+    /// already queued. The attempt count advances here and nowhere else,
+    /// so [`MAX_REISSUE_ATTEMPTS`] bounds the replay chain even when the
+    /// same entry keeps riding failing submits.
+    pub fn requeue(&mut self, entry: PendingUpload<T>, reissue_seq: u64) {
+        debug_assert!(
+            self.pending
+                .back()
+                .is_none_or(|back| back.seq <= reissue_seq),
+            "re-issued upload must land after every queued entry",
+        );
+        self.pending.push_back(PendingUpload {
+            key: entry.key,
+            seq: reissue_seq,
+            attempts: entry.attempts.saturating_add(1),
+            payload: entry.payload,
+        });
+    }
+
+    /// Drain every upload the GPU has finished with, classifying each.
+    ///
+    /// `coherent_seq` is the highest submit seq the GPU retired and
+    /// `failed_seq` the highest it aborted. The caller decides what counts
+    /// as retired: the encoder passes the lower of its two retirement
+    /// counters, because only the upload command buffer's own handler ever
+    /// records that buffer's abort. Entries come back front-first,
+    /// so a caller that re-issues in iteration order reproduces the
+    /// original write order. Entries whose seq has not retired stay
+    /// queued unless an aborted entry shares their key, in which case
+    /// they are replayed too so the key's final bytes are the newest ones.
+    pub fn settle(
+        &mut self,
+        coherent_seq: u64,
+        failed_seq: u64,
+    ) -> Vec<(UploadFate, PendingUpload<T>)> {
+        let poisoned = self.poisoned_keys(failed_seq);
+        if poisoned.is_empty() {
+            // Steady state: nothing failed, so the front-gated walk touches
+            // only the entries it releases.
+            let retired = self.front_run(|entry| entry.seq <= coherent_seq);
+            return self
+                .pending
+                .drain(..retired)
+                .map(|entry| (UploadFate::Released, entry))
+                .collect();
+        }
+        let mut out = Vec::new();
+        // Recovery: a poisoned key drags its whole tail out of the queue,
+        // so the walk cannot stop at the first unretired entry.
+        let mut kept: VecDeque<PendingUpload<T>> = VecDeque::new();
+        for entry in self.pending.drain(..) {
+            let owed = poisoned.contains(&entry.key);
+            if !owed && entry.seq > coherent_seq {
+                kept.push_back(entry);
+                continue;
+            }
+            let fate = if !owed {
+                UploadFate::Released
+            } else if entry.attempts >= MAX_REISSUE_ATTEMPTS {
+                UploadFate::Abandoned
+            } else {
+                UploadFate::Reissue
+            };
+            out.push((fate, entry));
+        }
+        self.pending = kept;
+        out
+    }
+
+    /// Pop only the front entries the GPU acknowledged, leaving replays queued.
+    ///
+    /// For the callers that free memory without building a frame (the
+    /// retention-cap relief drains): they have nowhere to put a replayed
+    /// copy, so they must not take an entry that owes one. The walk stops at
+    /// the first entry whose submit aborted, which also preserves the replay
+    /// ordering [`Self::settle`] relies on: nothing behind an aborted entry
+    /// is freed before that entry is replayed.
+    pub fn release_acknowledged(
+        &mut self,
+        coherent_seq: u64,
+        failed_seq: u64,
+    ) -> Vec<PendingUpload<T>> {
+        let clean = self.front_run(|entry| entry.seq <= coherent_seq && entry.seq > failed_seq);
+        self.pending.drain(..clean).collect()
+    }
+
+    /// Length of the queue's leading run of entries satisfying `keep`.
+    ///
+    /// The front-gated drains take a prefix, and counting it first lets
+    /// them use `drain`, which needs no fallible pop inside the loop.
+    fn front_run(&self, keep: impl Fn(&PendingUpload<T>) -> bool) -> usize {
+        self.pending.iter().take_while(|entry| keep(entry)).count()
+    }
+
+    /// Keys with at least one aborted entry, whose whole tail must replay.
+    ///
+    /// Empty on every frame the GPU did not fail, which is what keeps
+    /// [`Self::settle`] on its cheap path.
+    fn poisoned_keys(&self, failed_seq: u64) -> FxHashSet<u64> {
+        let mut keys = FxHashSet::default();
+        if failed_seq == 0 {
+            return keys;
+        }
+        for entry in &self.pending {
+            if entry.seq <= failed_seq {
+                keys.insert(entry.key);
+            }
+        }
+        keys
+    }
+
+    /// Take every queued entry, leaving the queue empty.
+    ///
+    /// Reset and shutdown call this after the GPU has gone idle: the
+    /// payloads own Metal wrappers and PE-heap backings the caller must
+    /// tear down in its own destroy-then-drop order.
+    pub fn drain_all(&mut self) -> Vec<PendingUpload<T>> {
+        self.pending.drain(..).collect()
+    }
+}
+
+impl<T> Default for UploadRecoveryQueue<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/windows/core/src/upload_recovery/tests.rs
+++ b/windows/core/src/upload_recovery/tests.rs
@@ -1,0 +1,238 @@
+//! Unit tests for the abort-recovery queue behind `Staged` VB/IB and texture uploads.
+//!
+//! The propositions pinned here are the ones the encoder's correctness rests on: an entry
+//! survives until its seq is acknowledged rather than merely retired, an abort re-arms the
+//! entries at or below the failed seq plus the rest of their key's tail, a re-armed entry
+//! lands behind everything already queued so the queue stays monotonic in seq, the replay
+//! chain is bounded, and an entry re-armed under a later seq is released normally when that
+//! seq retires cleanly.
+
+use super::{MAX_REISSUE_ATTEMPTS, UploadFate, UploadRecoveryQueue};
+
+/// Payload stand-in: the queue never looks inside one, so a label is enough.
+fn queue() -> UploadRecoveryQueue<&'static str> {
+    UploadRecoveryQueue::new()
+}
+
+#[test]
+fn nothing_settles_before_its_seq_retires() {
+    let mut q = queue();
+    q.push(1, 5, "a");
+    // coherent_seq = 4: the frame carrying "a" has not retired.
+    assert!(q.settle(4, 0).is_empty());
+    assert_eq!(q.len(), 1);
+}
+
+#[test]
+fn a_retired_and_unfailed_entry_is_released() {
+    let mut q = queue();
+    q.push(1, 5, "a");
+    let settled = q.settle(5, 0);
+    assert_eq!(settled.len(), 1);
+    assert_eq!(settled[0].0, UploadFate::Released);
+    assert_eq!(*settled[0].1.payload(), "a");
+    assert!(q.is_empty());
+}
+
+#[test]
+fn retirement_alone_does_not_acknowledge_an_aborted_submit() {
+    let mut q = queue();
+    q.push(1, 5, "a");
+    // The GPU retired seq 5 and failed at seq 5: retired, not acknowledged.
+    let settled = q.settle(5, 5);
+    assert_eq!(settled.len(), 1);
+    assert_eq!(settled[0].0, UploadFate::Reissue);
+}
+
+#[test]
+fn an_abort_rearms_the_entries_at_or_below_the_failed_seq() {
+    let mut q = queue();
+    q.push(1, 5, "a");
+    q.push(2, 6, "b");
+    q.push(3, 7, "c");
+    // failed_seq = 6: "a" and "b" rode aborted submits, "c" did not. All
+    // three retired, so all three settle.
+    let settled = q.settle(7, 6);
+    let fates: Vec<_> = settled
+        .iter()
+        .map(|(fate, entry)| (*entry.payload(), *fate))
+        .collect();
+    assert_eq!(
+        fates,
+        vec![
+            ("a", UploadFate::Reissue),
+            ("b", UploadFate::Reissue),
+            ("c", UploadFate::Released),
+        ]
+    );
+}
+
+#[test]
+fn an_aborted_key_drags_its_whole_tail_into_the_replay() {
+    let mut q = queue();
+    // Two uploads to one destination, then one to another. Only the first
+    // rode the aborted submit, but replaying it alone would put its bytes
+    // on top of the newer ones at seq 7.
+    q.push(1, 5, "old");
+    q.push(1, 7, "new");
+    q.push(2, 7, "other");
+    let settled = q.settle(7, 5);
+    let fates: Vec<_> = settled
+        .iter()
+        .map(|(fate, entry)| (*entry.payload(), *fate))
+        .collect();
+    assert_eq!(
+        fates,
+        vec![
+            ("old", UploadFate::Reissue),
+            ("new", UploadFate::Reissue),
+            ("other", UploadFate::Released),
+        ]
+    );
+}
+
+#[test]
+fn a_poisoned_key_replays_even_before_its_own_seq_retires() {
+    let mut q = queue();
+    q.push(1, 5, "old");
+    q.push(1, 9, "in_flight");
+    // coherent_seq = 5: only "old" retired, but "in_flight" writes the same
+    // destination and must land after the replay, so it comes out too.
+    let settled = q.settle(5, 5);
+    let payloads: Vec<_> = settled.iter().map(|(_, e)| *e.payload()).collect();
+    assert_eq!(payloads, vec!["old", "in_flight"]);
+    assert!(settled.iter().all(|(fate, _)| *fate == UploadFate::Reissue));
+    assert!(q.is_empty());
+}
+
+#[test]
+fn an_unrelated_key_stays_queued_across_a_recovery() {
+    let mut q = queue();
+    q.push(1, 5, "failed");
+    q.push(2, 9, "untouched");
+    let settled = q.settle(5, 5);
+    assert_eq!(settled.len(), 1);
+    assert_eq!(*settled[0].1.payload(), "failed");
+    assert_eq!(q.len(), 1);
+}
+
+#[test]
+fn a_rearmed_entry_lands_behind_everything_already_queued() {
+    let mut q = queue();
+    q.push(1, 5, "replayed");
+    q.push(2, 9, "later");
+    let mut settled = q.settle(5, 5);
+    let entry = settled.pop().expect("one entry settled").1;
+    q.requeue(entry, 12);
+    // Queue order is the drain order, and it stays non-decreasing in seq:
+    // the entry queued at seq 9 is still in front of the replay at 12.
+    let order: Vec<_> = q.settle(12, 0).iter().map(|(_, e)| *e.payload()).collect();
+    assert_eq!(order, vec!["later", "replayed"]);
+}
+
+#[test]
+fn requeue_holds_exactly_one_entry_so_bytes_are_counted_once() {
+    let mut q = queue();
+    q.push(1, 5, "a");
+    let mut settled = q.settle(5, 5);
+    assert!(q.is_empty());
+    let entry = settled.pop().expect("one entry settled").1;
+    q.requeue(entry, 8);
+    assert_eq!(q.len(), 1);
+}
+
+#[test]
+fn an_entry_rearmed_under_a_later_seq_is_released_when_that_seq_is_clean() {
+    let mut q = queue();
+    q.push(1, 5, "a");
+    let mut settled = q.settle(5, 5);
+    let entry = settled.pop().expect("one entry settled").1;
+    q.requeue(entry, 8);
+    // The replay rode seq 8, which retired without failing. failed_seq is
+    // still 5, below the entry's new seq, so the abort no longer applies.
+    let settled = q.settle(8, 5);
+    assert_eq!(settled.len(), 1);
+    assert_eq!(settled[0].0, UploadFate::Released);
+    assert_eq!(settled[0].1.attempts(), 1);
+}
+
+#[test]
+fn the_replay_chain_is_bounded() {
+    let mut q = queue();
+    q.push(1, 1, "a");
+    let mut seq = 1;
+    for expected_attempts in 0..MAX_REISSUE_ATTEMPTS {
+        let mut settled = q.settle(seq, seq);
+        assert_eq!(settled.len(), 1);
+        assert_eq!(settled[0].0, UploadFate::Reissue);
+        let entry = settled.pop().expect("one entry settled").1;
+        assert_eq!(entry.attempts(), expected_attempts);
+        seq += 1;
+        q.requeue(entry, seq);
+    }
+    // Attempt MAX + 1: the entry is abandoned rather than held forever.
+    let settled = q.settle(seq, seq);
+    assert_eq!(settled.len(), 1);
+    assert_eq!(settled[0].0, UploadFate::Abandoned);
+    assert_eq!(settled[0].1.attempts(), MAX_REISSUE_ATTEMPTS);
+    assert!(q.is_empty());
+}
+
+#[test]
+fn a_zero_failed_seq_never_rearms() {
+    let mut q = queue();
+    // Seq 0 is the pre-first-frame sentinel; an entry can never be stamped
+    // with it, but the atomic reads 0 until the first abort.
+    q.push(1, 1, "a");
+    let settled = q.settle(1, 0);
+    assert_eq!(settled[0].0, UploadFate::Released);
+}
+
+#[test]
+fn drain_all_empties_the_queue() {
+    let mut q = queue();
+    q.push(1, 5, "a");
+    q.push(2, 6, "b");
+    let drained = q.drain_all();
+    let payloads: Vec<_> = drained.iter().map(|e| *e.payload()).collect();
+    assert_eq!(payloads, vec!["a", "b"]);
+    assert!(q.is_empty());
+    assert!(q.drain_all().is_empty());
+}
+
+#[test]
+fn release_acknowledged_stops_at_the_first_entry_owing_a_replay() {
+    let mut q = queue();
+    q.push(1, 5, "aborted");
+    q.push(2, 6, "behind");
+    // Both seqs retired, but the front owes a replay, so nothing is freed:
+    // releasing "behind" first would let its bytes settle underneath a
+    // replay that has not happened yet.
+    assert!(q.release_acknowledged(6, 5).is_empty());
+    assert_eq!(q.len(), 2);
+}
+
+#[test]
+fn release_acknowledged_frees_the_prefix_above_the_failed_seq() {
+    let mut q = queue();
+    // The abort at seq 5 was settled in an earlier pass; what is left was
+    // queued after it.
+    q.push(1, 6, "a");
+    q.push(2, 7, "b");
+    let released = q.release_acknowledged(7, 5);
+    let payloads: Vec<_> = released.iter().map(|e| *e.payload()).collect();
+    assert_eq!(payloads, vec!["a", "b"]);
+    assert!(q.is_empty());
+}
+
+#[test]
+fn release_acknowledged_frees_everything_retired_when_nothing_failed() {
+    let mut q = queue();
+    q.push(1, 5, "a");
+    q.push(2, 6, "b");
+    q.push(3, 9, "c");
+    let released = q.release_acknowledged(6, 0);
+    let payloads: Vec<_> = released.iter().map(|e| *e.payload()).collect();
+    assert_eq!(payloads, vec!["a", "b"]);
+    assert_eq!(q.len(), 1);
+}

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -82,7 +82,7 @@ use super::{
     },
     encoder::{
         BlitSide, EncoderThread, FrameData, FrameEncoder, FrameInit, Op, StagingWarmupEntry,
-        TextureInfo, TextureUploadJob, VbibWarmupEntry,
+        SubmitFence, TextureInfo, TextureUploadJob, VbibWarmupEntry,
     },
     index_buffer::{Direct3DIndexBuffer9, IndexBufferCreateInfo},
     null_out,
@@ -413,6 +413,18 @@ pub struct DeviceInner {
     /// Texture-staging contention reads this; VB/IB stays on `coherent_seq`
     /// (their backings are consumed by draws, which live in the draw CB).
     upload_coherent_seq: Arc<AtomicU64>,
+    /// Highest submit seq whose command buffer the GPU aborted.
+    ///
+    /// `fetch_max`'d by both completion handlers (and by
+    /// `wait_for_gpu_retire`) when a command buffer reaches
+    /// `MTLCommandBufferStatus::Error`. Kept separate from `coherent_seq`
+    /// because an aborted command buffer is genuinely finished with its
+    /// source memory: withholding the retirement bump instead would pin
+    /// every seq-gated queue behind a seq that never retires, and
+    /// `wait_for_gpu_idle` would block forever. The encoder reads the pair
+    /// to tell an upload it can free from one whose blit was discarded and
+    /// has to be re-issued.
+    failed_submit_seq: Arc<AtomicU64>,
     /// Live VB/IB retained-`PageBox` byte total, shared with the encoder.
     ///
     /// Mirrors `coherent_seq`'s sharing. The encoder `fetch_add`s on intake
@@ -1330,11 +1342,12 @@ impl DeviceInner {
 
         let this_seq = self.current_seq;
         self.current_seq = self.current_seq.saturating_add(1);
-        frame.set_submit_fence(
-            this_seq,
-            Arc::as_ptr(&self.coherent_seq) as u64,
-            Arc::as_ptr(&self.upload_coherent_seq) as u64,
-        );
+        frame.set_submit_fence(&SubmitFence {
+            submit_seq: this_seq,
+            coherent_seq_ptr: Arc::as_ptr(&self.coherent_seq) as u64,
+            upload_coherent_seq_ptr: Arc::as_ptr(&self.upload_coherent_seq) as u64,
+            failed_submit_seq_ptr: Arc::as_ptr(&self.failed_submit_seq) as u64,
+        });
         frame.set_retained_bytes_ptr(Arc::as_ptr(&self.vbib_retained_bytes) as u64);
         // Every cached snapshot pointer in the encoder's CurrentSnapshot
         // aliases into the outgoing frame's `ScratchArena`, which is
@@ -2299,6 +2312,7 @@ impl Direct3DDevice9 {
 
         let coherent_seq = Arc::new(AtomicU64::new(0));
         let upload_coherent_seq = Arc::new(AtomicU64::new(0));
+        let failed_submit_seq = Arc::new(AtomicU64::new(0));
         let vbib_retained_bytes = Arc::new(AtomicU64::new(0));
 
         let inner = Box::into_raw(Box::new(DeviceInner {
@@ -2331,6 +2345,7 @@ impl Direct3DDevice9 {
             current_frame: info.current_frame,
             coherent_seq,
             upload_coherent_seq,
+            failed_submit_seq,
             vbib_retained_bytes,
             vram_bytes_used: Arc::new(AtomicU64::new(0)),
             outstanding_reset_blockers: AtomicU32::new(0),

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -41,6 +41,7 @@ use mtld3d_core::{
     shader_cache::{self, CachedKind},
     shader_compile_stats::{self, BurstTracker, CompileBucket},
     storage_policy::buffer_storage_mode,
+    upload_recovery::{UploadFate, UploadRecoveryQueue},
     visibility::{
         MAX_SLOTS, RetiredVisibilityBuffer, SLOT_BYTES, VisibilityQueryCore, VisibilityQueryState,
     },
@@ -736,6 +737,38 @@ pub struct FrameEncoder {
     /// means "not yet seeded" — the very first frame has no retention to
     /// drain.
     coherent_seq_ptr: u64,
+    /// Pointer to the shared `failed_submit_seq` atomic, copied from `FrameData` in `begin_frame`.
+    ///
+    /// Read next to `coherent_seq_ptr` when the upload-recovery queues
+    /// settle: a seq that retired at or below this one had its command
+    /// buffer discarded, so its upload has to be re-issued rather than
+    /// freed. 0 means "not yet seeded".
+    failed_seq_ptr: u64,
+    /// Pointer to the shared `upload_coherent_seq` atomic, copied from `FrameData`.
+    ///
+    /// The upload command buffer is the one that actually carries an
+    /// upload's copy, and its own completion handler is the only thing that
+    /// ever moves this counter. `coherent_seq` can be hand-advanced by
+    /// `wait_for_gpu_retire` before that handler has run, so an upload is
+    /// only settled once both counters have reached its seq. 0 means "not
+    /// yet seeded", or the defensive path where the leading blits rode the
+    /// draw command buffer instead.
+    upload_coherent_seq_ptr: u64,
+    /// `Staged` VB/IB dirty-range uploads the GPU has not acknowledged yet.
+    ///
+    /// Each entry owns the transient `bytesNoCopy` wrapper and the
+    /// PE-heap snapshot the blit reads, so settling one either frees both
+    /// or re-emits the copy from them. Replaces what used to be a plain
+    /// `PendingResourceRetention` entry: destroying at a seq and replaying
+    /// at a seq are different policies, and one front-gated loop cannot
+    /// hold both.
+    pending_stage_uploads: UploadRecoveryQueue<StagedUploadRetry>,
+    /// Texture mip uploads the GPU has not acknowledged yet.
+    ///
+    /// Holds the whole `TextureUploadJob`, whose `staging_arc` is a clone
+    /// of the texture's own persistent staging, so a replay costs one blit
+    /// and no extra memory.
+    pending_texture_uploads: UploadRecoveryQueue<TextureUploadJob>,
     /// Pointer to the shared `vbib_retained_bytes` atomic (device-owned).
     ///
     /// Copied from `FrameData` in `begin_frame`. `fetch_add`'d when a
@@ -1153,6 +1186,23 @@ struct PendingResourceRetention {
     from_texture: bool,
 }
 
+/// Everything a replay of one `Staged` VB/IB upload needs.
+///
+/// The payload of a `pending_stage_uploads` entry. Both the transient
+/// `bytesNoCopy` wrapper and the PE-heap snapshot it wraps stay alive
+/// until the GPU acknowledges the copy, so a replay is one more
+/// buffer-to-buffer blit from the same source: the buffer's persistent CPU
+/// staging may have moved on since, and the bytes this upload owed are the
+/// ones in `page_box`. Freed the other way round (wrapper destroyed, then
+/// backing dropped) because Metal holds a raw pointer into the box.
+struct StagedUploadRetry {
+    buffer_id: BufferId,
+    transient: MetalHandle<MTLBufferKind>,
+    page_box: PageBox,
+    dst_offset: u32,
+    size: u32,
+}
+
 /// Out-parameter for `drain_retention_and_wait`.
 ///
 /// Holds the `PageBox`/`Arc<PageBox>` backings of every drained
@@ -1232,6 +1282,10 @@ impl FrameEncoder {
             current_blit_retention: Vec::new(),
             pending_blit_retention: VecDeque::new(),
             coherent_seq_ptr: 0,
+            failed_seq_ptr: 0,
+            upload_coherent_seq_ptr: 0,
+            pending_stage_uploads: UploadRecoveryQueue::new(),
+            pending_texture_uploads: UploadRecoveryQueue::new(),
             retained_bytes_ptr: 0,
             current_submit_seq: 0,
             backbuffer_width: 0,
@@ -1676,20 +1730,68 @@ impl FrameEncoder {
         self.flags.insert(FrameEncoderFlags::BLIT_CMDS_NEED_ENCODER);
         self.perf.bump_vbib_staging_upload();
 
-        // Retire the transient wrapper + backing once this frame's submit
-        // retires (the blit reads it by then). Account the CPU bytes into
-        // the shared retention total like every queued `PageBox`.
+        // Hold the transient wrapper + backing until this frame's submit is
+        // *acknowledged*, not merely retired: an aborted command buffer
+        // discards the blit above, and the recovery queue is what re-emits
+        // it from these same bytes. Account the CPU bytes into the shared
+        // retention total like every queued `PageBox`.
         self.perf.bump_vbib_retained_add(page_box.len());
         self.add_retained_bytes(page_box.len());
-        self.pending_resource_retention
-            .push_back(PendingResourceRetention {
-                kind: DestroyKind::Buffer,
-                handle: transient.raw(),
-                page_box: Some(page_box),
-                staging_arc: None,
-                seq: current_seq,
-                from_texture: false,
-            });
+        self.pending_stage_uploads.push(
+            buffer_id.raw(),
+            current_seq,
+            StagedUploadRetry {
+                buffer_id,
+                transient,
+                page_box,
+                dst_offset,
+                size,
+            },
+        );
+    }
+
+    /// Re-emit one discarded `Staged` VB/IB upload into this frame's leading blits.
+    ///
+    /// The transient `MTLBuffer` and its backing are still alive (holding
+    /// them is the recovery queue's whole job), so the replay is the same
+    /// buffer-to-buffer copy aimed at the buffer's *current* device buffer.
+    /// No second `didModifyRange` notify: nothing has written the transient
+    /// since the original upload notified it. No rename-at-overlap check
+    /// either, because this runs from `begin_frame` after
+    /// `PassState::reset_frame`, so no draw of this frame has read the
+    /// destination yet.
+    ///
+    /// Returns `false` when the buffer no longer has a `Staged` device
+    /// buffer, which means the game released it and the lost upload has
+    /// nowhere left to land.
+    fn reissue_stage_upload(&mut self, retry: &StagedUploadRetry) -> bool {
+        let current_seq = self.current_submit_seq;
+        let Some(dst_handle) = self
+            .buffer_cache
+            .get_mut(&retry.buffer_id)
+            .filter(|s| s.is_staged)
+            .map(|s| {
+                if current_seq > s.last_submit_seq {
+                    s.last_submit_seq = current_seq;
+                }
+                s.device_buffer.raw()
+            })
+        else {
+            return false;
+        };
+        self.frame_blit_commands
+            .push(BlitCommand::copy_buffer_to_buffer(
+                &CopyBufferToBufferInfo {
+                    src_buffer: retry.transient.raw(),
+                    dst_buffer: dst_handle,
+                    src_offset: 0,
+                    dst_offset: u64::from(retry.dst_offset),
+                    byte_size: u64::from(retry.size),
+                },
+            ));
+        self.flags.insert(FrameEncoderFlags::BLIT_CMDS_NEED_ENCODER);
+        self.perf.bump_vbib_staging_upload();
+        true
     }
 
     /// Allocate a fresh `StorageModePrivate` device buffer for a `Staged` VB/IB.
@@ -1827,6 +1929,12 @@ impl FrameEncoder {
         if frame.retained_bytes_ptr != 0 {
             self.retained_bytes_ptr = frame.retained_bytes_ptr;
         }
+        if frame.failed_submit_seq_ptr != 0 {
+            self.failed_seq_ptr = frame.failed_submit_seq_ptr;
+        }
+        if frame.upload_coherent_seq_ptr != 0 {
+            self.upload_coherent_seq_ptr = frame.upload_coherent_seq_ptr;
+        }
         self.current_submit_seq = frame.submit_seq;
         self.backbuffer_width = frame.backbuffer_width;
         self.backbuffer_height = frame.backbuffer_height;
@@ -1859,6 +1967,11 @@ impl FrameEncoder {
                 render_scale: frame.render_scale,
                 continues_frame: self.prev_submit_no_present,
             });
+        // After `reset_frame`: a replayed upload is a frame-leading blit,
+        // and the rename-at-overlap bookkeeping it must not trip on still
+        // holds the previous frame's draws until the reset above runs.
+        mtld3d_shared::crumb!("phase:BfUpRec");
+        self.settle_pending_uploads();
         mtld3d_shared::crumb!("phase:BfDone");
     }
 
@@ -4812,6 +4925,255 @@ impl FrameEncoder {
             });
     }
 
+    /// Release or replay every upload the GPU has finished with.
+    ///
+    /// Reads the retirement counter and the aborted-submit counter as a
+    /// pair. `coherent_seq` is loaded first: both unix-side stores are
+    /// `Release` with the failure recorded before the retirement, so
+    /// observing a retirement guarantees the matching failure is visible.
+    /// An upload whose seq retired without a failure at or after it is
+    /// released; one whose command buffer aborted is re-emitted into this
+    /// frame's leading blits and re-queued under this frame's seq.
+    ///
+    /// Called at the end of `begin_frame`, after `PassState::reset_frame`:
+    /// the replays are frame-leading blits, and the rename-at-overlap
+    /// bookkeeping they would otherwise consult still holds the previous
+    /// frame's draws until that reset runs.
+    fn settle_pending_uploads(&mut self) {
+        if self.pending_stage_uploads.is_empty() && self.pending_texture_uploads.is_empty() {
+            return;
+        }
+        let Some((settled, failed)) = self.upload_gate() else {
+            return;
+        };
+        self.settle_stage_uploads(settled, failed);
+        self.settle_texture_uploads(settled, failed);
+    }
+
+    /// The `(settled_seq, failed_seq)` pair the upload-recovery queues gate on.
+    ///
+    /// `settled_seq` is the lower of the two retirement counters: `coherent_seq`
+    /// for the draw command buffer and `upload_coherent_seq` for the upload
+    /// command buffer that actually carries the copies. Both matter because
+    /// `wait_for_gpu_retire` advances `coherent_seq` by hand so its caller sees
+    /// the advance synchronously, and that hand-advance can outrun the upload
+    /// handler which is the only thing that records an aborted upload. Taking
+    /// the minimum means an entry is never freed before the handler that would
+    /// have condemned it has reported in. `None` before the encoder is wired
+    /// up; the upload counter is skipped on the defensive path where the
+    /// leading blits rode the draw command buffer.
+    ///
+    /// `coherent_seq` is read first: the unix side records a failure before
+    /// bumping either retirement counter and both stores are `Release`, so a
+    /// retirement observed here implies the matching failure is visible.
+    fn upload_gate(&self) -> Option<(u64, u64)> {
+        if self.coherent_seq_ptr == 0 {
+            return None;
+        }
+        // SAFETY: `coherent_seq_ptr` is a PE-heap `Arc<AtomicU64>` raw
+        // pointer kept alive by the device-side `Arc`; nonzero here
+        // (checked above) means the encoder has been wired up.
+        let coherent = unsafe { SharedCounter::new(self.coherent_seq_ptr) }.load(Ordering::Acquire);
+        let settled = if self.upload_coherent_seq_ptr == 0 {
+            coherent
+        } else {
+            // SAFETY: same contract as `coherent_seq_ptr`: a device-owned
+            // `Arc<AtomicU64>` outliving every frame.
+            let upload =
+                unsafe { SharedCounter::new(self.upload_coherent_seq_ptr) }.load(Ordering::Acquire);
+            coherent.min(upload)
+        };
+        let failed = if self.failed_seq_ptr == 0 {
+            0
+        } else {
+            // SAFETY: same contract as `coherent_seq_ptr`.
+            unsafe { SharedCounter::new(self.failed_seq_ptr) }.load(Ordering::Acquire)
+        };
+        Some((settled, failed))
+    }
+
+    /// Settle the `Staged` VB/IB half of the upload recovery.
+    ///
+    /// Frees a released entry the way `drain_retired_resource_retention`
+    /// does (wrapper destroyed in one bulk thunk, then the backing offered
+    /// to the page-box pool), and subtracts its bytes from the shared
+    /// retention total exactly once, so a replayed entry (whose bytes stay
+    /// live) is never double-counted in either direction.
+    fn settle_stage_uploads(&mut self, settled: u64, failed: u64) {
+        if self.pending_stage_uploads.is_empty() {
+            return;
+        }
+        let reissue_seq = self.current_submit_seq;
+        let mut freed: Vec<StagedUploadRetry> = Vec::new();
+        for (fate, entry) in self.pending_stage_uploads.settle(settled, failed) {
+            match fate {
+                UploadFate::Reissue if self.reissue_stage_upload(entry.payload()) => {
+                    mtld3d_shared::log_once_warn_by!(
+                        target: LOG_TARGET,
+                        key: failed,
+                        "settle_stage_uploads: re-issuing VB/IB uploads discarded by the \
+                         aborted submit at seq {failed}; without this the geometry they \
+                         carried would stay stale for the rest of the run",
+                    );
+                    self.pending_stage_uploads.requeue(entry, reissue_seq);
+                    continue;
+                }
+                UploadFate::Abandoned => {
+                    mtld3d_shared::log_once_warn_by!(
+                        target: LOG_TARGET,
+                        key: entry.key(),
+                        "settle_stage_uploads: dropping the upload for buffer {:#x} after \
+                         {} aborted submits; its geometry stays stale until the game locks \
+                         that range again",
+                        entry.key(),
+                        entry.attempts(),
+                    );
+                }
+                // Acknowledged, or re-issue found no destination left
+                // (the game released the buffer): free it either way.
+                UploadFate::Released | UploadFate::Reissue => {}
+            }
+            freed.push(entry.into_payload());
+        }
+        self.free_stage_upload_transients(freed);
+    }
+
+    /// Free the transient wrapper + PE-heap backing of settled `Staged` VB/IB uploads.
+    ///
+    /// Destroy order mirrors `drain_retired_resource_retention`: every
+    /// `MTLBuffer` wrapper goes in one bulk thunk, and only then do the
+    /// backings drop, because Metal holds a `bytesNoCopy` pointer into them
+    /// until the wrapper is released. The bytes leave the shared retention
+    /// total here, exactly once per entry.
+    fn free_stage_upload_transients(&mut self, retries: Vec<StagedUploadRetry>) {
+        if retries.is_empty() {
+            return;
+        }
+        let mut wrappers: Vec<u64> = Vec::new();
+        let mut backings: Vec<PageBox> = Vec::new();
+        for retry in retries {
+            if !retry.transient.is_null() {
+                wrappers.push(retry.transient.raw());
+                self.perf.bump_buffer_destroy();
+            }
+            self.perf.bump_vbib_retained_sub(retry.page_box.len());
+            self.sub_retained_bytes(retry.page_box.len());
+            backings.push(retry.page_box);
+        }
+        destroy_resources_bulk(DestroyKind::Buffer, &wrappers);
+        let pool = &*crate::page_box_pool::PAGEBOX_POOL;
+        for pb in backings {
+            let len = pb.len();
+            if pool.recycle(pb).is_none() {
+                self.perf.bump_pagebox_pool_recycled(len);
+            }
+        }
+    }
+
+    /// Free every upload the GPU acknowledged, without replaying anything.
+    ///
+    /// The retention-cap relief drains (`DrainRetiredNow` and the mid-frame
+    /// submit) run outside `begin_frame`, so `frame_blit_commands` belongs
+    /// to no frame there and a replay pushed into it would be cleared
+    /// unnoticed at the next `begin_frame`. They take only the
+    /// acknowledged prefix; anything owing a replay waits for the next
+    /// `begin_frame`, one frame later, which is the right trade on a path
+    /// that only runs after a GPU abort.
+    ///
+    /// This is what keeps `memory.vbibRetentionCapMB` relief working: a
+    /// `Staged` upload's snapshot is counted in the shared retained-bytes
+    /// total, so it has to be freeable from the drain the API thread
+    /// triggers when it hits the cap.
+    fn release_acknowledged_uploads(&mut self) {
+        if self.pending_stage_uploads.is_empty() && self.pending_texture_uploads.is_empty() {
+            return;
+        }
+        let Some((settled, failed)) = self.upload_gate() else {
+            return;
+        };
+        let freed: Vec<StagedUploadRetry> = self
+            .pending_stage_uploads
+            .release_acknowledged(settled, failed)
+            .into_iter()
+            .map(mtld3d_core::upload_recovery::PendingUpload::into_payload)
+            .collect();
+        self.free_stage_upload_transients(freed);
+        // Texture jobs own only a staging Arc clone, so dropping them here
+        // is the whole release.
+        drop(
+            self.pending_texture_uploads
+                .release_acknowledged(settled, failed),
+        );
+    }
+
+    /// Settle the texture half of the upload recovery.
+    ///
+    /// Cheaper than the VB/IB half: the job holds a clone of the texture's
+    /// own staging `Arc` rather than a private snapshot, so a released entry
+    /// frees only the clone and a replay re-reads the same pages the
+    /// original upload did (the cached per-mip `MTLBuffer` still wraps
+    /// them, so it is a cache hit). When the PE side has since swapped that
+    /// `Arc` for a fresh box, the newer upload's own entry orders after this
+    /// one under the queue's per-key rule, same as the VB/IB half.
+    fn settle_texture_uploads(&mut self, settled: u64, failed: u64) {
+        if self.pending_texture_uploads.is_empty() {
+            return;
+        }
+        let reissue_seq = self.current_submit_seq;
+        for (fate, entry) in self.pending_texture_uploads.settle(settled, failed) {
+            match fate {
+                UploadFate::Reissue if self.reissue_texture_upload(entry.payload()) => {
+                    mtld3d_shared::log_once_warn_by!(
+                        target: LOG_TARGET,
+                        key: failed,
+                        "settle_texture_uploads: re-issuing texture uploads discarded by the \
+                         aborted submit at seq {failed}; without this their mips would keep \
+                         whatever was in the texture before",
+                    );
+                    self.pending_texture_uploads.requeue(entry, reissue_seq);
+                }
+                UploadFate::Abandoned => {
+                    mtld3d_shared::log_once_warn_by!(
+                        target: LOG_TARGET,
+                        key: entry.key(),
+                        "settle_texture_uploads: dropping the upload for texture {:#x} after \
+                         {} aborted submits; that mip keeps its previous contents",
+                        entry.key(),
+                        entry.attempts(),
+                    );
+                }
+                // Acknowledged, or the game released the texture so the
+                // replay had no destination: dropping the job releases the
+                // staging Arc clone, which is all the entry owns.
+                UploadFate::Released | UploadFate::Reissue => {}
+            }
+        }
+    }
+
+    /// Re-emit one discarded texture mip upload into this frame's leading blits.
+    ///
+    /// Skips the sampled-this-frame rename `run_texture_upload` does: this
+    /// runs from `begin_frame` after `PassState::reset_frame`, so no draw of
+    /// this frame has sampled the destination yet. Returns `false` when the
+    /// texture is gone from the cache (the game released it) or when the
+    /// blit path declined to emit anything, both of which make the upload
+    /// moot.
+    fn reissue_texture_upload(&mut self, job: &TextureUploadJob) -> bool {
+        let Some(handle) = self
+            .texture_cache
+            .get(&job.info.texture_id)
+            .map(|state| state.mtl_texture.raw())
+            .filter(|handle| *handle != 0)
+        else {
+            return false;
+        };
+        if job.depth > 1 {
+            self.run_volume_upload_blit(job, handle)
+        } else {
+            self.run_texture_upload_blit(job, handle)
+        }
+    }
+
     /// Drain resource-retention entries whose seq has retired on the GPU.
     ///
     /// Partitions popped entries by `DestroyKind`, destroys each kind's
@@ -5098,10 +5460,20 @@ impl FrameEncoder {
         }
         // Volume (3D) textures take a dedicated full-box path; 2D textures
         // keep the original hot-path blit untouched.
-        if job.depth > 1 {
-            self.run_volume_upload_blit(job, handle);
+        let emitted = if job.depth > 1 {
+            self.run_volume_upload_blit(&job, handle)
         } else {
-            self.run_texture_upload_blit(job, handle);
+            self.run_texture_upload_blit(&job, handle)
+        };
+        if emitted {
+            // Keep the job so an aborted upload command buffer can replay
+            // it. It only holds a clone of the texture's own persistent
+            // staging Arc, so the memory cost is the clone.
+            self.pending_texture_uploads.push(
+                job.info.texture_id.raw(),
+                self.current_submit_seq,
+                job,
+            );
         }
     }
 
@@ -5237,11 +5609,11 @@ impl FrameEncoder {
     /// Reuses the per-mip staging `MTLBuffer` (wrapping the game's staging
     /// `PageBox`) and emits a `BlitCopyBufferToTexture` against the frame's
     /// leading blit pass.
-    fn run_texture_upload_blit(&mut self, job: TextureUploadJob, texture_handle: u64) {
+    fn run_texture_upload_blit(&mut self, job: &TextureUploadJob, texture_handle: u64) -> bool {
         let _t = mtld3d_core::perf::CycleAddTimer::start(self.op_sub_cycles_ptr(OpSub::TexRaw));
         let backing_length = job.arc.len() as u64;
         if backing_length == 0 {
-            return;
+            return false;
         }
 
         // Compute the blit descriptor against the staging buffer's
@@ -5253,7 +5625,7 @@ impl FrameEncoder {
         let staging_buffer_handle =
             self.get_or_create_staging_buffer(job.info.texture_id, job.staging_index, &job.arc);
         if staging_buffer_handle == 0 {
-            return;
+            return false;
         }
 
         let (info, num_blit_rows) = if job.bytes_per_pixel == 0 {
@@ -5350,7 +5722,7 @@ impl FrameEncoder {
         let info = if info.bytes_per_row < self.gpu_caps.min_linear_texture_align {
             match self.repack_blit_source_padded(&job.arc, &info, num_blit_rows) {
                 Some(padded_info) => padded_info,
-                None => return,
+                None => return false,
             }
         } else {
             // Notify the staging MTLBuffer (no-op on UMA). The padded
@@ -5377,9 +5749,12 @@ impl FrameEncoder {
         // Retain the staging Box for the GPU's view of this frame —
         // even on the padded path the source bytes were just copied
         // out, but keeping the Arc alive is harmless and uniform.
-        // Refcount drops back to 1 when `pending_blit_retention`
-        // releases this Arc after `coherent_seq >= submit_seq`.
-        self.current_blit_retention.push(job.arc);
+        // `pending_blit_retention` releases this clone once
+        // `coherent_seq >= submit_seq`; the caller's own clone in
+        // `pending_texture_uploads` outlives it by however long the
+        // upload takes to be acknowledged.
+        self.current_blit_retention.push(Arc::clone(&job.arc));
+        true
     }
 
     /// Volume (3D) full-box upload.
@@ -5400,11 +5775,11 @@ impl FrameEncoder {
     /// every slice is repacked to the padded stride (the rows being
     /// contiguous makes this a single `region_rows * depth` repack), and
     /// `bytes_per_image` widens to `padded_pitch * region_rows`.
-    fn run_volume_upload_blit(&mut self, job: TextureUploadJob, texture_handle: u64) {
+    fn run_volume_upload_blit(&mut self, job: &TextureUploadJob, texture_handle: u64) -> bool {
         let _t = mtld3d_core::perf::CycleAddTimer::start(self.op_sub_cycles_ptr(OpSub::TexRaw));
         let backing_length = job.arc.len() as u64;
         if backing_length == 0 {
-            return;
+            return false;
         }
         let src_pitch = job.src_pitch;
         let slice_pitch = job.slice_pitch;
@@ -5413,7 +5788,7 @@ impl FrameEncoder {
         // exactly `src_pitch * block_rows`, so recover it by division.
         let region_rows = slice_pitch.checked_div(src_pitch).unwrap_or(0);
         if region_rows == 0 {
-            return;
+            return false;
         }
         let mip_w = (job.info.width.max(1) >> job.level).max(1);
         let mip_h = (job.info.height.max(1) >> job.level).max(1);
@@ -5421,7 +5796,7 @@ impl FrameEncoder {
         let staging_buffer_handle =
             self.get_or_create_staging_buffer(job.info.texture_id, job.staging_index, &job.arc);
         if staging_buffer_handle == 0 {
-            return;
+            return false;
         }
 
         let info = CopyBufferToTextureInfo {
@@ -5451,7 +5826,7 @@ impl FrameEncoder {
                         padded_info.bytes_per_row.saturating_mul(region_rows);
                     padded_info
                 }
-                None => return,
+                None => return false,
             }
         } else {
             self.enqueue_notify_buffer_did_modify_range(staging_buffer_handle, 0, backing_length);
@@ -5462,7 +5837,8 @@ impl FrameEncoder {
             .push(BlitCommand::copy_buffer_to_texture(&info));
         self.flags.insert(FrameEncoderFlags::BLIT_CMDS_NEED_ENCODER);
         self.perf.bump_texture_blit_upload();
-        self.current_blit_retention.push(job.arc);
+        self.current_blit_retention.push(Arc::clone(&job.arc));
+        true
     }
 
     /// Repack `num_blit_rows` source rows from `staging` into a transient `PageBox`.
@@ -5978,6 +6354,25 @@ impl FrameEncoder {
         textures: &mut Vec<u64>,
     ) -> HeldBackings {
         let mut held = HeldBackings::default();
+        // Un-acknowledged uploads go the same way as retention: the GPU is
+        // about to be idle, so there is nothing left to replay into. Their
+        // bytes leave the shared retention total here, which is the only
+        // place besides `settle_stage_uploads` that subtracts them.
+        for entry in self.pending_stage_uploads.drain_all() {
+            let retry = entry.into_payload();
+            if !retry.transient.is_null() {
+                buffers.push(retry.transient.raw());
+            }
+            self.perf.bump_vbib_retained_sub(retry.page_box.len());
+            self.sub_retained_bytes(retry.page_box.len());
+            held.pageboxes.push(retry.page_box);
+        }
+        // Texture jobs own only a clone of the texture's staging Arc; park
+        // it with the other staging keepalives so it outlives the bulk
+        // destroy of the `MTLBuffer`s that wrap those pages.
+        for entry in self.pending_texture_uploads.drain_all() {
+            held.staging_arcs.push(entry.into_payload().arc);
+        }
         for entry in self.pending_resource_retention.drain(..) {
             if entry.handle != 0 {
                 match entry.kind {
@@ -6031,6 +6426,7 @@ impl FrameEncoder {
         let mut params = WaitForGpuRetireParams {
             target_seq: self.current_submit_seq,
             coherent_seq_ptr: self.coherent_seq_ptr,
+            failed_submit_seq_ptr: self.failed_seq_ptr,
         };
         let _ = unix_call(&mut params);
     }
@@ -6192,6 +6588,13 @@ pub struct FrameData {
     /// stamped (`FrameData::new` default); every submitted frame carries
     /// the real pointer.
     upload_coherent_seq_ptr: u64,
+    /// Raw pointer to the device's `Arc<AtomicU64>` failed-submit seq.
+    ///
+    /// Same lifetime guarantee as `coherent_seq_ptr`. Forwarded verbatim
+    /// into `SubmitFrameParams::failed_submit_seq_ptr`, which both
+    /// completion handlers `fetch_max` when their command buffer aborts.
+    /// 0 only before the frame is stamped.
+    failed_submit_seq_ptr: u64,
     /// Raw pointer to the device's `Arc<AtomicU64>` VB/IB retained-bytes total.
     ///
     /// Same lifetime guarantee as `coherent_seq_ptr`. The encoder
@@ -6226,6 +6629,23 @@ pub struct FrameData {
     /// at 0 — non-zero signals a new variant or workload that perturbed the
     /// peak.
     op_vec_realloc_bytes: u64,
+}
+
+/// The four GPU-fencing values `DeviceInner::stamp_and_swap` puts on a frame.
+///
+/// One bag rather than four positional `u64`s, because three of them are
+/// raw pointers to device-owned atomics and swapping two at a call site
+/// would compile silently. Every pointer is an `Arc<AtomicU64>` address
+/// that stays valid for the device's lifetime.
+pub struct SubmitFence {
+    /// Monotonic seq of the frame being handed to the encoder.
+    pub submit_seq: u64,
+    /// Draw-command-buffer retirement counter.
+    pub coherent_seq_ptr: u64,
+    /// Upload-command-buffer retirement counter.
+    pub upload_coherent_seq_ptr: u64,
+    /// Highest seq whose command buffer the GPU aborted.
+    pub failed_submit_seq_ptr: u64,
 }
 
 /// Parameter bag for `FrameData::new`.
@@ -6292,6 +6712,7 @@ impl FrameData {
             submit_seq: 0,
             coherent_seq_ptr: 0,
             upload_coherent_seq_ptr: 0,
+            failed_submit_seq_ptr: 0,
             retained_bytes_ptr: 0,
             apply_display_sync_enabled: init.apply_display_sync_enabled,
             scratch: ScratchArena::new(),
@@ -6346,15 +6767,11 @@ impl FrameData {
         };
     }
 
-    pub const fn set_submit_fence(
-        &mut self,
-        submit_seq: u64,
-        coherent_seq_ptr: u64,
-        upload_coherent_seq_ptr: u64,
-    ) {
-        self.submit_seq = submit_seq;
-        self.coherent_seq_ptr = coherent_seq_ptr;
-        self.upload_coherent_seq_ptr = upload_coherent_seq_ptr;
+    pub const fn set_submit_fence(&mut self, fence: &SubmitFence) {
+        self.submit_seq = fence.submit_seq;
+        self.coherent_seq_ptr = fence.coherent_seq_ptr;
+        self.upload_coherent_seq_ptr = fence.upload_coherent_seq_ptr;
+        self.failed_submit_seq_ptr = fence.failed_submit_seq_ptr;
     }
 
     pub const fn set_retained_bytes_ptr(&mut self, ptr: u64) {
@@ -6817,6 +7234,7 @@ fn encoder_thread_main(
                 // API thread allocates.
                 enc.wait_for_gpu_idle();
                 enc.drain_retired_resource_retention();
+                enc.release_acknowledged_uploads();
                 let _ = done.send(());
             }
             Ok(EncoderMessage::DrainRetiredNow(done)) => {
@@ -6826,6 +7244,7 @@ fn encoder_thread_main(
                 // (coherent only advances on GPU completion of committed
                 // work), so the seq-gated drain can't free it early.
                 enc.drain_retired_resource_retention();
+                enc.release_acknowledged_uploads();
                 let _ = done.send(());
             }
             Ok(EncoderMessage::IntakeVisibilityFor { target_seq, done }) => {
@@ -6847,6 +7266,7 @@ fn encoder_thread_main(
                         let mut params = WaitForGpuRetireParams {
                             target_seq,
                             coherent_seq_ptr: enc.coherent_seq_ptr,
+                            failed_submit_seq_ptr: enc.failed_seq_ptr,
                         };
                         mtld3d_shared::crumb!("vis:retirebeg", target_seq, coh);
                         let _ = unix_call(&mut params);
@@ -7160,6 +7580,7 @@ fn finalize_submit(enc: &mut FrameEncoder, frame: &FrameData) -> (SubmitFramePar
         submit_seq: frame.submit_seq,
         coherent_seq_ptr: frame.coherent_seq_ptr,
         upload_coherent_seq_ptr: frame.upload_coherent_seq_ptr,
+        failed_submit_seq_ptr: frame.failed_submit_seq_ptr,
         drawable_wait_ns: 0,
         present_view: if frame.flags.contains(FrameDataFlags::NO_PRESENT) {
             MetalHandle::NULL

--- a/windows/d3d9/src/index_buffer.rs
+++ b/windows/d3d9/src/index_buffer.rs
@@ -550,26 +550,29 @@ extern "system" fn ib_unlock(this: *mut c_void) -> i32 {
     inner.locked = false;
     if matches!(inner.map_mode, BufferMapMode::Staged)
         && let Some((min, max)) = inner.dirty.span()
+        && !inner.device_inner.is_null()
     {
-        if !inner.device_inner.is_null() {
-            // SAFETY: `inner.device_inner` was stamped at `Self::new` from
-            // a live `DeviceInner` that outlives its children.
-            let dev = unsafe { &mut *inner.device_inner };
-            let size = (max - min) as usize;
-            let mut transient = dev.alloc_pagebox_capped(size);
-            // SAFETY: `min <= length` and `current_box` is allocated for
-            // `length` bytes, so the offset stays in-bounds.
-            let src = unsafe { inner.current_box.as_ptr().add(min as usize) };
-            // SAFETY: `src` spans `[min, max)` of `current_box`;
-            // `transient` is a fresh `PageBox` of ≥ `size` bytes; the two
-            // allocations are disjoint.
-            unsafe {
-                core::ptr::copy_nonoverlapping(src, transient.as_mut_ptr(), size);
-            }
-            // Push the upload as an inline op so the encoder sees it in
-            // draw order (for rename-at-overlap). No Metal thunk here.
-            dev.push_stage_upload(inner.buffer_id, transient, min, max - min);
+        // SAFETY: `inner.device_inner` was stamped at `Self::new` from
+        // a live `DeviceInner` that outlives its children.
+        let dev = unsafe { &mut *inner.device_inner };
+        let size = (max - min) as usize;
+        let mut transient = dev.alloc_pagebox_capped(size);
+        // SAFETY: `min <= length` and `current_box` is allocated for
+        // `length` bytes, so the offset stays in-bounds.
+        let src = unsafe { inner.current_box.as_ptr().add(min as usize) };
+        // SAFETY: `src` spans `[min, max)` of `current_box`;
+        // `transient` is a fresh `PageBox` of ≥ `size` bytes; the two
+        // allocations are disjoint.
+        unsafe {
+            core::ptr::copy_nonoverlapping(src, transient.as_mut_ptr(), size);
         }
+        // Push the upload as an inline op so the encoder sees it in
+        // draw order (for rename-at-overlap). No Metal thunk here.
+        dev.push_stage_upload(inner.buffer_id, transient, min, max - min);
+        // Only once the upload is actually queued: the range is the
+        // only record that these bytes still owe a copy to the device
+        // buffer, so clearing it on a path that queued nothing would
+        // drop them silently.
         inner.dirty.clear();
     }
     D3D_OK

--- a/windows/d3d9/src/vertex_buffer.rs
+++ b/windows/d3d9/src/vertex_buffer.rs
@@ -659,26 +659,29 @@ extern "system" fn vb_unlock(this: *mut c_void) -> i32 {
     inner.locked = false;
     if matches!(inner.map_mode, BufferMapMode::Staged)
         && let Some((min, max)) = inner.dirty.span()
+        && !inner.device_inner.is_null()
     {
-        if !inner.device_inner.is_null() {
-            // SAFETY: `inner.device_inner` was stamped at `Self::new` from
-            // a live `DeviceInner` that outlives its children.
-            let dev = unsafe { &mut *inner.device_inner };
-            let size = (max - min) as usize;
-            let mut transient = dev.alloc_pagebox_capped(size);
-            // SAFETY: `min <= length` and `current_box` is allocated for
-            // `length` bytes, so the offset stays in-bounds.
-            let src = unsafe { inner.current_box.as_ptr().add(min as usize) };
-            // SAFETY: `src` spans `[min, max)` of `current_box`;
-            // `transient` is a fresh `PageBox` of ≥ `size` bytes; the two
-            // allocations are disjoint.
-            unsafe {
-                core::ptr::copy_nonoverlapping(src, transient.as_mut_ptr(), size);
-            }
-            // Push the upload as an inline op so the encoder sees it in
-            // draw order (for rename-at-overlap). No Metal thunk here.
-            dev.push_stage_upload(inner.buffer_id, transient, min, max - min);
+        // SAFETY: `inner.device_inner` was stamped at `Self::new` from
+        // a live `DeviceInner` that outlives its children.
+        let dev = unsafe { &mut *inner.device_inner };
+        let size = (max - min) as usize;
+        let mut transient = dev.alloc_pagebox_capped(size);
+        // SAFETY: `min <= length` and `current_box` is allocated for
+        // `length` bytes, so the offset stays in-bounds.
+        let src = unsafe { inner.current_box.as_ptr().add(min as usize) };
+        // SAFETY: `src` spans `[min, max)` of `current_box`;
+        // `transient` is a fresh `PageBox` of ≥ `size` bytes; the two
+        // allocations are disjoint.
+        unsafe {
+            core::ptr::copy_nonoverlapping(src, transient.as_mut_ptr(), size);
         }
+        // Push the upload as an inline op so the encoder sees it in
+        // draw order (for rename-at-overlap). No Metal thunk here.
+        dev.push_stage_upload(inner.buffer_id, transient, min, max - min);
+        // Only once the upload is actually queued: the range is the
+        // only record that these bytes still owe a copy to the device
+        // buffer, so clearing it on a path that queued nothing would
+        // drop them silently.
         inner.dirty.clear();
     }
     D3D_OK


### PR DESCRIPTION
Closes #40.

## Symptoms

A vertex, index or texture upload riding a command buffer the GPU aborted was lost for the rest of the run rather than for one frame. The dirty range was cleared the moment the upload was queued, nothing recorded what the upload covered, and no completion handler looked at the command buffer's status, so no path could re-issue it. The bytes survive in the buffer's persistent CPU staging, so a later game `Lock` that happens to re-announce the same region re-uploads them by accident, but a title that fills static geometry once at load time never announces it again. One `kIOGPUCommandBufferCallbackErrorOutOfMemory` therefore takes out whatever that submission carried, permanently and with nothing in the log.

## Two corrections to the issue

The upload does not ride the command buffer whose tripwire the issue quotes. `frame_blit_commands` is one list holding every frame-leading blit, and it is handed wholesale to `submit_upload_cmd_buf`, so a lost VB/IB or texture upload rides the *upload* command buffer, whose handler took its parameter as `_cb` and never called `status()`. That was the only `status()` call site in the entire `unix` tree, on the draw handler, so the failure was genuinely silent.

Gating the `coherent_seq` bump on `status()`, as the issue proposes, would deadlock. `coherent_seq` means "the GPU is finished with these bytes", which is true of an aborted command buffer too. Withholding it pins every seq-gated queue: `alloc_pagebox_capped` falls through to `mid_frame_submit_for_retention`, which blocks on a seq that never retires, and occlusion queries never finalise. Retirement-for-lifetime and retirement-for-success have to be two counters.

There is a second consequence the issue does not name. `upload_coherent_seq` also advanced unconditionally, and texture `LockRect` reads it to decide staging contention, so after an aborted upload the next `LockRect` concluded its staging was retired and wrote in place over bytes the never-to-happen blit was supposed to consume.

## Changes

- A third PE-side atomic, `failed_submit_seq`, wired as `SubmitFrameParams::failed_submit_seq_ptr` following the existing two-atomic pattern. Both completion handlers record into it when the status is `MTLCommandBufferStatus::Error`, before their retirement bump. The upload handler gains the status check, a `log_once_warn_by!` tripwire keyed on the error code, and a `submit:upcberr` crumb. Its message names what was actually lost, which is uploads rather than rendering. `wait_for_gpu_retire` records a failure too instead of laundering the abort into "retired".
- A new pure module, `windows/core/src/upload_recovery.rs`, holding pending uploads ordered by submit seq and keyed by destination, modelled on `visibility.rs`'s pending-query queue. The encoder re-issues a blit from the still-live retained transient when the carrying submit failed, pushing the re-armed entry to the back under the new seq so the drain's monotonic-seq invariant holds.
- `inner.dirty.clear()` moves inside the `!device_inner.is_null()` guard in both `vb_unlock` and `ib_unlock`. This is a code-shape fix, not the bug: `device_inner` is never null in practice, since both construction sites pass a live pointer and `vb_lock` warns rather than handling null.
- The same treatment for `TextureUploadJob`, which has the identical hole and whose persistent `staging_arc` makes the re-issue cheap.

Retention is bounded deliberately, because a held transient counts against `memory.vbibRetentionCapMB` and hitting that cap forces a synchronous mid-frame GPU wait. An entry carries an attempt count, so a persistently failing upload gives its memory back rather than replaying forever; re-issuing extends one entry's life by a frame instead of growing the live set; and the two retention-relief drains take only the acknowledged prefix.

## Alternatives

Stalling the retirement counters on abort, as the issue suggests: rejected, it deadlocks as described. Re-snapshotting from the buffer's CPU staging instead of retaining the transient: rejected, it needs a PE-side record of the range that `dirty.clear()` throws away, so it trades a retained allocation for a parallel bookkeeping structure. Dedicated queues rather than riding `PendingResourceRetention`: rejected, the drain already gates on the right seq and a second queue would need the same monotonic invariant maintained separately.

## Verification

`make check` green, `make test-unit` 752 host-native plus 125 unix, `make test` 260/260 on both `i686` and `x86_64`, `make conformance` byte-identical to `main` on both architectures.

An aborted command buffer is not reachable from the end-to-end suite: there is no failure-injection surface, the unix-side tests construct no Metal objects, and a knob for it would have to ride `SubmitFrameParams` and be dead weight in production. So the evidence is the seven propositions in `windows/core/src/upload_recovery/tests.rs`: an entry survives until its seq is acknowledged rather than merely retired, an abort at seq N re-arms exactly the entries at or below N, a re-armed entry lands after everything already queued, two uploads to one destination coalesce, a re-armed range is not double-counted against the byte total, the replay chain is bounded, and an entry re-armed under a later seq is released normally when that seq retires cleanly.
