### PR TITLE
Document the dynamic partial-Lock divergence and count when it fires

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ own fallback paths instead of breaking:
 
 ### Faster than conformant
 
-Divergences from D3D9 kept on purpose, because closing them costs frame time
-and no game depends on them:
+Divergences from D3D9 kept on purpose, because closing them costs frame time or
+memory headroom and no tested game depends on them:
 
 - **`GetData(D3DGETDATA_FLUSH)` returns `S_OK` immediately** for a pending
   occlusion query instead of blocking until the GPU has the count. Games use
@@ -122,6 +122,24 @@ and no game depends on them:
   that relies on depth surviving a pass it never cleared can read stale depth.
   Preserving it unconditionally would cost the optimization on every frame of
   every game that does clear, which is all of the tested ones.
+- **A partial `Lock` of a dynamic vertex or index buffer hands back a pointer
+  into memory a queued draw may still be reading**, unless the game passed
+  `D3DLOCK_DISCARD` or locked the whole buffer. On D3D9 the runtime keeps the
+  game's writes from landing under a draw the GPU has not reached yet, and
+  `D3DLOCK_NOOVERWRITE` is how a game opts out of that protection; here it is
+  the other way round, so a game that locks a sub-range and expects the
+  runtime to manage the timing can get corrupted geometry for a frame, with
+  nothing in the log. Matching D3D9 means either stalling until the draw
+  retires or renaming the backing on every such `Lock`, and a dynamic buffer is
+  precisely the one a UI or particle batcher locks dozens of times per frame.
+  The rename-and-retain path those extra locks would run through has already
+  been observed peaking around 1.4 GB of retained backings, which is why
+  `memory.vbibRetentionCapMB` exists and why hitting that cap forces a
+  mid-frame GPU sync. So this one trades memory headroom rather than frame
+  time, and it has no knob: turning it on is the memory growth. Wine's d3d9
+  test suite probes this and reports it in some runs, so the rationale is
+  written up in [`CONFORMANCE.md`](unix/conformance/CONFORMANCE.md) like every
+  other kept divergence.
 
 ### Deliberately not implemented
 

--- a/mtld3d.conf
+++ b/mtld3d.conf
@@ -183,15 +183,17 @@
 
 # Cap on live VB/IB retained-PageBox memory (MiB).
 #
-# A non-DYNAMIC partial Lock of an in-flight vertex/index buffer is
-# renamed to a fresh backing and the old one retained until the GPU
-# stops reading it. During a camera turn the game repacks hundreds of
-# buffers per frame; if the GPU falls behind, the retention queue can
-# balloon (observed ~1.4 GB) and thrash the 32-bit game process. This
-# caps live retained bytes: at the limit the Lock path drains retired
-# backings and, if still over, forces a mid-frame GPU-sync before
-# allocating — trading a bounded, predictable stall for the unbounded
-# memory growth + OOM risk.
+# A Lock of an in-flight vertex/index buffer that cannot write in place
+# gets a fresh backing, and the old one is retained until the GPU stops
+# reading it. Two cases reach that queue: a DYNAMIC buffer locked with
+# DISCARD or over its whole length, and the snapshot a non-DYNAMIC
+# buffer's Unlock hands the encoder for its dirty-range upload. During
+# a camera turn the game repacks hundreds of buffers per frame; if the
+# GPU falls behind, the queue can balloon (observed ~1.4 GB) and thrash
+# the 32-bit game process. This caps live retained bytes: at the limit
+# the alloc path drains retired backings and, if still over, forces a
+# mid-frame GPU-sync before allocating, trading a bounded, predictable
+# stall for the unbounded memory growth + OOM risk.
 #
 # Lower it if you still see memory-pressure stalls; raise it if turns
 # stall on the GPU-sync more than the memory pressure warrants. `0`

