### PR TITLE
Judge Rule A's depth first-use discard by the depth extent

### DIFF
--- a/windows/core/src/passes.rs
+++ b/windows/core/src/passes.rs
@@ -1996,7 +1996,12 @@ impl PassState {
         // survive) need `Load` so prior content carries forward — real
         // D3D9 drivers preserve depth content across frames; MTLD3D
         // must match.
-        let viewport_covers_attachment = vpx == 0
+        //
+        // Each plane is judged against its own attachment's extent. D3D9 only
+        // requires the depth-stencil surface to be at least as large as the
+        // render target, so a viewport that covers render target 0 exactly can
+        // still leave a larger depth surface partly un-rendered.
+        let viewport_covers_color_extent = vpx == 0
             && vpy == 0
             && vpw == self.current_color_size.0
             && vph == self.current_color_size.1;
@@ -2008,7 +2013,7 @@ impl PassState {
             |texture: MetalHandle<MTLTextureKind>, subresource: u32| match pending_color_clear {
                 Some((r, g, b, a)) => ColorLoad::Clear { r, g, b, a },
                 None if ENABLE_FIRST_USE_DONTCARE
-                    && viewport_covers_attachment
+                    && viewport_covers_color_extent
                     && !texture.is_null()
                     && !self.seen_color_rts.contains(&(texture, subresource))
                     && !self.seen_sampled_textures.contains(&texture)
@@ -2035,8 +2040,11 @@ impl PassState {
         });
         // The depth texture's first use this frame under a viewport that
         // covers it: the Rule A predicate, shared by the depth plane and the
-        // stencil plane because both live in that one texture.
-        let depth_first_use = viewport_covers_attachment
+        // stencil plane because both live in that one texture. Coverage is
+        // measured against the depth attachment's own extent, greater-or-equal
+        // because D3D9 clips the viewport to the render target, so an oversized
+        // viewport still covers everything the pass can write.
+        let depth_first_use = self.viewport_covers_depth_attachment()
             && !self.current_depth_texture.is_null()
             && !self
                 .current_attachments

--- a/windows/core/src/passes/tests.rs
+++ b/windows/core/src/passes/tests.rs
@@ -1158,6 +1158,44 @@ fn rule_a_reset_frame_re_arms_dontcare() {
 }
 
 #[test]
+fn rule_a_depth_wider_than_the_rt_loads_on_first_use() {
+    // D3D9 only requires the depth-stencil surface to be at least as large as
+    // the render target, so a larger one is legal. Under a viewport that covers
+    // render target 0 exactly, the pass cannot write the depth surface outside
+    // that area, so its first use in the frame must Load rather than discard
+    // what the surface holds there. The stencil plane rides the same texture.
+    let rt = tex(0x3000);
+    let ds = tex(0x3300);
+    let mut s = fresh();
+    s.set_color_render_target(rt, 256, 256, RT_FORMAT, RenderScale::IDENTITY);
+    s.set_depth_stencil_attachment(ds, (512, 512), false, true);
+    s.set_viewport(0, 0, 256, 256, 0.0, 1.0);
+    s.emit_command(dummy_draw());
+    assert_eq!(s.passes().len(), 1);
+    assert_eq!(s.passes()[0].depth_load(), DepthLoad::Load);
+    assert_eq!(s.passes()[0].stencil_load(), StencilLoad::Load);
+    // The colour plane is judged against its own extent and keeps the discard.
+    assert_eq!(s.passes()[0].color_load(), ColorLoad::DontCare);
+}
+
+#[test]
+fn rule_a_depth_matching_the_rt_still_discards_on_first_use() {
+    // The counterpart to the oversized case: a depth surface the viewport does
+    // cover keeps Rule A's first-use discard, so measuring the depth plane
+    // against its own extent costs nothing in the common shape.
+    let rt = tex(0x3000);
+    let ds = tex(0x3300);
+    let mut s = fresh();
+    s.set_color_render_target(rt, 256, 256, RT_FORMAT, RenderScale::IDENTITY);
+    s.set_depth_stencil_attachment(ds, (256, 256), false, true);
+    s.set_viewport(0, 0, 256, 256, 0.0, 1.0);
+    s.emit_command(dummy_draw());
+    assert_eq!(s.passes().len(), 1);
+    assert_eq!(s.passes()[0].depth_load(), DepthLoad::DontCare);
+    assert_eq!(s.passes()[0].stencil_load(), StencilLoad::DontCare);
+}
+
+#[test]
 fn rule_a_first_use_stencil_is_dontcare_and_later_use_loads() {
     // The stencil plane lives in the depth texture, so it takes the
     // first-use DontCare under the depth predicate. A second pass on the


### PR DESCRIPTION
## Symptoms

A depth-stencil surface larger than render target 0 can lose its content outside the render target's area. The failure is silent: nothing logs, and the result is stale or discarded depth (and stencil, which shares the texture) wherever something later reads the region the smaller render target never covered. Reaching it needs all three of a depth surface larger than render target 0, that texture's first use in a frame, and a later read of the region outside the render target, which is why no game report is attached to it.

## Root cause

`ensure_pass_open` computed a single coverage boolean from the colour attachment alone, `vpx == 0 && vpy == 0 && vpw == current_color_size.0 && vph == current_color_size.1`, and used it verbatim as the first term of `depth_first_use`, which gates `DepthLoad::DontCare` and, through the same flag, `StencilLoad::DontCare`. D3D9 only requires the depth-stencil surface to be at least as large as the render target, and wined3d enforces exactly that direction (`wined3d/device.c` returns `D3DERR_CONFLICTINGRENDERSTATE` when the depth stencil is smaller than the colour buffer), so a larger depth surface is legal. Under a viewport matching render target 0 the colour predicate is true, so Rule A chose `DontCare` for a viewport that leaves part of the depth surface un-rendered, discarding whatever it held there. This is the hazard the comment above the predicate already describes for the shared cascade atlas, one step removed: `depth.aliasSameSize` exists to support one depth surface shared with differently scoped rendering, which is how the shape becomes reachable.

The opposite asymmetry was present but only forfeited the optimisation: the colour predicate is strict equality, so an oversized viewport, which D3D9 clips to the render target and which Wine's `test_viewport` uses at 1280x960, 2000x1600 and 8192x8192 on a 640x480 target, dropped Rule A to `Load`.

## Changes

`windows/core/src/passes.rs`: the first term of `depth_first_use` is now `viewport_covers_depth_attachment`, which measures the same effective viewport against the bound depth level's own extent (`current_depth_size`) with the greater-or-equal shape the clear-fold path already uses, so an oversized viewport still counts as covering. The stencil plane keeps following the depth plane, since both live in one texture. The colour local keeps its strict-equality shape and is renamed to `viewport_covers_color_extent` to say which extent it measures, and the comment above it records that each plane is judged against its own attachment.

`windows/core/src/passes/tests.rs`: two cases in the Rule A section, one per direction of the predicate.

## Alternatives

Widen the shared predicate to `max(colour extent, depth extent)`: rejected, it answers neither plane's question and would hand the colour plane a `Load` it does not need whenever the depth surface is the larger one.

Make the colour predicate greater-or-equal in the same change so an oversized viewport stops forfeiting Rule A on colour: rejected as a separate change, it is a performance question rather than the correctness bug, and it moves behaviour on a path this change does not otherwise touch.

Drop Rule A for the depth plane whenever the depth and colour extents differ: rejected, it forfeits the discard for the legal and common case of a depth surface the viewport does cover.

## Verification

`make check` clean. `make test` green: 778 native core unit tests, 125 conformance-crate unit tests, and 281 end-to-end tests per architecture, i686 and x86_64, with 0 FAIL, 0 SIGABRT, 0 TIMEOUT and 5 benign LEAK lines across the two legs.

`make conformance` reports no regressions on either architecture. The only movement is on known flaky and ceiling sites (`device.c:4475`, `device.c:4480` and `device.c:15088`, each 1 to 0, tolerated), so the baseline is not re-recorded.

`rule_a_depth_wider_than_the_rt_loads_on_first_use` fails before the change (`left: DontCare, right: Load` on the depth plane) and passes after. `rule_a_depth_matching_the_rt_still_discards_on_first_use` passes both before and after, and pins that the optimisation is kept where the viewport does cover the depth surface.

Closes #60
