### PR TITLE
Keep the ColorFill pass off the sRGB views

### DIFF
--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -3919,8 +3919,13 @@ impl FrameEncoder {
             .set_depth_stencil_attachment(MetalHandle::NULL, (0, 0), false, false);
         self.pass_state.set_viewport(rx, ry, rw, rh, 0.0, 1.0);
         self.pass_state.note_color_read_back(fill.texture);
+        // `ColorFill` writes the colour bytes verbatim, so the fill pass
+        // attaches the base view and applies no encode whatever
+        // `D3DRS_SRGBWRITEENABLE` the game left set. The next draw or `Clear`
+        // re-applies the game's state to the pass it opens.
+        self.pass_state.set_srgb_write_enabled(false);
         let (r, g, b, a) = fill.rgba;
-        self.clear_color_bounded_to_viewport(r, g, b, a);
+        self.clear_color_bounded_to_viewport(r, g, b, a, false);
         // A folded fill is still only a pending clear; materialise it here so
         // it lands on this destination rather than on the restored one.
         self.pass_state.ensure_pass_open();


### PR DESCRIPTION
## Symptoms

`main` at `d56c909` does not build: `error[E0061]: this method takes 5 arguments but 4 arguments were supplied` at `windows/d3d9/src/encoder.rs`, the `clear_color_bounded_to_viewport` call inside the GPU `ColorFill` pass.

## Root cause

The GPU `ColorFill` pass (#159) and the sRGB attachment-view swap (#178) landed independently. The swap added an `srgb_write` parameter to the clear helpers; the fill pass predates it and was merged without a compile check after its rebase.

## Changes

`windows/d3d9/src/encoder.rs`: the fill pass forces the sRGB write state off before binding its destination, the same rule the scaling StretchRect pass follows, and passes no encode to the clear. `ColorFill` writes the colour bytes verbatim in D3D9, so this is the semantics, not only the compile fix; the next draw or `Clear` re-applies the game's state to the pass it opens.

## Alternatives

Pass the game's state through: rejected, a fill is a byte write and must not be gamma-encoded, and the fill's own pass must attach the base view so the pipeline and the attachment agree.

## Verification

`cargo clippy --target i686-pc-windows-msvc` clean, `mtld3d-core` unit tests 838 passed; the ColorFill and sRGB-write end-to-end tests run in CI on this PR.
