### PR TITLE
Log every UpdateSurface and UpdateTexture rejection

### DIFF
--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -5500,10 +5500,18 @@ extern "system" fn device_update_surface(
     let _timer = device_timer(this, DeviceSubCategory::Misc);
     // SAFETY: vtable args; live `Direct3DSurface9` pointers per the ABI.
     let Some(src_surf) = (unsafe { InPtr::<crate::surface::Direct3DSurface9>::opt(src) }) else {
+        mtld3d_shared::log_once_warn!(
+            target: crate::LOG_TARGET,
+            "reject UpdateSurface: null source surface → INVALIDCALL"
+        );
         return D3DERR_INVALIDCALL;
     };
     // SAFETY: as above.
     let Some(dst_surf) = (unsafe { InPtr::<crate::surface::Direct3DSurface9>::opt(dst) }) else {
+        mtld3d_shared::log_once_warn!(
+            target: crate::LOG_TARGET,
+            "reject UpdateSurface: null destination surface → INVALIDCALL"
+        );
         return D3DERR_INVALIDCALL;
     };
     // SAFETY: vtable thunk; `this` is *mut Direct3DDevice9 per IDirect3DDevice9 ABI.
@@ -5550,6 +5558,11 @@ extern "system" fn device_update_surface(
         }
         let dst_level = dst_surf.mip_level() as usize;
         let Some(bpp) = map_d3d_format(src_fmt).map(|m| m.bytes_per_pixel()) else {
+            mtld3d_shared::log_once_warn!(
+                target: crate::LOG_TARGET,
+                "reject UpdateSurface: unmapped source format {} (0x{src_fmt:x}) → INVALIDCALL",
+                mtld3d_core::format::format_name(src_fmt)
+            );
             return D3DERR_INVALIDCALL;
         };
         let src_pitch = linear_row_pitch(src_w, bpp) as usize;
@@ -5592,12 +5605,20 @@ extern "system" fn device_update_surface(
                 .copy_bytes_to_staging_region(dst_level, &image, rect, point)
         };
         if !copied {
+            mtld3d_shared::log_once_warn!(
+                target: crate::LOG_TARGET,
+                "reject UpdateSurface: source region outside the destination mip → INVALIDCALL"
+            );
             return D3DERR_INVALIDCALL;
         }
         schedule_staging_upload_at_next_bind(tex);
         return D3D_OK;
     }
     if src_parent.is_null() || dst_parent.is_null() || std::ptr::eq(src_parent, dst_parent) {
+        mtld3d_shared::log_once_warn!(
+            target: crate::LOG_TARGET,
+            "reject UpdateSurface: endpoints are not two distinct textures → INVALIDCALL"
+        );
         return D3DERR_INVALIDCALL;
     }
     let src_level = src_surf.mip_level() as usize;
