### PR TITLE
Flush StretchRect endpoints only after every rejection gate

### DIFF
--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -5756,7 +5756,6 @@ extern "system" fn device_stretch_rect(
     let src_surf = src.cast::<Direct3DSurface9>();
     let dst_surf = dst.cast::<Direct3DSurface9>();
 
-    flush_dirty_mips_for_stretch(&obj, src_surf, dst_surf);
     let dev = obj.inner();
     if dev.frame_dump.active {
         dev.frame_dump_event(&format!(
@@ -5836,6 +5835,9 @@ extern "system" fn device_stretch_rect(
             );
             return D3DERR_INVALIDCALL;
         }
+        // Past every depth-stencil gate, so the endpoints' pending uploads are
+        // work this call will use.
+        flush_dirty_mips_for_stretch(&obj, src_surf, dst_surf);
         // Same-format Private→Private depth copy on the 1:1 blit path. The
         // blit is entered into the load/store model like a colour copy: the
         // source counts as read (its last pass keeps its depth store) and the
@@ -5932,6 +5934,9 @@ extern "system" fn device_stretch_rect(
         );
         return D3DERR_INVALIDCALL;
     }
+    // Past every gate that can reject the call, so the endpoints' pending
+    // uploads are work this call will use.
+    flush_dirty_mips_for_stretch(&obj, src_surf, dst_surf);
     // A cross-Metal-format same-size copy also needs the render-quad path (the
     // 1:1 blit can't convert). `check_stretch_rect_formats` guaranteed a
     // cross-format destination is a render target or an offscreen-plain surface
@@ -6118,6 +6123,9 @@ fn convert_stretch_dst_staging(
 /// The `StretchRect` blit then operates on the latest
 /// CPU-uploaded content. Render targets never carry a `dirty` flag
 /// (RTs aren't Lock+Unlocked), so this is a no-op for them.
+///
+/// Every caller sits below the gates that return `D3DERR_INVALIDCALL`, so a
+/// rejected `StretchRect` schedules no upload for either endpoint.
 fn flush_dirty_mips_for_stretch(
     obj: &Direct3DDevice9,
     src_surf: *mut crate::surface::Direct3DSurface9,


### PR DESCRIPTION
## Symptoms

A `StretchRect` that ends in `D3DERR_INVALIDCALL` still did the work of a successful one on both endpoints. A title that issues the call speculatively, or on a managed or system-memory surface, paid two texture uploads per rejected call and got nothing for them. The rejection itself was already correct, so the only trace is the upload traffic and the `reject StretchRect: src/dst not D3DPOOL_DEFAULT → INVALIDCALL` line that follows it.

## Root cause

`device_stretch_rect` called `flush_dirty_mips_for_stretch` on both surfaces' parent textures immediately after casting the two surface pointers, above `resolve_stretch_surface` and above every gate that can reject: the `D3DPOOL_DEFAULT` requirement, the source and destination surface-class rules, the format check, the rect parse, and the scaling-into-a-non-render-target rule. The depth-stencil branch has its own gates and reached the same early flush.

The flush exists so the blit or the render quad reads the latest CPU-uploaded content, which only matters once the call is going to emit one. Nothing between the old call site and the gates depends on it: `resolve_stretch_surface` reads dimensions, usage and pool from the texture rather than its Metal handle, and the draw-time bind path runs the same `rehydrate_for_device` plus `flush_dirty_mips` pair before it samples a texture.

## Changes

`windows/d3d9/src/device.rs`: `device_stretch_rect` now flushes at two points instead of one. The colour path flushes after the last gate that can return `D3DERR_INVALIDCALL` and before the cross-format CPU converter, the offscreen staging refresh and the encoder op. The depth-stencil branch flushes after its own eligibility, rect and full-surface checks and before it pushes the depth blit. The doc comment on `flush_dirty_mips_for_stretch` states the position as an invariant.

## Alternatives

Flush lazily from inside the blit and render-quad emitters: rejected as a larger change, since the emitters run on the encoder thread and the uploads have to be scheduled from the API thread ahead of them.

Keep one call site and hoist the gates above it instead: rejected because the depth branch and the colour path reject on different rules, so a single pre-gate block would duplicate the surface resolution.

## Verification

`make check` clean. `make test` green: 782 core unit tests, 125 conformance unit tests, and 285 end-to-end results on each architecture (i686 283 PASS + 2 LEAK, x86_64 282 PASS + 3 LEAK), no FAIL, SIGABRT or TIMEOUT. `make conformance` reports no regressions on either architecture; the only movement is the known flaky `device.c:4475`, `device.c:4480` and the `device.c:15088` ceiling site counting down.

No new test accompanies the change, because the elimination is not observable through the D3D9 API. The upload counters (`texture_blit_uploads` and its siblings in `windows/core/src/perf.rs`) live on the unix side behind the `PERF` build gate, the flush logs only at trace level on `mtld3d::d3d9::tex`, and the end-to-end harness reads neither, so pinning it would need a new knob. The reordered flush is netted by the existing tests that depend on it: `stretch_rect_converts_r5g6b5_into_x8r8g8b8` and `expanded_offscreen_plain_is_a_stretch_rect_source` lock and fill an offscreen-plain source and then `StretchRect` it with no draw in between, so the render quad reads black unless the upload is scheduled ahead of the encoder op, and `stretch_rect_addresses_source_and_destination_mip_levels` does the same across mip levels.

Closes #106
