### PR TITLE
Give the retire test's FrameReset the sRGB back-buffer field

### DIFF
--- a/windows/core/src/passes/tests.rs
+++ b/windows/core/src/passes/tests.rs
@@ -2907,6 +2907,7 @@ fn colour_reuse_after_sample(retire: bool) -> (ColorLoad, StoreAction) {
     }
     s.reset_frame(&FrameReset {
         backbuffer: backbuffer(),
+        backbuffer_srgb: backbuffer_srgb(),
         backbuffer_size: BB_SIZE,
         backbuffer_format: BB_FORMAT,
         depth_texture: depth(),


### PR DESCRIPTION
## Symptoms

`cargo nextest run -p mtld3d-core` on `main` stops at `error[E0063]: missing field backbuffer_srgb in initializer of passes::FrameReset` in `windows/core/src/passes/tests.rs`, so `make test-unit` and `make clippy-native` are red.

## Root cause

The test was written on a branch that predates the `backbuffer_srgb` field PR #178 added to `FrameReset`, and merged after it without a rebase build of the test target.

## Changes

`windows/core/src/passes/tests.rs`: the one `reset_frame` call without the field gets `backbuffer_srgb: backbuffer_srgb()`, as every other call in the file has.

## Alternatives

None worth taking: the field is mandatory and the helper already exists.

## Verification

`cargo nextest run -p mtld3d-core --target aarch64-apple-darwin`: builds and passes (851 tests).

Closes #215
