### PR TITLE
Split the Surface perf row into per-entry-point sub-rows

### DIFF
--- a/scripts/derive_inventory.txt
+++ b/scripts/derive_inventory.txt
@@ -121,6 +121,7 @@ windows/core/src/perf.rs PairShaderId Clone,Copy,PartialEq,Eq,Hash
 windows/core/src/perf.rs PairStatsSample Clone,Copy
 windows/core/src/perf.rs PerPairStats Default,Clone,Copy
 windows/core/src/perf.rs Stat Clone,Copy,Default
+windows/core/src/perf.rs SurfaceSubCategory Clone,Copy,Debug,strum::EnumCount
 windows/core/src/pipeline_state.rs ExtraColorAttachments Clone,Copy,Debug,PartialEq,Eq,Hash
 windows/core/src/pipeline_state.rs PipelineAttachFlags Clone,Copy,Debug,Default,PartialEq,Eq,Hash
 windows/core/src/pipeline_state.rs PipelineRsBits Clone,Copy,Debug,Default,PartialEq,Eq,Hash

--- a/windows/core/src/perf.rs
+++ b/windows/core/src/perf.rs
@@ -162,6 +162,34 @@ pub enum BindSubCategory {
     ViewScissor,
 }
 
+/// Sub-bucket inside the `Surface` `ApiCategory`.
+///
+/// Every `IDirect3DSurface9` vtable thunk tags its `ApiTimer` with a
+/// `SurfaceSubCategory` (via `surf_timer`), so the 5-second summary can
+/// decompose the `Surface` row the way `Bind` decomposes. The row mixes
+/// a getter storm (tens of thousands of near-free calls per window) with
+/// the few entry points that can block for milliseconds — `LockRect`
+/// (staging rename, preserve memcpy, or the synchronous backbuffer
+/// readback), `UnlockRect` (upload queueing) and the GDI DC pair — so a
+/// spike in the aggregate row was unattributable before the split.
+///
+/// `Misc` is the catch-all so the sub-buckets sum exactly to
+/// `api_cycles_by_category[Surface]`.
+#[derive(Clone, Copy, Debug, strum::EnumCount)]
+#[repr(u32)]
+pub enum SurfaceSubCategory {
+    /// `LockRect`: map, staging rename, or synchronous backbuffer readback.
+    LockRect = 0,
+    /// `UnlockRect`: unmap plus dirty-range upload queueing.
+    UnlockRect,
+    /// `GetDC`: DIB section + memory DC build.
+    GetDc,
+    /// `ReleaseDC`: DC teardown and write-back.
+    ReleaseDc,
+    /// Everything else: getters, `IUnknown`, container walks.
+    Misc,
+}
+
 /// Per-draw snapshot dirty-mark gate whose redundant-skip rate the perf summary reports.
 ///
 /// Each variant indexes the `keys_gate_calls` / `keys_gate_skips` arrays:
