### PR TITLE
Prune the pass state's handle-keyed records at texture destroy

### DIFF
--- a/windows/core/src/passes.rs
+++ b/windows/core/src/passes.rs
@@ -1071,8 +1071,10 @@ pub struct PassState {
     /// and by `finalize_store_actions` to skip `StoreAction::DontCare` on
     /// the same. Closes a hole in the original load/store optimiser that
     /// discarded CSM cascade content between the caster pass that wrote
-    /// it and the scene pass that sampled it. Reset each frame in
-    /// `reset_frame`.
+    /// it and the scene pass that sampled it. Kept across `reset_frame`,
+    /// because a cascade written in one frame is sampled in the next; an
+    /// entry leaves only through `unregister_texture`, when the `MTLTexture`
+    /// behind the handle is destroyed.
     seen_sampled_textures: FxHashSet<MetalHandle<MTLTextureKind>>,
     /// Texture handles bound as a fragment sampler input so far THIS frame, in op-stream order.
     ///
@@ -1142,9 +1144,9 @@ pub struct PassState {
     ///
     /// Entries outlive the frame that made them, because a cascade is
     /// sampled frames after it was rendered, but not the texture itself:
-    /// `unregister_sampleable_depth` drops a handle when the encoder retires
-    /// the `MTLTexture` behind it, so a later allocation that lands on the
-    /// same address is not mistaken for the cascade that used to live there.
+    /// `unregister_texture` drops a handle when the `MTLTexture` behind it is
+    /// destroyed, so a later allocation that lands on the same address is not
+    /// mistaken for the cascade that used to live there.
     seen_sampleable_depth_textures: FxHashSet<MetalHandle<MTLTextureKind>>,
     /// Per-frame counter: how many caster draws targeted each cascade depth handle.
     ///
@@ -1416,10 +1418,9 @@ impl PassState {
         // correct trade.
         //
         // Memory cost: bounded by the number of distinct texture
-        // handles ever used as a sampler input over the session
-        // (~100s for WoW). Cleared only at device-reset (when the
-        // game might destroy and reissue textures with the same
-        // handles).
+        // handles sampled by a live texture (~100s for WoW), because
+        // `unregister_texture` takes a handle back out when the
+        // `MTLTexture` behind it is destroyed.
     }
 
     #[must_use]
@@ -1551,18 +1552,45 @@ impl PassState {
         self.seen_sampleable_depth_textures.contains(&depth_tex)
     }
 
-    /// Drop `texture` from the sampleable-depth set as its `MTLTexture` is retired.
+    /// Drop every record keyed on `texture` as its `MTLTexture` is destroyed.
     ///
-    /// Called by the encoder from every path that hands a texture handle to
-    /// the retention queue (resource release and rename-at-overlap), so the
-    /// set never names an address Metal is free to hand back for an unrelated
-    /// allocation. A no-op for a handle that was never a sampleable depth
-    /// attachment, which is the common case.
-    pub fn unregister_sampleable_depth(&mut self, texture: MetalHandle<MTLTextureKind>) {
+    /// A handle is an allocation address, so Metal is free to hand the same
+    /// value back for the next texture once this one is gone. Every set and
+    /// map here is keyed on that address, and an entry that outlives the
+    /// texture makes the load/store rules answer for the wrong resource:
+    /// Rules A, C and D would keep `Load`/`Store` on an attachment nothing
+    /// samples, Rule B would refuse a first-use `DontCare` on a fresh depth
+    /// surface, and rename-at-overlap would copy a texture no draw has read.
+    ///
+    /// Covers `seen_color_rts` and `seen_depth_rts` with their segment twins,
+    /// `blit_written_rts`, `seen_sampled_textures`, `frame_sampled_textures`,
+    /// `seen_sampleable_depth_textures`, and the two cascade-probe counters.
+    /// `srgb_twin_to_base` is not one of them: it mirrors the encoder's live
+    /// texture cache through `register_srgb_twin` / `unregister_srgb_twin`
+    /// rather than accumulating what passes did. `backbuffer_texture` and the
+    /// current-attachment handles are single bindings that every
+    /// [`Self::reset_frame`] reseeds.
+    ///
+    /// The caller is the encoder's retention drain, which runs when the GPU
+    /// has retired the submission that last named the handle. Pruning where
+    /// the D3D9 object is released would be too early: the passes that
+    /// reference the texture are built and their store actions are not
+    /// finalised until submit.
+    pub fn unregister_texture(&mut self, texture: MetalHandle<MTLTextureKind>) {
         if texture.is_null() {
             return;
         }
+        self.seen_color_rts.retain(|&(handle, _)| handle != texture);
+        self.seen_color_rts_segment
+            .retain(|&(handle, _)| handle != texture);
+        self.seen_depth_rts.remove(&texture);
+        self.seen_depth_rts_segment.remove(&texture);
+        self.blit_written_rts.remove(&texture);
+        self.seen_sampled_textures.remove(&texture);
+        self.frame_sampled_textures.remove(&texture);
         self.seen_sampleable_depth_textures.remove(&texture);
+        self.frame_caster_writes.remove(&texture);
+        self.frame_cascade_samples.remove(&texture);
     }
 
     /// Metal pixel format the next pass binds for colour attachment 0.

--- a/windows/core/src/passes/tests.rs
+++ b/windows/core/src/passes/tests.rs
@@ -2882,6 +2882,123 @@ fn cascade_rebind_with_the_same_sampleable_flag_is_a_no_op() {
     );
 }
 
+/// Drive a sample-then-reuse pair of frames, optionally retiring the texture between them.
+///
+/// Frame N renders into `rt` and samples it, which puts the handle in the
+/// session-wide sampled set. Frame N+1 binds the same address as a colour
+/// target nothing reads. Returns that pass's load and store actions.
+fn colour_reuse_after_sample(retire: bool) -> (ColorLoad, StoreAction) {
+    let rt = tex(0xCAFE_8000);
+    let mut s = fresh();
+    s.set_color_render_target(rt, 256, 256, RT_FORMAT, RenderScale::IDENTITY);
+    s.emit_command(dummy_draw());
+    s.set_color_render_target(
+        backbuffer(),
+        BB_SIZE.0,
+        BB_SIZE.1,
+        BB_FORMAT,
+        s.render_scale,
+    );
+    s.emit_command(Command::set_fragment_texture(rt.raw(), 0));
+    s.emit_command(dummy_draw());
+    s.end_current_pass("test");
+    if retire {
+        s.unregister_texture(rt);
+    }
+    s.reset_frame(&FrameReset {
+        backbuffer: backbuffer(),
+        backbuffer_size: BB_SIZE,
+        backbuffer_format: BB_FORMAT,
+        depth_texture: depth(),
+        depth_size: BB_SIZE,
+        depth_has_stencil: false,
+        render_scale: RenderScale::IDENTITY,
+        continues_frame: false,
+    });
+    s.set_color_render_target(rt, 256, 256, RT_FORMAT, RenderScale::IDENTITY);
+    s.emit_command(dummy_draw());
+    s.set_color_render_target(
+        backbuffer(),
+        BB_SIZE.0,
+        BB_SIZE.1,
+        BB_FORMAT,
+        s.render_scale,
+    );
+    s.emit_command(dummy_draw());
+    s.end_current_pass("test");
+    s.finalize_load_actions();
+    s.finalize_store_actions(false);
+    let reuse = s
+        .passes()
+        .iter()
+        .find(|p| p.color_texture() == rt)
+        .expect("the reuse pass is present");
+    (reuse.color_load(), reuse.color_store())
+}
+
+/// A retired colour handle stops looking sampled, so its address can be reused.
+///
+/// `seen_sampled_textures` deliberately outlives the frame that filled it, so
+/// every rule that consults it keeps `Load` and `Store` on the handle for as
+/// long as the entry stands. That is right while the texture lives and wrong
+/// the moment Metal is free to hand its address to an unrelated allocation.
+#[test]
+fn a_retired_colour_handle_drops_its_sampled_marking() {
+    assert_eq!(
+        colour_reuse_after_sample(true),
+        (ColorLoad::DontCare, StoreAction::DontCare),
+        "the reused address is a first use nothing reads: Rule A discards the load, \
+         Rule D drops the store",
+    );
+    assert_eq!(
+        colour_reuse_after_sample(false),
+        (ColorLoad::Load, StoreAction::Store),
+        "a live texture sampled last frame keeps both, which is what the prune must \
+         not weaken",
+    );
+}
+
+/// Retiring a texture re-arms every frame-scoped record keyed on its handle.
+///
+/// The colour seen-set is keyed on `(handle, subresource)` and the sampled
+/// set on the handle alone, so a destroy and a same-frame reallocation onto
+/// the same address must leave both answering for the new texture.
+#[test]
+fn unregister_texture_re_arms_the_frame_scoped_sets() {
+    let rt = tex(0xCAFE_8100);
+    let mut s = fresh();
+    s.set_color_render_target(rt, 256, 256, RT_FORMAT, RenderScale::IDENTITY);
+    s.emit_command(dummy_draw());
+    s.set_color_render_target(
+        backbuffer(),
+        BB_SIZE.0,
+        BB_SIZE.1,
+        BB_FORMAT,
+        s.render_scale,
+    );
+    s.emit_command(Command::set_fragment_texture(rt.raw(), 0));
+    s.emit_command(dummy_draw());
+    assert!(
+        s.texture_sampled_this_frame(rt),
+        "the bind marks the handle sampled this frame",
+    );
+    s.unregister_texture(rt);
+    assert!(
+        !s.texture_sampled_this_frame(rt),
+        "an upload into the reallocated address must not trigger a rename",
+    );
+    s.set_color_render_target(rt, 256, 256, RT_FORMAT, RenderScale::IDENTITY);
+    s.emit_command(dummy_draw());
+    assert_eq!(
+        s.passes()
+            .last()
+            .expect("the reuse pass is present")
+            .color_load(),
+        ColorLoad::DontCare,
+        "the reused address is a first use again, so Rule A discards its load",
+    );
+}
+
 /// A retired depth handle stops being sampleable, so its address can be reused.
 ///
 /// Metal is free to hand the address of a destroyed `MTLTexture` back for the
@@ -2898,7 +3015,7 @@ fn a_retired_depth_handle_drops_its_sampleable_marking() {
         s.is_depth_handle_sampleable(handle),
         "the cascade bind marks the handle",
     );
-    s.unregister_sampleable_depth(handle);
+    s.unregister_texture(handle);
     assert!(
         !s.is_depth_handle_sampleable(handle),
         "retiring the texture drops the marking",

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -5793,6 +5793,20 @@ impl FrameEncoder {
         }
     }
 
+    /// Prune the pass state's handle-keyed records for a texture being destroyed.
+    ///
+    /// The retention drains are the one point where an `MTLTexture` handle
+    /// stops naming this resource: the GPU has retired every submission that
+    /// referenced it, so no pass under construction can name it either, and
+    /// the address is about to become available to the next allocation.
+    fn retire_texture_handle(&mut self, handle: u64) {
+        // SAFETY: a `DestroyKind::Texture` retention entry carries the `.raw()`
+        // of a `MetalHandle<MTLTextureKind>`, so the value is an `MTLTexture`
+        // handle. `unregister_texture` only hashes it.
+        self.pass_state
+            .unregister_texture(unsafe { MetalHandle::<MTLTextureKind>::new(handle) });
+    }
+
     /// Drain resource-retention entries whose seq has retired on the GPU.
     ///
     /// Partitions popped entries by `DestroyKind`, destroys each kind's
@@ -5840,6 +5854,7 @@ impl FrameEncoder {
                     DestroyKind::Texture => {
                         textures.push(entry.handle);
                         self.perf.bump_texture_destroy();
+                        self.retire_texture_handle(entry.handle);
                     }
                     other => {
                         mtld3d_shared::log_once_warn!(target: LOG_TARGET,
@@ -6171,12 +6186,6 @@ impl FrameEncoder {
         }
         self.pass_state.unregister_srgb_twin(old_srgb);
         self.pass_state.register_srgb_twin(fresh_srgb, fresh);
-        // The renamed-away storage is retired below, so its address is no
-        // longer a sampleable depth attachment either.
-        // SAFETY: `old_handle` came out of the typed `texture_cache` via
-        // `.raw()`, so it is an `MTLTexture` handle or null.
-        self.pass_state
-            .unregister_sampleable_depth(unsafe { MetalHandle::<MTLTextureKind>::new(old_handle) });
         // The old texture (and its twin view) is read by this frame's
         // already-emitted draws — destroy only after the frame's GPU work
         // retires.
@@ -6939,10 +6948,6 @@ impl FrameEncoder {
             let seq = self.current_submit_seq;
             let mtl_texture = state.mtl_texture;
             self.pass_state.unregister_srgb_twin(state.mtl_texture_srgb);
-            // The `MTLTexture` is about to be retired, so the address may come
-            // back as an unrelated allocation: drop any sampleable-depth
-            // marking with it.
-            self.pass_state.unregister_sampleable_depth(mtl_texture);
             // `into_iter` so each slot's `keepalive` Arc moves into the
             // retention entry — the `MTLBuffer` wrapper must outlive
             // the page-backing it wraps via `bytesNoCopy`.
@@ -7242,11 +7247,14 @@ impl FrameEncoder {
         for entry in self.pending_texture_uploads.drain_all() {
             held.staging_arcs.push(entry.into_payload().arc);
         }
-        for entry in self.pending_resource_retention.drain(..) {
+        while let Some(entry) = self.pending_resource_retention.pop_front() {
             if entry.handle != 0 {
                 match entry.kind {
                     DestroyKind::Buffer => buffers.push(entry.handle),
-                    DestroyKind::Texture => textures.push(entry.handle),
+                    DestroyKind::Texture => {
+                        textures.push(entry.handle);
+                        self.retire_texture_handle(entry.handle);
+                    }
                     other => {
                         mtld3d_shared::log_once_warn!(target: LOG_TARGET,
                             "drain_retention_and_wait: unexpected kind {other:?} \


### PR DESCRIPTION
## Symptoms

No visual defect and no log line. The load/store optimizer silently gives up elisions it is entitled to: a render target that nothing samples keeps `StoreAction::Store`, and its first use in a frame loads instead of discarding, because a texture that died earlier in the session left its address behind in `PassState`'s bookkeeping and a later, unrelated allocation landed on it. The cost is bandwidth (a cascade colour attachment is multiple MB per frame), which is why it went unnoticed.

## Root cause

`PassState` identifies textures by raw `MTLTexture` handle, which is an allocation address. `seen_sampled_textures` is deliberately session-wide (a cascade written in frame N is sampled in frame N+1), and nothing ever removed an entry. `frame_sampled_textures`, `seen_color_rts`, `seen_depth_rts`, their segment twins, `blit_written_rts` and the two cascade-probe counters are frame- or segment-scoped, so they alias only until the next `reset_frame`, but that window still covers a destroy and a reallocation inside one frame.

Metal is free to hand the address of a destroyed texture to the next allocation. When it does, Rule A refuses the first-use `DontCare`, Rules C and D keep `Store`, Rule B refuses to discard a depth surface, and rename-at-overlap copies a texture no draw has read, all on behalf of a resource that no longer exists.

## Changes

`PassState::unregister_texture` replaces `unregister_sampleable_depth` and drops the handle from every record keyed on it: `seen_color_rts` and `seen_depth_rts` with their segment twins, `blit_written_rts`, `seen_sampled_textures`, `frame_sampled_textures`, `seen_sampleable_depth_textures`, `frame_caster_writes` and `frame_cascade_samples`. The two colour sets are keyed on `(handle, subresource)` and are pruned by `retain`. `srgb_twin_to_base` is left alone: it mirrors the encoder's live texture cache through `register_srgb_twin` / `unregister_srgb_twin` rather than accumulating what passes did. `backbuffer_texture` and the current-attachment handles are single bindings that every `reset_frame` reseeds.

The call site is the encoder's retention drain (`drain_retired_resource_retention`, and `drain_retention_and_wait` for the Reset and shutdown paths), on every `DestroyKind::Texture` entry. That is the point where the handle stops naming the resource. Pruning where the D3D9 object is released, which is where the depth version of this sat, is too early: the passes that reference the texture are already built and their store actions are not finalised until submit, so a mid-frame release would let Rule D discard a store an already-emitted later pass still reads. Retirement is seq-gated, so by the time the drain pops the entry the GPU has finished every submission that named the handle. The sRGB twin views are retired through the same queue and so get pruned too, which matters because the twin handle is itself inserted into the sampled sets.

Two field doc comments said `seen_sampled_textures` is reset per frame and cleared at device reset. Neither was true; they now state where an entry actually leaves.

This builds on the branch for #48, whose `unregister_sampleable_depth` this replaces.

## Alternatives

Prune in `destroy_cached_texture` and the rename-at-overlap tail, next to `unregister_srgb_twin`: rejected, it prunes before the frame's passes are finalised and would cost correctness on the sampled sets, not just precision.

One `unregister_*` method per set: rejected, every set is keyed on the same address and retires at the same instant, so splitting them invites the next set to be forgotten.

Clear the sets wholesale on device reset (what the old comment claimed happened): rejected, it does not help a texture destroyed during play, which is the common case, and it throws away live cascade markings.

Key the sets on `TextureId` instead of the Metal handle: rejected as a much larger change, and the sets are consulted from the command stream where only the handle is available.

## Verification

`make check` clean. `make test`: 786 + 125 native unit tests pass, and both end-to-end legs report 283/283 passed with 2 leaky each; no `FAIL`, `SIGABRT` or `TIMEOUT` on either architecture. `make conformance`: no regressions on either architecture, the only movement being the flaky 4475/4480 and the 15088 ceiling reading below their pins, so the baseline is not re-recorded.

Three unit tests in `windows/core/src/passes/tests.rs`. `a_retired_colour_handle_drops_its_sampled_marking` renders into a target, samples it, retires it, and reuses the address in the next frame: with the prune the reuse pass gets `ColorLoad::DontCare` and `StoreAction::DontCare`, and the same sequence without the retirement keeps `Load` and `Store`, which pins that the cross-frame cascade protection is unweakened. `unregister_texture_re_arms_the_frame_scoped_sets` covers the same-frame case, the `(handle, subresource)` keying and `texture_sampled_this_frame`. Both fail against a `unregister_texture` that prunes only the sampleable-depth set: `left: (Load, Store)`, `right: (DontCare, DontCare)`. `a_retired_depth_handle_drops_its_sampleable_marking` is the depth case, carried over from #48.

There is no end-to-end test: the issue is a lost store elision with no observable D3D9 behaviour, and the drain the prune hangs off has no seam an e2e test can reach.

Closes #96
