### PR TITLE
Bundle new_color_target's arguments into a create-info struct

### DIFF
--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -94,7 +94,7 @@ use super::{
     shader_bindings::{CONSTANT_ROWS, PS_FLOAT_CONSTANT_LIMIT, ShaderBindings},
     stage_bindings::{STAGE_COUNT, StageBindings, TextureSwapDelta},
     state_block::{RecordingStateBlock, StateOp},
-    surface::Direct3DSurface9,
+    surface::{ColorTargetCreateInfo, Direct3DSurface9},
     texture::{
         CUBE_FACE_COUNT, Direct3DTexture9, SourceImage, TextureCreateInfo, TextureFlags,
         TextureInner, new_uninit_page_box,
@@ -4944,16 +4944,16 @@ fn create_color_target_surface(
     if unix_call(&mut params) != 0 || params.texture_handle.is_null() {
         return None;
     }
-    let surf = Direct3DSurface9::new_color_target(
+    let surf = Direct3DSurface9::new_color_target(&ColorTargetCreateInfo {
         device_inner,
-        params.texture_handle,
-        params.srgb_texture_handle,
+        metal_color_handle: params.texture_handle,
+        metal_color_srgb_handle: params.srgb_texture_handle,
         width,
         height,
         format,
         usage,
-        scale,
-    );
+        render_scale: scale,
+    });
     // The surface owns a DEFAULT-pool Metal texture no `TextureInner` covers,
     // so charge it here; `finalize_surface`'s colour retire arm refunds it.
     // SAFETY: `device_inner` is the live owning device, non-null for every

--- a/windows/d3d9/src/surface.rs
+++ b/windows/d3d9/src/surface.rs
@@ -128,6 +128,25 @@ pub struct Direct3DSurface9 {
     inner: *mut SurfaceInner,
 }
 
+/// Everything `Direct3DSurface9::new_color_target` needs to build the surface.
+///
+/// `metal_color_srgb_handle` is the eager sRGB twin view of
+/// `metal_color_handle` and is null when the format has no sRGB counterpart.
+/// `width` and `height` are the logical extent `GetDesc` reports;
+/// `render_scale` is the factor the Metal texture was allocated at. `usage` is
+/// `D3DUSAGE_RENDERTARGET` for a render target and `0` for an offscreen-plain
+/// `D3DPOOL_DEFAULT` surface.
+pub struct ColorTargetCreateInfo {
+    pub device_inner: *mut DeviceInner,
+    pub metal_color_handle: MetalHandle<MTLTextureKind>,
+    pub metal_color_srgb_handle: MetalHandle<MTLTextureKind>,
+    pub width: u32,
+    pub height: u32,
+    pub format: u32,
+    pub usage: u32,
+    pub render_scale: RenderScale,
+}
+
 impl Direct3DSurface9 {
     /// Standalone color render-target surface.
     ///
@@ -135,32 +154,21 @@ impl Direct3DSurface9 {
     /// with `D3DPOOL_DEFAULT`. Wraps a persistent render-target-capable
     /// `MTLTexture` via `metal_color_handle`, identical to the backbuffer
     /// surface, so `StretchRect` and `GetRenderTargetData` resolve it for free.
-    /// `usage` is `D3DUSAGE_RENDERTARGET` for a render target, `0` for an
-    /// offscreen-plain `D3DPOOL_DEFAULT` surface.
-    pub fn new_color_target(
-        device_inner: *mut DeviceInner,
-        metal_color_handle: MetalHandle<MTLTextureKind>,
-        metal_color_srgb_handle: MetalHandle<MTLTextureKind>,
-        width: u32,
-        height: u32,
-        format: u32,
-        usage: u32,
-        render_scale: RenderScale,
-    ) -> Self {
+    pub fn new_color_target(info: &ColorTargetCreateInfo) -> Self {
         let inner = Box::into_raw(Box::new(SurfaceInner {
-            device_inner,
+            device_inner: info.device_inner,
             parent_texture: core::ptr::null_mut(),
             mip_level: 0,
             cube_face: u32::MAX,
-            standalone_width: width,
-            standalone_height: height,
-            standalone_render_scale: render_scale,
-            standalone_format: format,
-            standalone_usage: usage,
+            standalone_width: info.width,
+            standalone_height: info.height,
+            standalone_render_scale: info.render_scale,
+            standalone_format: info.format,
+            standalone_usage: info.usage,
             standalone_pool: D3DPOOL_DEFAULT,
             metal_depth_handle: MetalHandle::NULL,
-            metal_color_handle,
-            metal_color_srgb_handle,
+            metal_color_handle: info.metal_color_handle,
+            metal_color_srgb_handle: info.metal_color_srgb_handle,
             readback: None,
             dc_shim: None,
             system_memory: None,


### PR DESCRIPTION
## Symptoms

The first clippy leg of `make check` is red on `main`:

```
warning: this function has too many arguments (8/7)
   --> d3d9/src/surface.rs:140:5
    = note: `#[warn(clippy::too_many_arguments)]` on by default
```

`build.warnings = "deny"` turns that warning into a failure, so `clippy-pe-i686` stops before it reaches the rest of the tree.

## Root cause

`Direct3DSurface9::new_color_target` accumulated positional parameters until it crossed the seven-argument threshold: the sRGB twin handle and the render scale joined the device pointer, the colour handle, the extent, the format and the usage.

## Changes

`windows/d3d9/src/surface.rs` gains a `ColorTargetCreateInfo` holding the eight values, and `new_color_target` takes it by reference and reads its fields into `SurfaceInner`. The struct is wider than 16 bytes and every use is a borrow, so it derives nothing and the derive inventory is unchanged. The two sentences of the old function doc that described `usage` move onto the struct, where the fields they describe now live.

`windows/d3d9/src/device.rs` fills the struct at the sole create site, `create_color_target_surface`, which serves `CreateRenderTarget` and `CreateOffscreenPlainSurface(D3DPOOL_DEFAULT)`.

## Alternatives

Per-site `#[allow(clippy::too_many_arguments)]`: rejected, `docs/CONVENTIONS.md` allows no fourth per-site allow and names the parameter struct as the fix for this lint.

Splitting the constructor into a render-target and an offscreen-plain variant: rejected, the two differ only in the `usage` value and would duplicate the whole `SurfaceInner` initializer.

Naming it `ColorTargetParams`: rejected, `CreateColorTargetParams` is the FFI wire struct filled in a few lines above the same call site, and two `*ColorTargetParams` in one function reads as one type. `ColorTargetCreateInfo` follows `DepthTextureCreateInfo`, `IndexBufferCreateInfo` and `TextureCreateInfo`.

## Verification

A pure refactor with no behaviour change, so no test moves from failing to passing; the existing e2e coverage of the create path (`render_target.rs` for `CreateRenderTarget`, `device.rs` for `CreateOffscreenPlainSurface`) pins that the surface still comes out the same.

`cd windows && cargo +stable clippy --target i686-pc-windows-msvc` is clean, the eight-argument warning is gone.

`make check` passes end to end (fmt-check, clippy on both PE targets and native, audit, doc). `make test` runs 857 windows unit tests and 125 unix unit tests, all passing, and 347 e2e tests per architecture: i686 346 passed (1 leaky), x86_64 346 passed (2 leaky). The one failure on each architecture is `implicit_surface::release_dc_on_a_lockable_backbuffer_reaches_the_back_buffer`, which is #214 and fails the same way without this change.

Both gates were run on a tree with the duplicate `color_fill_render_target_overwrites_earlier_draws` of #218 removed locally, since that duplicate stops `mtld3d-tests` from compiling at all; the removal is not part of this change.

Closes #216