@@ -310,6 +338,12 @@ pub struct ApiTimer {
     /// `start_device(Bind)` timer would, plus the per-`BindSubCategory`
     /// breakdown row. Always implies `device_sub == Some(Bind)`.
     bind_sub: Option<BindSubCategory>,
+    /// Set on `Surface`-category timers built via `start_surface`.
+    ///
+    /// Bumps both the top-level `Surface` bucket and a per-sub-category
+    /// breakdown row. Always implies `category == Surface` and
+    /// `device_sub == None`.
+    surface_sub: Option<SurfaceSubCategory>,
     /// The parent timer's `active_child_cycles` accumulator.
     ///
     /// Saved at `start` and restored (plus this timer's own `elapsed`) at
@@ -360,6 +394,7 @@ impl ApiTimer {
             category,
             device_sub: None,
             bind_sub: None,
+            surface_sub: None,
             saved_child_cycles,
             enabled,
         }
@@ -388,6 +423,7 @@ impl ApiTimer {
             category: ApiCategory::Device,
             device_sub: Some(sub),
             bind_sub: None,
+            surface_sub: None,
             saved_child_cycles,
             enabled,
         }
@@ -418,6 +454,7 @@ impl ApiTimer {
             category: ApiCategory::Device,
             device_sub: Some(DeviceSubCategory::Bind),
             bind_sub: Some(sub),
+            surface_sub: None,
             saved_child_cycles,
             enabled,
         }
@@ -427,6 +464,35 @@ impl ApiTimer {
     #[inline]
     #[must_use]
     pub const fn start_bind(_perf_ptr: *mut ApiPerfState, _sub: BindSubCategory) -> Self {
+        Self
+    }
+
+    /// Like `start(Surface)`, but tags the timer with a `SurfaceSubCategory`.
+    ///
+    /// On `Drop`, a single `rdtsc()` delta bumps the top-level `Surface`
+    /// bucket AND `surface_sub_cycles[sub]` in one pass. Used by every
+    /// `IDirect3DSurface9` vtable thunk (via `surf_timer`).
+    #[cfg(perf_tracking)]
+    pub fn start_surface(perf_ptr: *mut ApiPerfState, sub: SurfaceSubCategory) -> Self {
+        let enabled = !perf_ptr.is_null() && perf_enabled();
+        let saved_child_cycles = Self::enter_scope(perf_ptr, enabled);
+        let start = if enabled { rdtsc() } else { 0 };
+        Self {
+            start,
+            perf_ptr,
+            category: ApiCategory::Surface,
+            device_sub: None,
+            bind_sub: None,
+            surface_sub: Some(sub),
+            saved_child_cycles,
+            enabled,
+        }
+    }
+
+    #[cfg(not(perf_tracking))]
+    #[inline]
+    #[must_use]
+    pub const fn start_surface(_perf_ptr: *mut ApiPerfState, _sub: SurfaceSubCategory) -> Self {
         Self
     }
 }
@@ -493,6 +559,8 @@ impl Drop for ApiTimer {
             perf.add_bind_cycles(bind, self_time);
         } else if let Some(sub) = self.device_sub {
             perf.add_device_cycles(sub, self_time);
+        } else if let Some(sub) = self.surface_sub {
+            perf.add_surface_cycles(sub, self_time);
         } else {
             perf.add_api_cycles(self.category, self_time);
         }
@@ -648,6 +716,15 @@ struct FrameCounters {
     bind_sub_cycles: [u64; BindSubCategory::COUNT],
     /// Companion call-count array for `bind_sub_cycles`.
     bind_sub_calls: [u32; BindSubCategory::COUNT],
+    /// Per-sub-category cycle bucket inside the `Surface` `ApiCategory`.
+    ///
+    /// Bumped by `ApiTimer::start_surface` on every `IDirect3DSurface9`
+    /// vtable thunk; sums to `api_cycles_by_category[Surface]` within the
+    /// same frame. Splits the getter storm from the entry points that can
+    /// block (`LockRect` readback, `UnlockRect` upload, the GDI DC pair).
+    surface_sub_cycles: [u64; SurfaceSubCategory::COUNT],
+    /// Companion call-count array for `surface_sub_cycles`.
+    surface_sub_calls: [u32; SurfaceSubCategory::COUNT],
     /// Per-[`KeysGate`] live setter-call count this frame.
     ///
     /// Denominator for the redundant-skip rate in the perf summary.
@@ -732,6 +809,8 @@ impl FrameCounters {
             device_sub_calls: [0; DeviceSubCategory::COUNT],
             bind_sub_cycles: [0; BindSubCategory::COUNT],
             bind_sub_calls: [0; BindSubCategory::COUNT],
+            surface_sub_cycles: [0; SurfaceSubCategory::COUNT],
+            surface_sub_calls: [0; SurfaceSubCategory::COUNT],
             keys_gate_calls: [0; KeysGate::COUNT],
             keys_gate_skips: [0; KeysGate::COUNT],
             draw_snapshot_cycles: 0,
@@ -1100,6 +1179,25 @@ impl ApiPerfState {
         let cyc = &mut self.counters.bind_sub_cycles[idx];
         *cyc = cyc.saturating_add(cycles);
         let cnt = &mut self.counters.bind_sub_calls[idx];
+        *cnt = cnt.saturating_add(1);
+    }
+
+    /// Add cycles + one call to the `Surface` top and per-`SurfaceSubCategory` buckets.
+    ///
+    /// Both land under one `rdtsc()` delta supplied by
+    /// `ApiTimer::start_surface`. Sub-bucket sums equal the parent Surface
+    /// row by construction (`Misc` is the catch-all; every surface thunk
+    /// names a variant).
+    pub const fn add_surface_cycles(&mut self, sub: SurfaceSubCategory, cycles: u64) {
+        let top = &mut self.counters.api_cycles_by_category[ApiCategory::Surface as usize];
+        *top = top.saturating_add(cycles);
+        let top_cnt = &mut self.counters.api_call_counts_by_category[ApiCategory::Surface as usize];
+        *top_cnt = top_cnt.saturating_add(1);
+
+        let idx = sub as usize;
+        let cyc = &mut self.counters.surface_sub_cycles[idx];
+        *cyc = cyc.saturating_add(cycles);
+        let cnt = &mut self.counters.surface_sub_calls[idx];
         *cnt = cnt.saturating_add(1);
     }
 
@@ -2327,6 +2425,10 @@ struct PerfWindow {
     bind_sub_by: [Stat; BindSubCategory::COUNT],
     /// Per-`BindSubCategory` call counts (sum only).
     bind_sub_calls_by: [Stat; BindSubCategory::COUNT],
+    /// Per-`SurfaceSubCategory` bucket: sum + per-frame peak.
+    surface_sub_by: [Stat; SurfaceSubCategory::COUNT],
+    /// Per-`SurfaceSubCategory` call counts (sum only).
+    surface_sub_calls_by: [Stat; SurfaceSubCategory::COUNT],
     /// Per-[`KeysGate`] live setter calls / skips (sum only).
     keys_gate_calls_by: [Stat; KeysGate::COUNT],
     keys_gate_skips_by: [Stat; KeysGate::COUNT],
@@ -2522,6 +2624,10 @@ impl PerfWindow {
         for i in 0..BindSubCategory::COUNT {
             self.bind_sub_by[i].add(s.counters.bind_sub_cycles[i]);
             self.bind_sub_calls_by[i].add(u64::from(s.counters.bind_sub_calls[i]));
+        }
+        for i in 0..SurfaceSubCategory::COUNT {
+            self.surface_sub_by[i].add(s.counters.surface_sub_cycles[i]);
+            self.surface_sub_calls_by[i].add(u64::from(s.counters.surface_sub_calls[i]));
         }
         for i in 0..KeysGate::COUNT {
             self.keys_gate_calls_by[i].add(u64::from(s.counters.keys_gate_calls[i]));
@@ -3223,6 +3329,13 @@ impl<'a> Summary<'a> {
             if *cat as usize == ApiCategory::Device as usize {
                 self.write_device_sub_rows(out, present_ms);
             }
+            // Decompose `Surface` the same way: the row mixes a getter
+            // storm with the few entry points that can block for
+            // milliseconds, so a spiking peak was unattributable from
+            // the aggregate row alone.
+            if *cat as usize == ApiCategory::Surface as usize {
+                self.write_surface_sub_rows(out);
+            }
             // Nest `Wait for GPU` under `Query`: the raw Query bucket
             // accumulates every GetData / Issue / GetType call; the
             // FLUSH-on-Pending wait (Metal `waitUntilCompleted`) is
@@ -3535,6 +3648,55 @@ impl<'a> Summary<'a> {
                     aux: Some(format!("({calls:>10})")),
                     desc: Some(desc),
                     peak: Some(cycles_to_ms(w.bind_sub_by[idx].max)),
+                },
+            );
+        }
+    }
+
+    /// Render the per-`SurfaceSubCategory` rows nested under the `Surface` `ApiCategory`.
+    ///
+    /// Sums to the parent `Surface` row by construction — every
+    /// `IDirect3DSurface9` vtable thunk tags a variant via `surf_timer`,
+    /// with `Misc` as the catch-all.
+    fn write_surface_sub_rows(&self, out: &mut String) {
+        let w = self.w;
+        let f = u64::from(self.frames);
+        let s = &self.s;
+        let rows: &[(&str, SurfaceSubCategory, &str)] = &[
+            (
+                "LockRect",
+                SurfaceSubCategory::LockRect,
+                "map/rename/readback",
+            ),
+            (
+                "UnlockRect",
+                SurfaceSubCategory::UnlockRect,
+                "unmap + upload queue",
+            ),
+            ("GetDC", SurfaceSubCategory::GetDc, "DIB + memory DC"),
+            ("ReleaseDC", SurfaceSubCategory::ReleaseDc, "DC write-back"),
+            ("Misc", SurfaceSubCategory::Misc, "getters + IUnknown"),
+        ];
+        for (i, (name, sub, desc)) in rows.iter().enumerate() {
+            let branch = if i + 1 == rows.len() {
+                "└─"
+            } else {
+                "├─"
+            };
+            let idx = *sub as usize;
+            let label = format!("│  │  {branch} {name}");
+            let avg_ms = cycles_to_ms(w.surface_sub_by[idx].sum / f);
+            let calls = w.surface_sub_calls_by[idx].sum;
+            write_row(
+                out,
+                s,
+                &Row {
+                    label: &label,
+                    bold_label: false,
+                    ms: Some(avg_ms),
+                    aux: Some(format!("({calls:>10})")),
+                    desc: Some(desc),
+                    peak: Some(cycles_to_ms(w.surface_sub_by[idx].max)),
                 },
             );
         }

--- a/windows/core/src/perf/tests.rs
+++ b/windows/core/src/perf/tests.rs
@@ -232,7 +232,7 @@ fn summary_golden_layout() {
         "buckets: api_d3d9=2.80  api_outside=3.00  enc_work=1.50  submit_work=0.10  gpu_wait=6.00  (ms/frame, avg)\n",
         "\n",
         "API thread             10.00 ms                                             peak 10.00 ms\n",
-        "├─ D3D9 calls           4.00 ms   ( 40.0 %)           243 calls             peak  4.00 ms\n",
+        "├─ D3D9 calls           4.00 ms   ( 40.0 %)           263 calls             peak  4.00 ms\n",
         "│  ├─ Device            0.30 ms   (       123)                              peak  0.30 ms\n",
         "│  │  ├─ Frame          0.04 ms   (         3)                              peak  0.04 ms\n",
         "│  │  │  ├─ Send stall  3.20 ms                       encoder backpressure  peak  3.20 ms\n",
@@ -262,7 +262,12 @@ fn summary_golden_layout() {
         "│  ├─ VertexBuffer      0.20 ms   (        88)                              peak  0.20 ms\n",
         "│  ├─ IndexBuffer       0.08 ms   (        32)                              peak  0.08 ms\n",
         "│  ├─ Texture           0.00 ms   (         0)                              peak  0.00 ms\n",
-        "│  ├─ Surface           0.00 ms   (         0)                              peak  0.00 ms\n",
+        "│  ├─ Surface           0.04 ms   (        20)                              peak  0.04 ms\n",
+        "│  │  ├─ LockRect       0.02 ms   (         2)        map/rename/readback   peak  0.02 ms\n",
+        "│  │  ├─ UnlockRect     0.01 ms   (         2)        unmap + upload queue  peak  0.01 ms\n",
+        "│  │  ├─ GetDC          0.01 ms   (         1)        DIB + memory DC       peak  0.01 ms\n",
+        "│  │  ├─ ReleaseDC      0.00 ms   (         0)        DC write-back         peak  0.00 ms\n",
+        "│  │  └─ Misc           0.00 ms   (        15)        getters + IUnknown    peak  0.00 ms\n",
         "│  ├─ Query             0.00 ms   (         0)                              peak  0.00 ms\n",
         "│  │  └─ Wait for GPU   0.00 ms                       waitUntilCompleted    peak  0.00 ms\n",
         "│  ├─ StateBlock        0.00 ms   (         0)                              peak  0.00 ms\n",
@@ -411,9 +416,11 @@ fn sample_window() -> PerfWindow {
     cats[ApiCategory::Device as usize] = 300_000;
     cats[ApiCategory::VertexBuffer as usize] = 200_000;
     cats[ApiCategory::IndexBuffer as usize] = 80_000;
+    cats[ApiCategory::Surface as usize] = 40_000;
     calls[ApiCategory::Device as usize] = 123;
     calls[ApiCategory::VertexBuffer as usize] = 88;
     calls[ApiCategory::IndexBuffer as usize] = 32;
+    calls[ApiCategory::Surface as usize] = 20;
     // Decompose Device into sub-buckets; must sum to cats[Device]
     // = 300_000 to mirror the production invariant. Calls sum to
     // calls[Device] = 123.
@@ -460,6 +467,23 @@ fn sample_window() -> PerfWindow {
     bcalls[BindSubCategory::RtDs as usize] = 1;
     bcalls[BindSubCategory::FfFixed as usize] = 1;
     bcalls[BindSubCategory::ViewScissor as usize] = 0;
+    // Decompose the Surface category (40_000 cyc, 20 calls) into
+    // SurfaceSubCategory rows. Sums must match `cats[Surface]` exactly —
+    // every surface thunk tags a variant via `surf_timer`, with `Misc`
+    // as the catch-all. Multiples of 10_000 cycles round cleanly at
+    // `{:.2}` under runtime tsc_hz calibration.
+    let mut ssub = [0u64; SurfaceSubCategory::COUNT];
+    let mut scalls = [0u32; SurfaceSubCategory::COUNT];
+    ssub[SurfaceSubCategory::LockRect as usize] = 20_000;
+    ssub[SurfaceSubCategory::UnlockRect as usize] = 10_000;
+    ssub[SurfaceSubCategory::GetDc as usize] = 10_000;
+    ssub[SurfaceSubCategory::ReleaseDc as usize] = 0;
+    ssub[SurfaceSubCategory::Misc as usize] = 0;
+    scalls[SurfaceSubCategory::LockRect as usize] = 2;
+    scalls[SurfaceSubCategory::UnlockRect as usize] = 2;
+    scalls[SurfaceSubCategory::GetDc as usize] = 1;
+    scalls[SurfaceSubCategory::ReleaseDc as usize] = 0;
+    scalls[SurfaceSubCategory::Misc as usize] = 15;
     let s = FrameSample {
         counters: FrameCounters {
             api_cycles_by_category: cats,
@@ -503,6 +527,8 @@ fn sample_window() -> PerfWindow {
             device_sub_calls: dcalls,
             bind_sub_cycles: bsub,
             bind_sub_calls: bcalls,
+            surface_sub_cycles: ssub,
+            surface_sub_calls: scalls,
             keys_gate_calls: [0; KeysGate::COUNT],
             keys_gate_skips: [0; KeysGate::COUNT],
             // snapshot dominates the Draws bucket; split inside it

--- a/windows/d3d9/src/surface.rs
+++ b/windows/d3d9/src/surface.rs
@@ -1,7 +1,7 @@
 use core::ffi::c_void;
 
 use log::trace;
-use mtld3d_core::page_box::PageBox;
+use mtld3d_core::{page_box::PageBox, perf::SurfaceSubCategory};
 use mtld3d_shared::{
     BlitTextureToBufferParams, InPtr, InPtrMut, MetalHandle, ValueIn, VtableThis,
     mtl_handle::MTLTextureKind,
@@ -1021,14 +1021,14 @@ impl SurfaceInner {
 // ── IUnknown ──
 
 #[inline]
-fn surf_timer(this: *mut c_void) -> mtld3d_core::perf::ApiTimer {
-    use mtld3d_core::perf::{ApiCategory, ApiTimer};
+fn surf_timer(this: *mut c_void, sub: SurfaceSubCategory) -> mtld3d_core::perf::ApiTimer {
+    use mtld3d_core::perf::ApiTimer;
     // SAFETY: vtable thunk; `this` is *mut Direct3DSurface9 per IDirect3DSurface9 ABI.
     let perf_ptr = (unsafe { InPtr::<Direct3DSurface9>::opt(this) })
         .map_or(core::ptr::null_mut(), |obj| {
             crate::device::DeviceInner::perf_ptr_of(obj.inner().device_inner)
         });
-    ApiTimer::start(perf_ptr, ApiCategory::Surface)
+    ApiTimer::start_surface(perf_ptr, sub)
 }
 
 extern "system" fn surface_query_interface(
@@ -1036,7 +1036,7 @@ extern "system" fn surface_query_interface(
     riid: *const Guid,
     ppv: *mut *mut c_void,
 ) -> i32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     // SAFETY: vtable thunk; `this`, `riid` and `ppv` are the caller's per the
     // IUnknown::QueryInterface ABI.
     unsafe {
@@ -1072,7 +1072,7 @@ unsafe fn container_forward_texture(this: *mut c_void) -> *mut Direct3DTexture9 
 }
 
 extern "system" fn surface_add_ref(this: *mut c_void) -> u32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     // SAFETY: IDirect3DSurface9 AddRef thunk; `this` is the live wrapper.
     let tex = unsafe { container_forward_texture(this) };
     if tex.is_null() {
@@ -1095,7 +1095,7 @@ extern "system" fn surface_add_ref(this: *mut c_void) -> u32 {
 }
 
 extern "system" fn surface_release(this: *mut c_void) -> u32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     // SAFETY: IDirect3DSurface9 Release thunk; `this` is the live wrapper.
     let tex = unsafe { container_forward_texture(this) };
     if tex.is_null() {
@@ -1411,7 +1411,7 @@ unsafe impl crate::com_ref::ComChild for Direct3DSurface9 {
 // ── IDirect3DResource9 stubs ──
 
 extern "system" fn surface_get_device(this: *mut c_void, device: *mut *mut c_void) -> i32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     trace!(target: LOG_TARGET, "IDirect3DSurface9::GetDevice()");
     // SAFETY: vtable thunk; `this` is *mut Direct3DSurface9 per IDirect3DSurface9 ABI.
     unsafe { crate::com_ref::com_get_device::<Direct3DSurface9>(this, device) }
@@ -1424,7 +1424,7 @@ extern "system" fn surface_set_private_data(
     size: u32,
     flags: u32,
 ) -> i32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     // SAFETY: vtable in-param; `guid` is *const Guid per IDirect3DResource9 ABI.
     let Some(guid) = (unsafe { InPtr::<Guid>::opt(guid.cast()) }) else {
         return D3DERR_INVALIDCALL;
@@ -1448,7 +1448,7 @@ extern "system" fn surface_get_private_data(
     data: *mut c_void,
     size: *mut u32,
 ) -> i32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     // SAFETY: vtable in-param; `guid` is *const Guid per IDirect3DResource9 ABI.
     let Some(guid) = (unsafe { InPtr::<Guid>::opt(guid.cast()) }) else {
         return D3DERR_INVALIDCALL;
@@ -1463,7 +1463,7 @@ extern "system" fn surface_get_private_data(
 }
 
 extern "system" fn surface_free_private_data(this: *mut c_void, guid: *const Guid) -> i32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     // SAFETY: vtable in-param; `guid` is *const Guid per IDirect3DResource9 ABI.
     let Some(guid) = (unsafe { InPtr::<Guid>::opt(guid.cast()) }) else {
         return D3DERR_INVALIDCALL;
@@ -1479,7 +1479,7 @@ extern "system" fn surface_free_private_data(this: *mut c_void, guid: *const Gui
 }
 
 extern "system" fn surface_set_priority(this: *mut c_void, _priority: u32) -> u32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     mtld3d_shared::log_once_info!(
         target: crate::LOG_TARGET,
         "IDirect3DSurface9::SetPriority: no Metal analog, no-op"
@@ -1488,7 +1488,7 @@ extern "system" fn surface_set_priority(this: *mut c_void, _priority: u32) -> u3
 }
 
 extern "system" fn surface_get_priority(this: *mut c_void) -> u32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     mtld3d_shared::log_once_info!(
         target: crate::LOG_TARGET,
         "IDirect3DSurface9::GetPriority: no Metal analog, no-op"
@@ -1497,7 +1497,7 @@ extern "system" fn surface_get_priority(this: *mut c_void) -> u32 {
 }
 
 extern "system" fn surface_pre_load(this: *mut c_void) {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     // See IDirect3DTexture9::PreLoad — Metal has no resident-set hint.
     mtld3d_shared::log_once_info!(
         target: crate::LOG_TARGET,
@@ -1506,7 +1506,7 @@ extern "system" fn surface_pre_load(this: *mut c_void) {
 }
 
 extern "system" fn surface_get_type(this: *mut c_void) -> u32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     trace!(target: LOG_TARGET, "IDirect3DSurface9::GetType()");
     1 // D3DRTYPE_SURFACE
 }
@@ -1535,7 +1535,7 @@ extern "system" fn surface_get_container(
     riid: *const Guid,
     container: *mut *mut c_void,
 ) -> i32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     if container.is_null() {
         return D3DERR_INVALIDCALL;
     }
@@ -1606,7 +1606,7 @@ extern "system" fn surface_get_container(
 }
 
 extern "system" fn surface_get_desc(this: *mut c_void, desc: *mut D3DSURFACE_DESC) -> i32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::Misc);
     // SAFETY: vtable thunk; `this` is *mut Direct3DSurface9 per IDirect3DSurface9 ABI.
     let Some(obj) = (unsafe { InPtr::<Direct3DSurface9>::opt(this) }) else {
         return D3DERR_INVALIDCALL;
@@ -1661,7 +1661,7 @@ extern "system" fn surface_lock_rect(
     rect: *const c_void,
     flags: u32,
 ) -> i32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::LockRect);
     if locked_rect.is_null() {
         return D3DERR_INVALIDCALL;
     }
@@ -1764,7 +1764,7 @@ extern "system" fn surface_lock_rect(
 }
 
 extern "system" fn surface_unlock_rect(this: *mut c_void) -> i32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::UnlockRect);
     // SAFETY: vtable thunk; `this` is *mut Direct3DSurface9 per IDirect3DSurface9 ABI.
     let Some(obj) = (unsafe { InPtr::<Direct3DSurface9>::opt(this) }) else {
         return D3DERR_INVALIDCALL;
@@ -2475,7 +2475,7 @@ impl SurfaceInner {
 }
 
 extern "system" fn surface_get_dc(this: *mut c_void, hdc: *mut *mut c_void) -> i32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::GetDc);
     if hdc.is_null() {
         return D3DERR_INVALIDCALL;
     }
@@ -2583,7 +2583,7 @@ extern "system" fn surface_get_dc(this: *mut c_void, hdc: *mut *mut c_void) -> i
 }
 
 extern "system" fn surface_release_dc(this: *mut c_void, hdc: *mut c_void) -> i32 {
-    let _timer = surf_timer(this);
+    let _timer = surf_timer(this, SurfaceSubCategory::ReleaseDc);
     // SAFETY: vtable thunk; `this` is *mut Direct3DSurface9 per IDirect3DSurface9 ABI.
     let Some(obj) = (unsafe { InPtrMut::<Direct3DSurface9>::opt(this) }) else {
         return D3DERR_INVALIDCALL;


### PR DESCRIPTION
## Symptoms

Issue #67: a 43.8 ms frame spent in `IDirect3DSurface9` calls in an otherwise healthy Stormwind window, unattributable because the `Surface` row aggregates a getter storm (tens of thousands of near-free calls per window) with the few entry points that can block for milliseconds. The same signature (~52 ms peaks) reappeared in the 2026-08-27 cursor-hitch investigation and could not be pinned there either.

## Changes

Every `IDirect3DSurface9` vtable thunk now tags its `ApiTimer` with a `SurfaceSubCategory` through `surf_timer`, accumulated the same way the `Bind` sub-buckets are and rendered as nested rows under `Surface`: `LockRect` (map / staging rename / synchronous backbuffer readback), `UnlockRect` (unmap + upload queueing), `GetDC`, `ReleaseDC`, and `Misc` as the catch-all, so the sub-rows sum exactly to the parent row.

Sample from a live window:

```
│  ├─ Surface           0.00 ms   (     18034)                              peak  0.01 ms
│  │  ├─ LockRect       0.00 ms   (       282)        map/rename/readback   peak  0.00 ms
│  │  ├─ UnlockRect     0.00 ms   (       282)        unmap + upload queue  peak  0.00 ms
│  │  ├─ GetDC          0.00 ms   (         0)        DIB + memory DC       peak  0.00 ms
│  │  ├─ ReleaseDC      0.00 ms   (         0)        DC write-back         peak  0.00 ms
│  │  └─ Misc           0.00 ms   (     17470)        getters + IUnknown    peak  0.00 ms
```

## Alternatives considered

A `RUST_LOG` run over the surface targets (the fallback #67 names) would attribute one occurrence but leaves the row coarse for the next one; the split answers it permanently and mirrors the existing `Bind` decomposition, so no new reporting machinery.

## Verification

`make check` green. `make test` green (both e2e legs; x86_64 273/273). The perf golden-layout test gained a populated Surface decomposition (40k cycles over 20 calls across the sub-buckets) so the row arithmetic and layout are pinned. A PERF=1 in-game session on this branch produced the window above; the ~52 ms Surface peaks did not recur in that session (they are scenario-dependent), so the attribution of #67's frame itself stays open until it fires again with the split in place.