### PR TITLE
End the pass when a colour rebind changes format or extent

### DIFF
--- a/windows/core/src/passes.rs
+++ b/windows/core/src/passes.rs
@@ -1605,8 +1605,8 @@ impl PassState {
     /// Bind or unbind render target `slot` (1..=3) for the next pass.
     ///
     /// Mirrors `set_color_render_target_subresource`: a rebind of the same
-    /// texture and subresource refreshes the size and format in place, any
-    /// other change materialises a pending colour clear and ends the pass.
+    /// texture, subresource, format and extent is a no-op, any other change
+    /// materialises a pending colour clear and ends the pass.
     /// `slot.logical_size` is the D3D9-reported extent; the stored `size` is
     /// what `slot.scale` makes of it.
     pub fn set_extra_color_render_target(&mut self, slot: usize, binding: Option<ExtraColorSlot>) {
@@ -1617,7 +1617,11 @@ impl PassState {
         );
         let index = slot - 1;
         let current = &self.current_extra_color[index];
-        if current.texture == binding.texture && current.subresource == binding.subresource {
+        if current.texture == binding.texture
+            && current.subresource == binding.subresource
+            && current.format == binding.format
+            && current.size == binding.size
+        {
             self.current_extra_color[index] = binding;
             self.recompute_extra_present_mask();
             return;
@@ -2509,8 +2513,8 @@ impl PassState {
 
     /// Rebind the color attachment for the next pass.
     ///
-    /// No-op if the new texture matches the current one (games often re-assert
-    /// the backbuffer between scenes).
+    /// No-op if the new texture, subresource, format and extent all match what
+    /// is bound (games often re-assert the backbuffer between scenes).
     ///
     /// Only flushes pending clears when a *color* clear is pending: the
     /// color attachment is about to change, so the pending color clear
@@ -2556,11 +2560,15 @@ impl PassState {
         let (width, height) = (scale.dimension(width), scale.dimension(height));
         let (slice, level) = subresource;
         let packed_subresource = slice | (level << 8);
+        // A pass freezes the attachment's format and extent when it opens, so
+        // the binding is only unchanged when both still match: a same-handle
+        // rebind that moves either one leaves the descriptor carrying one pair
+        // while the draws that follow build their pipelines against the other.
         if self.current_color_texture == texture
             && self.current_color_subresource == packed_subresource
+            && self.current_color_format == format
+            && self.current_color_size == (width, height)
         {
-            self.current_color_size = (width, height);
-            self.current_color_format = format;
             if self.has_extra_color_targets() {
                 self.recompute_extra_present_mask();
             } else {

--- a/windows/core/src/passes/tests.rs
+++ b/windows/core/src/passes/tests.rs
@@ -623,6 +623,43 @@ fn color_format_propagates_per_pass() {
 }
 
 #[test]
+fn rebinding_the_same_target_with_a_new_format_breaks_the_pass() {
+    const OTHER_FORMAT: PixelFormat = PixelFormat::Rgba16Float;
+    let rt = tex(0x3000);
+    // Handle and subresource unchanged, pixel format not. The open pass
+    // froze the old format in its attachment descriptor, so it has to
+    // close: otherwise the next draw builds a pipeline declaring the new
+    // format against a pass attaching the old one.
+    let mut s = fresh();
+    s.set_color_render_target(rt, 256, 256, RT_FORMAT, RenderScale::IDENTITY);
+    s.emit_command(dummy_draw());
+    s.set_color_render_target(rt, 256, 256, OTHER_FORMAT, RenderScale::IDENTITY);
+    s.emit_command(dummy_draw());
+
+    assert_eq!(s.passes().len(), 2);
+    assert_eq!(s.passes()[0].color_texture(), rt);
+    assert_eq!(s.passes()[1].color_texture(), rt);
+    assert_eq!(s.passes()[0].color_format(), RT_FORMAT);
+    assert_eq!(s.passes()[1].color_format(), OTHER_FORMAT);
+}
+
+#[test]
+fn rebinding_the_same_target_with_a_new_extent_breaks_the_pass() {
+    let rt = tex(0x3000);
+    // The extent is frozen at pass open too: it sizes the attachment and
+    // decides Rule A's full-attachment-write predicate.
+    let mut s = fresh();
+    s.set_color_render_target(rt, 256, 256, RT_FORMAT, RenderScale::IDENTITY);
+    s.emit_command(dummy_draw());
+    s.set_color_render_target(rt, 128, 128, RT_FORMAT, RenderScale::IDENTITY);
+    s.emit_command(dummy_draw());
+
+    assert_eq!(s.passes().len(), 2);
+    assert_eq!(s.passes()[0].color_size(), (256, 256));
+    assert_eq!(s.passes()[1].color_size(), (128, 128));
+}
+
+#[test]
 fn emit_scissor_enabled_uses_game_rect() {
     let mut s = fresh();
     s.set_viewport(0, 0, 640, 480, 0.0, 1.0);
@@ -2960,6 +2997,30 @@ fn binding_an_extra_target_breaks_the_pass_and_rebinding_it_does_not() {
     s.set_extra_color_render_target(1, None);
     assert!(s.current_pass_closed(), "unbinding ends the pass");
     assert_eq!(s.extra_present_mask(), 0);
+}
+
+#[test]
+fn rebinding_an_extra_target_with_a_new_format_breaks_the_pass() {
+    // Same rule as render target 0: an extra's format is frozen into the
+    // pass at open, so a same-handle rebind that changes it closes the pass.
+    let mut s = fresh();
+    s.set_extra_color_render_target(1, Some(slot(tex(0x3000), BB_SIZE)));
+    s.emit_command(dummy_draw());
+    let mut recoloured = slot(tex(0x3000), BB_SIZE);
+    recoloured.format = PixelFormat::Rgba16Float;
+    s.set_extra_color_render_target(1, Some(recoloured));
+    assert!(s.current_pass_closed(), "a new format ends the pass");
+    s.emit_command(dummy_draw());
+
+    assert_eq!(s.passes().len(), 2);
+    assert_eq!(
+        s.passes()[0].extra_color()[0].format(),
+        PixelFormat::R8Unorm
+    );
+    assert_eq!(
+        s.passes()[1].extra_color()[0].format(),
+        PixelFormat::Rgba16Float
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Symptoms

Latent, with no reproducer today. Rebinding the colour render target to the handle and subresource already bound, with a different Metal pixel format or a different extent, left the open render pass alone and updated the state in place. Any draw that followed in that pass would build its pipeline against the new format while the pass descriptor still attached the old one, which Metal reports as `For color attachment 0, the render pipeline's pixelFormat (...) does not match the framebuffer's pixelFormat (...)` and otherwise renders through the wrong attachment size.

## Root cause

`set_color_render_target_subresource` in `windows/core/src/passes.rs` took its early return on handle and subresource equality alone, and wrote `current_color_format` and `current_color_size` on that path. A pass freezes both when it opens, so the state and the open pass disagree from that point until something else breaks the pass. A Metal texture's pixel format is fixed, so reaching this needs the same handle to arrive with a different `PixelFormat` mapping, which no caller does today; the extent half is reachable through a scale change on an already bound target.

`set_extra_color_render_target` carried the same shape for render targets 1..3, where the frozen values also decide whether the target takes part in the pass at all.

## Changes

`windows/core/src/passes.rs`: the colour rebind counts as unchanged only when handle, subresource, format and extent all match. Anything else falls through to the existing break path, which emits the `pass-break trigger=set_color_rt` trace line, materialises a pending colour clear on the outgoing attachment and ends the pass before the new values are stored. The extras setter gets the same guard on its slot, comparing texture, subresource, format and size.

## Alternatives

Assert that format and extent match on the same-handle path: rejected, it turns a recoverable state change into an abort in release paths that have no other reason to fail.

Leave the extras setter alone as out of scope: rejected, it is the same defect in the function that documents itself as mirroring this one, and there the frozen extent also decides pass membership.

## Verification

`make check`, `make test` and `make conformance` are green. `make test`: 786 native core tests, 125 unix tests, and 285 end-to-end tests per architecture (i686 and x86_64), all `PASS`, 0 `FAIL` / `SIGABRT` / `TIMEOUT`, with 3 and 2 benign `LEAK` lines. `make conformance` reports no regressions on either architecture; only known-flaky sites (4475, 4480) and the 15088 ceiling move, all downwards.

Three unit tests in `windows/core/src/passes/tests.rs` fail before the change and pass after: `rebinding_the_same_target_with_a_new_format_breaks_the_pass` and `rebinding_the_same_target_with_a_new_extent_breaks_the_pass` pin that the open pass closes and the next pass carries the new format or extent, and `rebinding_an_extra_target_with_a_new_format_breaks_the_pass` pins the same for render target 1. `set_render_target_same_handle_no_break` and `binding_an_extra_target_breaks_the_pass_and_rebinding_it_does_not` still pin the fast path for a rebind that matches in full.

Closes #97
