### PR TITLE
Upload the back buffer's DC page at its row stride, not its pixel size

### DIFF
--- a/windows/d3d9/src/surface.rs
+++ b/windows/d3d9/src/surface.rs
@@ -2279,8 +2279,10 @@ fn backbuffer_dc_upload(inner: &mut SurfaceInner) {
     // SAFETY: `inner.device_inner` is non-null (checked above) and points to
     // the live owning device, a different allocation from the page above.
     let device_inner = unsafe { &mut *inner.device_inner };
+    // The snapshot page is tightly packed, so a row is exactly `width` pixels.
+    let src_stride = width * bpp;
     device_inner.push_op(Box::new(move |enc| {
-        enc.upload_bytes_to_color_handle(color_handle, &bytes, width, height, bpp);
+        enc.upload_bytes_to_color_handle(color_handle, &bytes, width, height, src_stride);
     }));
 }
 


### PR DESCRIPTION
## Symptoms

`implicit_surface::release_dc_on_a_lockable_backbuffer_reaches_the_back_buffer` fails on `main` on both architectures with the Metal abort `sourceBytesPerRow(16) must be >= (2560)`.

## Root cause

`backbuffer_dc_upload` in `windows/d3d9/src/surface.rs` passed `bpp` as the last argument of `FrameEncoder::upload_bytes_to_color_handle`. That parameter is `src_stride`, the byte pitch of a row: PR #198 changed the signature from bytes-per-pixel to stride, and PR #199 added this call site against the old shape.

## Changes

`windows/d3d9/src/surface.rs`: compute `src_stride = width * bpp` (the snapshot page is tightly packed) and pass that.

## Alternatives

Keep a bytes-per-pixel overload on the encoder: two entry points for one upload invite exactly this mix-up again.

## Verification

`make test` in a private tree: the failing test passes on both architectures, no other change in per-test results.

Closes #214