@@ -5610,6 +5631,10 @@ extern "system" fn device_update_surface(
         (unsafe { ValueIn::<[i32; 2]>::read_opt(dst_point) }).map_or((0, 0), |p| (p[0], p[1]));
     copy_systemmem_to_default(dst_parent, src_parent, |dst, src| {
         if !dst.update_region_valid(dst_level, src, src_level, rect, point) {
+            mtld3d_shared::log_once_warn!(
+                target: crate::LOG_TARGET,
+                "reject UpdateSurface: source rect/destination point out of bounds → INVALIDCALL"
+            );
             return D3DERR_INVALIDCALL;
         }
         match (dst_surf.cube_face(), src_surf.cube_face()) {
@@ -5626,7 +5651,13 @@ extern "system" fn device_update_surface(
             (None, None) => {
                 let _ = dst.copy_sub_region_from(dst_level, src, src_level, rect, point);
             }
-            _ => return D3DERR_INVALIDCALL,
+            _ => {
+                mtld3d_shared::log_once_warn!(
+                    target: crate::LOG_TARGET,
+                    "reject UpdateSurface: cube face mixed with a plain surface → INVALIDCALL"
+                );
+                return D3DERR_INVALIDCALL;
+            }
         }
         D3D_OK
     })
@@ -5639,6 +5670,10 @@ extern "system" fn device_update_texture(
 ) -> i32 {
     let _timer = device_timer(this, DeviceSubCategory::Misc);
     if src.is_null() || dst.is_null() {
+        mtld3d_shared::log_once_warn!(
+            target: crate::LOG_TARGET,
+            "reject UpdateTexture: null source or destination texture → INVALIDCALL"
+        );
         return D3DERR_INVALIDCALL;
     }
     // All texture interfaces share this wrapper layout. The type flag below
@@ -5647,6 +5682,10 @@ extern "system" fn device_update_texture(
     let src_parent = src.cast::<crate::texture::Direct3DTexture9>();
     let dst_parent = dst.cast::<crate::texture::Direct3DTexture9>();
     if std::ptr::eq(src_parent.cast_const(), dst_parent.cast_const()) {
+        mtld3d_shared::log_once_warn!(
+            target: crate::LOG_TARGET,
+            "reject UpdateTexture: source and destination are one texture → INVALIDCALL"
+        );
         return D3DERR_INVALIDCALL;
     }
     // SAFETY: vtable thunk; `this` is *mut Direct3DDevice9 per IDirect3DDevice9 ABI.
@@ -5666,6 +5705,10 @@ extern "system" fn device_update_texture(
     // SAFETY: same invariant as the source pointer above.
     let dst_is_cube = unsafe { (*dst_parent).is_cube() };
     if src_is_cube != dst_is_cube {
+        mtld3d_shared::log_once_warn!(
+            target: crate::LOG_TARGET,
+            "reject UpdateTexture: cube and non-cube endpoints mixed → INVALIDCALL"
+        );
         return D3DERR_INVALIDCALL;
     }
     if src_is_cube {


### PR DESCRIPTION
## Symptoms

`IDirect3DDevice9::UpdateSurface` from a standalone `D3DPOOL_SYSTEMMEM` / `D3DPOOL_SCRATCH` surface into a texture destination returned `D3DERR_INVALIDCALL` with nothing on the warn surface when the source format had no entry in the mtld3d format table. A title whose update silently failed left a `RUST_LOG=info` run clean, and the resulting texture was simply never populated. Nine further rejections in `device_update_surface` and `device_update_texture` were silent for the same reason; only the locked-endpoint and destination pool/format arms logged.

## Root cause

The `map_d3d_format(src_fmt)` `None` arm in the standalone system-memory branch of `device_update_surface` (`windows/d3d9/src/device.rs`) was a bare `return D3DERR_INVALIDCALL`. `docs/CONVENTIONS.md`, section "No silent failures", requires every stub, fallback, default `_ =>` arm and silent early return to log once; the rule is a review rule, `scripts/audit.sh` does not grep for it, so the arms drifted in unnoticed as the two functions grew.

## Changes

`windows/d3d9/src/device.rs`: every rejection in `device_update_surface` and `device_update_texture` now fires `log_once_warn!` naming its reason before returning `D3DERR_INVALIDCALL`. In `device_update_surface` that is the null source surface, the null destination surface, the unmapped source format, a system-memory source region that does not fit the destination mip, endpoints that are not two distinct textures, a source rect or destination point out of bounds, and a cube face mixed with a plain surface. In `device_update_texture` it is null endpoints, a source and destination naming one texture, and cube mixed with non-cube. The format arm names the format through `mtld3d_core::format::format_name` plus the raw `D3DFMT` code, since `format_name` returns `"D3DFMT_unknown"` for exactly the codes that reach this arm.

The staging-copy result is spelled as an `if !copied` early return rather than `return if copied { .. } else { .. }` so the failure has somewhere to log. Return values and control flow are otherwise unchanged.

The two `InPtr::opt` filters that reject a null `src`/`dst` are argument rejections, not the tree-wide silent null-`this` idiom, so they log here as well. Null-`this` filters elsewhere in the file are left alone.

## Alternatives

`log_once_warn_by!` keyed on the format code, so each distinct unmapped format gets its own line: rejected, one line per call site is enough to point at the format table and the per-key variant costs a mutex on a path that can repeat.

One shared rejection helper for both entry points: rejected, the reasons carry no common data and a helper would collapse the per-call-site latch that makes `log_once_warn!` fire once per reason instead of once per function.

Leaving the null-argument filters silent to match the rest of the file: rejected, a null surface passed to `UpdateSurface` is an application error worth one line, and the file's silent filters are all null-`this` checks, which this change does not touch.

## Verification

`make check` green (fmt, clippy nursery and pedantic on both PE targets and native, `audit: clean (234 files)`, doc). `make test` green: 783 core unit tests, 125 unix unit tests, and the end-to-end suite twice, 284 tests on i686 and 284 on x86_64, 1471 `PASS` and 5 benign `LEAK` across the four runs, no `FAIL`, `SIGABRT` or `TIMEOUT`.

No test accompanies the change. The end-to-end harness asserts on `HRESULT`s and pixels and cannot observe a log line, and the returned codes are unchanged, so a test that fails before and passes after does not exist for this diff. A reviewer judges it by reading the arms against the "No silent failures" section of `docs/CONVENTIONS.md`.

Conformance was not run: the diff adds log statements only and touches no render, state or shader-emission path.

Closes #127
