### PR TITLE
Drop the unreachable cube-face release in finalize_surface

### DIFF
--- a/windows/d3d9/src/surface.rs
+++ b/windows/d3d9/src/surface.rs
@@ -337,13 +337,21 @@ impl Direct3DSurface9 {
     /// Cube face surface backed by its parent cube subresource.
     ///
     /// Container-cached exactly like [`Self::new_texture_backed`], keyed by
-    /// `(face, mip_level)`.
+    /// `(face, mip_level)`. The owning cube is recorded twice: as
+    /// `parent_texture`, which carries extent, format and the refcount
+    /// forwarding every sub-surface does, and as `state_owner_texture`, the
+    /// resource-wide lock/DC state all six faces share. Both are the same
+    /// pointer, so a face never has one without the other.
     pub fn new_cube_texture_backed(
         device_inner: *mut DeviceInner,
         parent_texture: *mut Direct3DTexture9,
         face: u32,
         mip_level: u32,
     ) -> Self {
+        debug_assert!(
+            !parent_texture.is_null(),
+            "cube face surface created without its owning cube texture"
+        );
         let inner = Box::into_raw(Box::new(SurfaceInner {
             device_inner,
             parent_texture,
@@ -833,13 +841,17 @@ struct SurfaceInner {
     /// upload on unlock (the staging was filled by a read-back, never written,
     /// so re-uploading it would clobber the rendered pixels). `0` otherwise.
     lock_flags: u32,
-    /// Non-null for a cube-map face shell.
+    /// Non-null for a cube-map face shell, where it equals `parent_texture`.
     ///
     /// The owning cube `Direct3DTexture9`, whose `TextureInner` carries the
     /// per-resource lock/DC state shared by all six faces (D3D9 gates the whole
-    /// cube, not the individual face). The face holds a reference on it (taken
-    /// by `GetCubeMapSurface`) so it outlives the face; the face's finalize
-    /// releases it. Null for every other surface.
+    /// cube, not the individual face). A face is constructed with both this
+    /// field and `parent_texture` pointing at that cube, so neither is ever null
+    /// alone. The cube outlives the face: each reference `GetCubeMapSurface`
+    /// takes on it is dropped by the container forwarding in `surface_release`,
+    /// and the face itself is freed from inside the cube's own teardown
+    /// (`finalize_texture`), so nothing is released here on the face's behalf.
+    /// Null for every other surface.
     state_owner_texture: *mut Direct3DTexture9,
 }
 
@@ -874,9 +886,9 @@ impl SurfaceInner {
             return &raw mut self.dc_lock;
         }
         // SAFETY: `state_owner_texture` is the owning cube `Direct3DTexture9`,
-        // kept alive by the reference this face holds (released only at the
-        // face's finalize); D3D9 objects are single-threaded so the exclusive
-        // borrow of its inner state is sound for this call.
+        // which outlives every face it hands out (a face is freed only from
+        // inside the cube's own teardown); D3D9 objects are single-threaded so
+        // the exclusive borrow of its inner state is sound for this call.
         let tex = unsafe { &*self.state_owner_texture };
         tex.dc_lock_state_ptr()
     }
@@ -888,14 +900,15 @@ impl SurfaceInner {
     /// `GetDC` anywhere on the resource blocks it; so does this surface already
     /// being mapped (same-face double-lock).
     fn try_begin_lock(&mut self) -> Result<(), i32> {
-        // A cube-face surface shares the level's lock with its parent cube
-        // texture: if the level is already locked through the cube's own
-        // `LockRect`, locking the face surface is INVALIDCALL. Cube faces carry
-        // the parent only as `state_owner_texture` (parent_texture is null), so
-        // the texture-level delegation in `surface_lock_rect` doesn't see it.
+        // A cube face and its parent cube map one subresource through two
+        // objects, so a face lock has to see the cube's per-subresource lock
+        // state: a level already locked through the cube's own `LockRect` makes
+        // locking the face INVALIDCALL. Checked before this surface records
+        // anything, so a rejected lock leaves the per-face flag and the shared
+        // map count untouched.
         if !self.state_owner_texture.is_null() {
-            // SAFETY: `state_owner_texture` is the live owning cube texture set
-            // by `set_cube_state_owner`; single-threaded access is sound.
+            // SAFETY: `state_owner_texture` is the owning cube texture, set at
+            // construction and outliving the face; single-threaded access is sound.
             let cube = unsafe { &*self.state_owner_texture };
             if cube
                 .inner()
@@ -1166,20 +1179,19 @@ unsafe fn finalize_surface(this: *mut Direct3DSurface9) {
         !inner.flags.contains(SurfaceFlags::CONTAINER_CACHED),
         "container-cached sub-resource surface finalized outside its container's teardown"
     );
-    let owner_tex = inner.state_owner_texture;
-    if owner_tex.is_null() {
+    // A cube face has nothing of the cube to give back here. The reference
+    // `GetCubeMapSurface` took on it is dropped by the container forwarding in
+    // `surface_release`, and the face's DC lives on the shared cube state, torn
+    // down when the cube itself finalizes. A face only ever reaches this point
+    // from inside that teardown (`finalize_texture` calls
+    // `finalize_cached_surface` with the cube's inner state borrowed and about
+    // to be freed), so calling back into the cube from here would re-enter an
+    // object mid-teardown.
+    if inner.state_owner_texture.is_null() {
         // A standalone surface released while a `GetDC` is still outstanding
         // (the app skipped `ReleaseDC`) would leak its memory DC + DIB; tear
-        // them down. (A cube face's DC lives on the shared cube state, torn
-        // down when the cube texture itself finalizes — the cube outlives every
-        // face that references it, so no face frees the shared DC here.)
+        // them down.
         teardown_gdi_dc(inner.dc_lock.held_dc);
-    } else if inner.parent_texture.is_null() {
-        // SAFETY: `owner_tex` is the cube `Direct3DTexture9` whose reference
-        // this face took at `GetCubeMapSurface`; drop it to balance that AddRef.
-        let release = unsafe { (*owner_tex).vtbl().release };
-        // SAFETY: `release` is the texture's IUnknown::Release thunk.
-        unsafe { release(owner_tex.cast::<c_void>()) };
     }
     // Release the internal texture an owned offscreen-plain surface holds. The
     // surface took over the texture's single create-ref, so this drops it to


### PR DESCRIPTION
## Symptoms

No user-visible symptom. `finalize_surface` carries a branch that cannot execute, and four comments around the cube-face lifetime describe a surface shape no constructor produces, including one that names a function (`set_cube_state_owner`) that does not exist in the tree.

## Root cause

`finalize_surface` branched on `state_owner_texture`: null took the GDI teardown, non-null with a null `parent_texture` released the owning cube "to balance that AddRef". The second branch needs a surface with `state_owner_texture` set and `parent_texture` null. `new_cube_texture_backed` is the only site that sets `state_owner_texture`, and it sets it from the same argument it stores in `parent_texture` a few lines earlier, so a cube face always has both. Every other constructor leaves `state_owner_texture` null. The branch is therefore dead, and dead is what keeps the refcounting correct: the reference `GetCubeMapSurface` takes on the cube is balanced by `surface_release`'s container forwarding, which calls `com_release::<Direct3DTexture9>` whenever `container_forward_texture` is non-null. Releasing again from `finalize_surface` would be a second drop of that same reference, and re-entrant on top of it: a cube face is `CONTAINER_CACHED`, so its only finalize site is `finalize_texture` calling `finalize_cached_surface` inside the cube's own teardown, with the cube's `TextureInner` borrowed and about to be freed.

The comments encoded the same absent shape. `try_begin_lock` claimed cube faces carry the parent only as `state_owner_texture` with `parent_texture` null, and that the texture-level delegation in `surface_lock_rect` cannot see it; in fact that delegation is exactly what routes a face lock to `cube_lock_rect`. The `state_owner_texture` field doc and the `dc_lock_ptr` SAFETY comment both said the face's own finalize releases the cube reference, and a cube face has no finalize of its own.

## Changes

`windows/d3d9/src/surface.rs`: remove the unreachable `else if inner.parent_texture.is_null()` arm from `finalize_surface`, leaving the standalone-surface GDI teardown as the only case, with a comment stating why a cube face gives nothing back at that point. Rewrite the `state_owner_texture` field doc, the `dc_lock_ptr` SAFETY comment and the `try_begin_lock` guard comment to describe the constructed model: a face holds the cube in both fields, reaches it through `parent_texture` for extent, format and refcount forwarding and through `state_owner_texture` for the shared lock/DC state, and is freed from inside the cube's teardown. Record the invariant where it is established: `new_cube_texture_backed` documents that both fields are the same pointer and `debug_assert!`s that the cube it is handed is non-null. The release profiles keep `debug-assertions` on, so that assert runs in the end-to-end suite.

## Alternatives

Repair the branch into reachability by nulling `parent_texture` for a cube face: rejected, it would break refcount forwarding, extent and format resolution, and the face lock path, all of which read the parent.

Keep the branch as defensive cover for a future constructor: rejected, it is not cover but a hazard. Reaching it would double-release the cube and do so re-entrantly during the cube's own teardown.

Leave the code and fix only the comments: rejected, the comments are wrong precisely because they describe the branch's premise, so the two have to move together.

## Verification

`make check` green (fmt, clippy on both PE targets and native, `audit: clean (232 files)`, doc). `make test` green: 776 `mtld3d-core` unit tests, 125 unix-side tests, and both end-to-end architectures at 281/281, 0 FAIL, 0 SIGABRT, 0 TIMEOUT (3 leaky on i686, 2 on x86_64, benign). Conformance is untouched: no render, state or shader-emission path changes.

The change removes dead code and cannot fail a test that passed before, so there is no fail-then-pass proof to give. The regression net is the existing cube coverage, which exercises the finalize path and now also the new assert on both architectures: `subresource_identity::cube_face_surface_has_one_identity` (a face released to refcount zero, re-acquired as the same object, and finally freed through `finalize_texture` at the cube's teardown), `textures::managed_dxt_cube_keeps_faces_independent` (a face handle taken and dropped while the cube stays alive), and `textures::cube_render_target_faces_generate_mips_independently` (two face surfaces used as render targets across the cube's lifetime).

Closes #58
