### PR TITLE
Measure the RESZ resolve destination in render space

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ x86_64 Wine because Rosetta 2 is slow at the x87 math D3D9-era games do.
   reaching every bound target.
 - **Presentation**: windowed and fullscreen swap chains, adapter mode
   enumeration, hardware color cursors, and MetalFX upscaling on the way to the
-  screen with `render.scale` choosing the render resolution. Fullscreen never
-  changes the display mode; what it does instead is under
-  [Display-mode switching](#deliberately-not-implemented).
+  screen with `render.scale` choosing the render resolution. A render target or
+  depth-stencil the game creates at the reported back-buffer size rasterizes at
+  that same scale, so a depth resolve into an INTZ texture stays a same-size
+  copy. Fullscreen never changes the display mode; what it does instead is
+  under [Display-mode switching](#deliberately-not-implemented).
 - **HDR**: on an EDR-capable display the layer is upgraded to
   `extendedDynamicRange` and present routes through a BT.2446-A
   inverse-tone-mapping pass in ICtCp, its peak following the display's live

--- a/windows/core/src/render_scale.rs
+++ b/windows/core/src/render_scale.rs
@@ -11,6 +11,16 @@
 //! can read back must stay logical, or D3D9's coordinate space stops agreeing
 //! with `GetClientRect` and mouse input.
 //!
+//! The back buffer is not the only surface that shrinks. A render target or
+//! depth-stencil the game creates at the reported back-buffer size is part of
+//! the same image and is rasterized at the same scale, the auto depth-stencil
+//! and a `D3DUSAGE_DEPTHSTENCIL` texture (INTZ, DF24, DF16, a plain depth
+//! format) alike, so a colour/depth pair stays the same size and a depth
+//! resolve from the attachment into such a texture stays a same-size copy.
+//! Descriptors keep reporting the logical size; whatever addresses the Metal
+//! texture itself, an attachment extent or a full-surface blit, measures it in
+//! render space.
+//!
 //! A scale of 100% is an exact identity on every conversion here, so the
 //! default configuration cannot perturb a single pixel.
 

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -7859,7 +7859,13 @@ extern "system" fn device_set_render_state(this: *mut c_void, state: u32, value:
             // is rebound or released, both on this thread.
             let tex = unsafe { &*tex };
             let inner = tex.inner();
-            let (id, w, h) = (tex.texture_id(), inner.mip_width(0), inner.mip_height(0));
+            // The resolve is a texture-to-texture copy, so the destination is
+            // measured where its Metal texture lives: a depth texture created
+            // at the reported back-buffer size is rasterized at
+            // `render.scale` of it, exactly like the depth attachment the
+            // resolve compares it against.
+            let (w, h) = inner.render_extent();
+            let id = tex.texture_id();
             if dev.frame_dump.active {
                 dev.frame_dump_event(&format!("RESZ resolve → {id:?} {w}x{h}"));
             }

--- a/windows/d3d9/src/texture.rs
+++ b/windows/d3d9/src/texture.rs
@@ -563,6 +563,20 @@ impl TextureInner {
         self.mip_heights[level]
     }
 
+    /// Base-level extent of the backing Metal texture.
+    ///
+    /// `mip_width`/`mip_height` report the logical size D3D9 answers with. A
+    /// render-target or depth-stencil texture created at the reported
+    /// back-buffer size is rasterized at `render.scale` of that, so a command
+    /// that addresses the Metal texture directly (a full-surface blit, an
+    /// attachment extent) has to be measured here instead.
+    pub fn render_extent(&self) -> (u32, u32) {
+        (
+            self.render_scale.dimension(self.width),
+            self.render_scale.dimension(self.height),
+        )
+    }
+
     pub fn mip_bytes_per_row(&self, level: usize) -> u32 {
         self.mip_bytes_per_row[level]
     }


### PR DESCRIPTION
## Symptoms

At any `render.scale` below 1.0 every RESZ resolve is rejected:

```
RESZ resolve size mismatch: depth 480x360 vs destination 640x480 — skipped
```

A title that uses RESZ to hand scene depth to a second consumer (soft particles, SSAO) loses the depth copy entirely as soon as the knob is turned down, and samples whatever the destination texture happened to hold. `make test SCALE=0.75` (also 0.5 and 0.67) reproduces it: `render_target::resz_resolve_copies_bound_depth_into_the_stage0_texture` fails on both arches, and passes at 1.0.

## Root cause

A render target or depth-stencil the game creates at the reported back-buffer size shares the back buffer's scale, so a `CreateTexture(INTZ, D3DUSAGE_DEPTHSTENCIL)` at that size is already backed by a Metal texture of `scale × reported`, exactly like the auto depth-stencil and like the depth attachment extent the resolve is checked against. The RESZ arm of `SetRenderState` measured the stage-0 destination with `mip_width(0)` / `mip_height(0)` instead, which is the logical size D3D9 reports. The guard therefore compared a rasterized extent against a reported one, and the two cannot agree below 1.0.

## Changes

`windows/d3d9/src/texture.rs` gains `TextureInner::render_extent`, the base-level extent of the backing Metal texture (`render_scale` applied to the reported size, an exact identity at the default scale).

`windows/d3d9/src/device.rs` measures the RESZ destination with it, so the size guard and the copy region it queues are both in the space the two Metal textures live in. The frame-dump line follows the same extent.

`README.md` and the `render_scale` module header record that a render target or depth-stencil created at the reported back-buffer size rasterizes at the same scale, that descriptors keep reporting the logical size, and that anything addressing the Metal texture itself measures it in render space.

## Alternatives

Resolve through a resampling blit into a reported-size destination: rejected, it needs a depth-capable resolve pass and leaves the sampled texture at a different resolution from the attachment it mirrors, for no gain since a scaled game samples it with normalised coordinates either way.

Stop scaling depth-stencil textures so the destination stays at the reported size: rejected, the colour/depth pairing is what makes `render.scale` save anything, and a scaled colour target with an unscaled depth buffer cannot be bound together.

## Verification

`render_target::resz_resolve_copies_bound_depth_into_the_stage0_texture` fails before this change and passes after, on both arches, at `render.scale` 0.75, 0.5 and 0.67; it passes before and after at 1.0. That is the test to judge this by, and `make test SCALE=0.75` is how to run it.

`make check` clean. `make test`: 281 e2e tests per arch, 281 PASS on i686 and 281 PASS on x86_64 (one leaky each), plus 783 unit tests in the windows workspace and 125 in the unix one. `make conformance`: no regressions on either arch; the only movement is the known flaky pair 4475 and 4480 and the 15088 ceiling, all counting down.

The whole e2e suite at `render.scale=0.75` with `--no-fail-fast` is 273 of 281 on both arches. The eight that stay red are unrelated to the resolve: `vertex_decl::unbound_declared_stream_reads_zeros` (#89) and seven in `points`, where the point size reaches `[[point_size]]` in reported pixels while the grid it rasterizes on is the scaled one (`windows/core/src/vs_draw.rs`, `build_vs_draw_bytes` copies `D3DRS_POINTSIZE` through verbatim).

Closes #88