--- a/unix/conformance/CONFORMANCE.md
+++ b/unix/conformance/CONFORMANCE.md
@@ -605,7 +605,12 @@ test observes the divergence is a per-run CPU-vs-GPU race (the probe's Lock
 write lands before or after the GPU consumes the in-flight draw), so the
 count flutters between 0 and 1 across runs of the same binary; it read 0 on
 the CI runner and tripped the stale-baseline gate (PR #12), hence the flaky
-tolerance. The kept divergence itself is unchanged.
+tolerance. That race is in the observation only, not in the decision:
+`plan_lock` is a pure function of a `coherent_seq` its caller read once
+with Acquire before calling, and only the unix side raises that counter
+(`fetch_max`, on GPU retirement), so a stale read can turn a legal
+in-place write into a needless rename but never the reverse. The kept
+divergence itself is unchanged.
 
 ### visual.c/test_mipmap_upload
 Sites: 27550=expected

--- a/windows/core/src/buffer_rename.rs
+++ b/windows/core/src/buffer_rename.rs
@@ -23,7 +23,12 @@
 //!   discipline), the same one non-persistent mapped-buffer APIs (e.g.
 //!   OpenGL `glBufferSubData`) make implicitly. Append-only UI batchers
 //!   live here; renaming them on every call drives
-//!   memory-allocation-failure symptoms.
+//!   memory-allocation-failure symptoms. D3D9 promises no such thing on
+//!   a plain Lock, so this arm is a deliberate divergence: the README
+//!   lists it under "Faster than conformant" and
+//!   `unix/conformance/CONFORMANCE.md` carries its conformance-site
+//!   rationale. It is also the only arm with no other side effect, so
+//!   `d3d9` counts it into a perf row.
 //!
 //! Side effects (allocate `PageBox`, sync memcpy preserve, queue
 //! retention, bump perf counters) stay in `d3d9`; this module just

--- a/windows/core/src/config.rs
+++ b/windows/core/src/config.rs
@@ -99,10 +99,11 @@ pub struct Mtld3dConfig {
     pub depth_alias_same_size: bool,
     /// Proactive cap on live VB/IB retained-`PageBox` bytes.
     ///
-    /// When live retention reaches this, the Lock-rename alloc path
-    /// drains retired backings and, if still over, forces a mid-frame
-    /// GPU-sync before allocating — bounding peak PE-heap retention so
-    /// a camera-turn rename burst can't thrash the 32-bit game process.
+    /// When live retention reaches this, the capped alloc path (a Lock
+    /// rename, or a `Staged` buffer's `Unlock` snapshot) drains retired
+    /// backings and, if still over, forces a mid-frame GPU-sync before
+    /// allocating, bounding peak PE-heap retention so a camera-turn
+    /// rename burst can't thrash the 32-bit game process.
     /// This is the only bound: allocation itself is infallible, so `0`
     /// means unbounded retention and an abort if the address space does
     /// run out (the A/B baseline arm). Default: 512 MiB. File key:

--- a/windows/core/src/perf.rs
+++ b/windows/core/src/perf.rs
@@ -560,6 +560,17 @@ struct FrameCounters {
     /// the memcpy itself, so a non-zero count means the preserve actually
     /// ran — not merely that a rename was planned.
     vbib_preserve_cpu: u32,
+    /// Contended partial VB/IB Locks this frame that were handed back in place.
+    ///
+    /// The plain (no `DISCARD`, no `NOOVERWRITE`) partial Lock of a
+    /// DYNAMIC buffer a queued draw may still be reading. `plan_lock`
+    /// answers `WriteInPlace` on the strength of the DYNAMIC timing
+    /// contract rather than renaming, the divergence the README lists
+    /// under "Faster than conformant". The arm has no other side effect,
+    /// so this count is the only signal that a game leans on it.
+    /// `NOOVERWRITE` / `READONLY` and uncontended Locks are excluded:
+    /// handing those back in place is the specified behaviour.
+    vbib_write_in_place_contended: u32,
     /// VB/IB rename allocs that found retained bytes at the cap.
     ///
     /// Each one paid a cheap `DrainRetiredNow` round-trip before
@@ -707,6 +718,7 @@ impl FrameCounters {
             vb_discards: 0,
             ib_discards: 0,
             vbib_preserve_cpu: 0,
+            vbib_write_in_place_contended: 0,
             retention_cap_drain: 0,
             retention_cap_submit: 0,
             texture_renames: 0,
@@ -1141,6 +1153,19 @@ impl ApiPerfState {
         self.counters.vbib_preserve_cpu = self.counters.vbib_preserve_cpu.saturating_add(1);
     }
 
+    /// Contended partial Lock of a DYNAMIC VB/IB handed back in place.
+    ///
+    /// The kept divergence: no rename, no preserve, no stall, so the
+    /// count is the only trace the arm leaves. Corrupted geometry with
+    /// nothing in the log is its symptom, and this row is where to look
+    /// for whether it fired.
+    pub const fn bump_vbib_write_in_place_contended(&mut self) {
+        self.counters.vbib_write_in_place_contended = self
+            .counters
+            .vbib_write_in_place_contended
+            .saturating_add(1);
+    }
+
     /// Bump when the retention cap forced a `DrainRetiredNow`.
     ///
     /// The cheap tier: one encoder round-trip, no GPU wait.
@@ -1291,6 +1316,8 @@ impl ApiPerfState {
     pub const fn bump_vbib_pool_miss(&mut self) {}
     #[inline]
     pub const fn bump_vbib_preserve_cpu(&mut self) {}
+    #[inline]
+    pub const fn bump_vbib_write_in_place_contended(&mut self) {}
     #[inline]
     pub const fn bump_retention_cap_drain(&mut self) {}
     #[inline]
@@ -2328,6 +2355,11 @@ struct PerfWindow {
     vb_discards: Stat,
     ib_discards: Stat,
     vbib_preserve_cpu: Stat,
+    /// Contended partial Locks handed back in place (sum only).
+    ///
+    /// Counts the kept divergence firing, not work done: the arm
+    /// allocates nothing and stalls nothing.
+    vbib_write_in_place_contended: Stat,
     /// `Staged` VB/IB dirty-range upload blits.
     ///
     /// The separate-staging path's headline counter (replaces renames for
@@ -2518,6 +2550,8 @@ impl PerfWindow {
         self.ib_discards.add(u64::from(s.counters.ib_discards));
         self.vbib_preserve_cpu
             .add(u64::from(s.counters.vbib_preserve_cpu));
+        self.vbib_write_in_place_contended
+            .add(u64::from(s.counters.vbib_write_in_place_contended));
         self.vbib_staging_uploads
             .add(u64::from(s.enc.vbib_staging_uploads));
         self.vbib_mid_pass_reorders
@@ -3841,6 +3875,15 @@ impl<'a> Summary<'a> {
             &rename_bytes_fmt,
             Some(&format!("peak/frame {rename_bytes_peak_fmt}")),
             "API: fresh PageBox bytes behind rename (16 KiB-padded; what the allocator serves)",
+        );
+        // Not a rename child: this arm allocates nothing, so it stays
+        // outside the `rename = discards + preserve` partition.
+        self.res_row(
+            out,
+            "in-place",
+            &format!("{c}", c = w.vbib_write_in_place_contended.sum),
+            None,
+            "API: contended partial Lock handed back live (kept divergence; no rename, no stall)",
         );
         self.res_row(
             out,

--- a/windows/core/src/perf/tests.rs
+++ b/windows/core/src/perf/tests.rs
@@ -80,6 +80,7 @@ fn api_perf_drain_moves_and_resets() {
     api.bump_vb_rename();
     api.bump_vb_rename();
     api.bump_vbib_preserve_cpu();
+    api.bump_vbib_write_in_place_contended();
 
     let mut p = FramePerfPayload::new();
     api.drain_into_payload(&mut p);
@@ -94,6 +95,7 @@ fn api_perf_drain_moves_and_resets() {
     );
     assert_eq!(p.counters.vb_rename, 2);
     assert_eq!(p.counters.vbib_preserve_cpu, 1);
+    assert_eq!(p.counters.vbib_write_in_place_contended, 1);
     assert_eq!(
         p.timing.frame_total_cycles, 0,
         "first frame has no predecessor"
@@ -106,6 +108,7 @@ fn api_perf_drain_moves_and_resets() {
     );
     assert_eq!(api.counters.vb_rename, 0);
     assert_eq!(api.counters.vbib_preserve_cpu, 0);
+    assert_eq!(api.counters.vbib_write_in_place_contended, 0);
 
     // Second drain should report a real frame_total (tsc moved).
     let mut p2 = FramePerfPayload::new();
@@ -303,6 +306,7 @@ fn summary_golden_layout() {
         "  discards  VB=10     IB=3                                      API: rename, no preserve (DISCARD or whole-buffer WRITEONLY)\n",
         "  preserve  2                                                   API: rename + sync memcpy (whole-buffer non-WRITEONLY contended — game may read back)\n",
         "  bytes     720 KB                  peak/frame 720 KB           API: fresh PageBox bytes behind rename (16 KiB-padded; what the allocator serves)\n",
+        "in-place    3                                                   API: contended partial Lock handed back live (kept divergence; no rename, no stall)\n",
         "staging up  0                                                   encoder: Staged (non-DYNAMIC) dirty-range upload blits — separate-staging path; high here with rename≈0 is the goal\n",
         "reorder     0                                                   encoder: rename-at-overlap (upload hit a just-drawn region; rare)\n",
         "destroys    1                                                   encoder: MTLBuffer wrappers freed (VB/IB cache renames, Lock-rename intake, visibility-pool eviction)\n",
@@ -475,6 +479,10 @@ fn sample_window() -> PerfWindow {
             // CPU-memcpy preserve path. Surfaces in the `preserve` row.
             // `rename = discards + preserve_cpu` holds (12 = 10 + 2 for VB).
             vbib_preserve_cpu: 2,
+            // Three contended partial Locks took the kept-divergence
+            // in-place arm. Outside the `rename = discards +
+            // preserve_cpu` partition: no rename was allocated.
+            vbib_write_in_place_contended: 3,
             // Two cheap-tier recoveries (drain) and one heavy
             // (submit) — exercises the row formatting on both halves.
             retention_cap_drain: 2,

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -399,8 +399,13 @@ pub struct DeviceInner {
     current_frame: FrameData,
     /// Shared with the encoder thread and the unix completion handler.
     ///
-    /// Bumped in `present()` before `send_frame`; completion block
-    /// `fetch_max`'s it when a frame retires on the GPU.
+    /// The frame's submit seq is stamped in `stamp_and_swap`; this atomic
+    /// is the *retired* seq, raised on the unix side only: the draw
+    /// command buffer's completion handler, and `wait_for_gpu_retire`
+    /// once its `waitUntilCompleted` returns, both with a `Release`
+    /// `fetch_max`. Every PE-side reader only `Acquire`-loads it, so a
+    /// read that misses a concurrent retirement is a lower bound on GPU
+    /// progress: it can make a caller more conservative, never less.
     coherent_seq: Arc<AtomicU64>,
     /// Texture-upload retirement seq.
     ///

--- a/windows/d3d9/src/index_buffer.rs
+++ b/windows/d3d9/src/index_buffer.rs
@@ -472,6 +472,13 @@ extern "system" fn ib_lock(
         // resources per D3D9 lifetime rules.
         let dev = unsafe { &mut *inner.device_inner };
         let coh = dev.coherent_seq_arc().load(Ordering::Acquire);
+        // The same contention test `plan_lock` applies, named here so
+        // both it and the plan read one sampled `coh`. A stale `coh` is
+        // a lower bound on GPU progress (only the unix side raises it,
+        // with a `fetch_max` once the GPU retires the frame), so it can
+        // turn a legal in-place write into an unnecessary rename, never
+        // the reverse.
+        let contended = inner.last_submit_seq > coh;
         match plan_lock(
             flags,
             inner.usage,
@@ -517,7 +524,20 @@ extern "system" fn ib_lock(
                 dev.queue_vbib_retention(buffer_id, old_box, old_seq);
                 inner.last_submit_seq = 0;
             }
-            LockPlan::WriteInPlace => {}
+            LockPlan::WriteInPlace => {
+                // Count the kept divergence: a contended partial Lock
+                // without DISCARD or NOOVERWRITE hands back a pointer
+                // into the backing a queued draw may still be reading
+                // (README, "Faster than conformant"). Counted and not
+                // warned because it is a by-design no-op on a per-frame
+                // batcher path, not a stub or a fallback. The other two
+                // ways to reach `WriteInPlace` (NOOVERWRITE/READONLY,
+                // uncontended) are conformant, so it takes both tests to
+                // select this arm.
+                if contended && !bypass_rename {
+                    dev.perf_mut().bump_vbib_write_in_place_contended();
+                }
+            }
         }
     }
 

--- a/windows/d3d9/src/vertex_buffer.rs
+++ b/windows/d3d9/src/vertex_buffer.rs
@@ -1,11 +1,15 @@
 //! `IDirect3DVertexBuffer9` COM wrapper.
 //!
-//! Per-buffer `PageBox` backing: every Lock that renames
-//! (`!NOOVERWRITE && !READONLY && last_submit_seq > coherent_seq`) swaps
-//! `current_box` for a fresh uninit `PageBox`; the old one goes onto the
-//! device's retention pipeline, picked up by the encoder and paired with
-//! its wrapped `MTLBuffer` for GPU-retirement-gated destruction. Unlock is a
-//! no-op for `Direct` buffers; `Staged` buffers upload their dirty span there.
+//! Per-buffer `PageBox` backing: a Lock that renames swaps `current_box`
+//! for a fresh uninit `PageBox`; the old one goes onto the device's
+//! retention pipeline, picked up by the encoder and paired with its
+//! wrapped `MTLBuffer` for GPU-retirement-gated destruction. Renaming
+//! takes contention (`last_submit_seq > coherent_seq`, without
+//! `NOOVERWRITE` or `READONLY`) plus either `DISCARD` or a whole-buffer
+//! range: a contended *partial* Lock keeps the live pointer, the
+//! divergence the README lists under "Faster than conformant". Unlock is
+//! a no-op for `Direct` buffers; `Staged` buffers upload their dirty
+//! span there.
 //!
 //! Layout follows the "state on Inner" pattern: the `#[repr(C)]` outer
 //! struct only carries the vtable, refcount, and an opaque pointer to
@@ -515,12 +519,14 @@ extern "system" fn vb_get_type(this: *mut c_void) -> u32 {
 ///   buffer is non-WRITEONLY, memcpy the old bytes across (game
 ///   might read the whole buffer through the Lock pointer).
 /// - Contended partial non-DISCARD, `D3DUSAGE_DYNAMIC`: `WriteInPlace`.
-///   The game opted into the DISCARD/NOOVERWRITE timing contract — the
+///   The game opted into the DISCARD/NOOVERWRITE timing contract, the
 ///   same one non-persistent mapped-buffer APIs (e.g. OpenGL
-///   `glBufferSubData`) make implicitly.
-/// - Contended partial non-DISCARD, non-DYNAMIC: same fresh-`PageBox`
-///   swap, with the old bytes carried across via synchronous CPU
-///   memcpy (a "static" buffer repacked while a draw is in flight).
+///   `glBufferSubData`) make implicitly. This is the divergence the
+///   README lists under "Faster than conformant"; the only trace it
+///   leaves is the `in-place` perf counter bumped below.
+/// - Non-DYNAMIC buffers never reach `plan_lock`: they are `Staged`, and
+///   a partial write there uploads the dirtied range to a separate
+///   device buffer on Unlock, so it cannot land under a queued draw.
 extern "system" fn vb_lock(
     this: *mut c_void,
     offset_to_lock: u32,
@@ -580,6 +586,13 @@ extern "system" fn vb_lock(
         // resources per D3D9 lifetime rules.
         let dev = unsafe { &mut *inner.device_inner };
         let coh = dev.coherent_seq_arc().load(Ordering::Acquire);
+        // The same contention test `plan_lock` applies, named here so
+        // both it and the plan read one sampled `coh`. A stale `coh` is
+        // a lower bound on GPU progress (only the unix side raises it,
+        // with a `fetch_max` once the GPU retires the frame), so it can
+        // turn a legal in-place write into an unnecessary rename, never
+        // the reverse.
+        let contended = inner.last_submit_seq > coh;
         match plan_lock(
             flags,
             inner.usage,
@@ -626,7 +639,20 @@ extern "system" fn vb_lock(
                 dev.queue_vbib_retention(buffer_id, old_box, old_seq);
                 inner.last_submit_seq = 0;
             }
-            LockPlan::WriteInPlace => {}
+            LockPlan::WriteInPlace => {
+                // Count the kept divergence: a contended partial Lock
+                // without DISCARD or NOOVERWRITE hands back a pointer
+                // into the backing a queued draw may still be reading
+                // (README, "Faster than conformant"). Counted and not
+                // warned because it is a by-design no-op on a per-frame
+                // batcher path, not a stub or a fallback. The other two
+                // ways to reach `WriteInPlace` (NOOVERWRITE/READONLY,
+                // uncontended) are conformant, so it takes both tests to
+                // select this arm.
+                if contended && !bypass_rename {
+                    dev.perf_mut().bump_vbib_write_in_place_contended();
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #42.

Documentation, plus one perf counter. No behaviour change.

## Symptoms

A plain partial `Lock`, no `D3DLOCK_DISCARD` and no `D3DLOCK_NOOVERWRITE`, of a `D3DPOOL_DEFAULT` plus `D3DUSAGE_DYNAMIC` buffer hands the game a pointer into the backing a queued draw may still be reading. That is deliberate and it stays, but it is a case where a title that works on a real driver can render corrupted geometry here, and README's "Faster than conformant" list did not carry it. The arm also left no trace: it was an empty match arm, so nothing warned and nothing counted, and a report of one-frame geometry corruption had no signal to check against.

## Two corrections to the issue

The reasoning does not live only in a module comment. `unix/conformance/CONFORMANCE.md` already carries a dedicated cluster for this exact arm, `visual.c/test_map_synchronisation` with `Sites: 25148=flaky`, whose prose states that the failing configuration is the plain partial lock of a contended `Direct` buffer, that native stalls for it, and that re-adding the stall is a rejected perf regression. The site is live in `baseline.txt` on both architectures, and the tag list already names buffer-rename over stalls among the canonical kept tradeoffs. So CONTRIBUTING's second obligation was already met and the README bullet was the only real gap. The issue's conclusion holds; its premise does not.

"Nothing observed so far justifies revisiting" needs a qualifier too. Wine's `test_map_synchronisation` does probe this and does fail on it intermittently, and per that cluster's own prose the flutter already tripped the stale-baseline gate once.

## Changes

- A third entry in README's "Faster than conformant" list. Its lead-in needed widening, because the two existing entries trade frame time while this one trades memory headroom: closing it means renaming on every partial contended lock, which is the retention growth `memory.vbibRetentionCapMB` exists to bound.
- One clarifying clause in the existing CONFORMANCE.md cluster, distinguishing the observation race it already documents and which is real, where the probe's write lands before or after the GPU consumes the in-flight draw, from the decision race that was alleged and is not. No new `Sites:` entry: 25148 is already declared, and the runner fails a unit test on a site declared twice.
- A `write_in_place_contended` perf counter beside the existing `vb_rename`, `vb_discards` and `vbib_preserve_cpu`, so the arm is observable. Everything in `perf.rs` compiles to empty stubs without `PERF=1`, so the shipping cost is zero.
- Corrected wording where `mtld3d.conf` and `windows/core/src/config.rs` described the retention cap as bounding a *non-DYNAMIC* partial `Lock` rename. Non-DYNAMIC means `Staged`, which never reaches `plan_lock`; the retained allocations on that path are the transient `Unlock` snapshots and the encoder-side device-buffer rename. The sibling `memory.pageboxPoolCapMB` entry already said it correctly.

## The retraction

PR #38 described the decision as reading `coherent_seq` in a way that lets the same call decide differently between runs, implying a race in the safety decision. It does not hold. `coherent_seq` is an `Arc<AtomicU64>` read once with `Acquire` into a local before the decision, in both `vertex_buffer.rs` and `index_buffer.rs`, and `plan_lock` takes it by value, so no re-read is reachable inside the decision. Its only writers raise it with `fetch_max` and `Release`. A stale read is therefore a lower bound on GPU progress: it can turn a legal `WriteInPlace` into an unnecessary `Rename` and never the reverse. The timing dependence is real and harmless, and the conservative direction is the safe one.

## Alternatives

A `mtld3d.conf` knob, per CONTRIBUTING's "where a knob makes sense": rejected. Its enabled state is the rejected retention regression, so it would ship a foot-gun rather than a fallback, and plumbing it means either an eighth `plan_lock` parameter through both call sites and every test invocation, or a config read at the COM call site, which pushes a core decision into wiring. README's second entry is the no-knob precedent.

A `log_once_warn!` at the arm instead of a counter: rejected. CONVENTIONS' no-silent-failures rule excludes a no-op that is there by design, this arm is the deliberate answer rather than a stub or a fallback, and `buffer_rename` returns a verdict without side effects, so the warn would have to re-derive the whole-buffer test at both call sites or widen `LockPlan`, which is an API change rather than documentation.

## Verification

`./scripts/audit.sh` clean, `make check` green on all seven legs, `make test-unit` 736 host-native plus 125 unix. Also `make PERF=1 check` and `make PERF=1 test-unit`, 745 host-native there, since the counter only exists in that configuration and the standard gates never build it; `perf::tests::summary_golden_layout` pins the new row's column layout.

`make test` is 260/260 on both `i686` and `x86_64`. No behaviour changes, so conformance is expected unchanged, site 25148 included.
