### PR TITLE
Count a window-manager rounding answer as covering the monitor

### DIFF
--- a/windows/core/src/fullscreen_resize.rs
+++ b/windows/core/src/fullscreen_resize.rs
@@ -8,11 +8,20 @@
 //! window. The answer is to re-assert the monitor rect — but never in an
 //! unbounded fight with a window manager that keeps clamping the window
 //! back, so the decision lives here as pure, host-testable state.
+//!
+//! A rect the window manager answers with a pixel larger than the monitor is
+//! not one of those resizes. The window still covers the display, and a
+//! re-assert only repeats the round trip that produced the extra pixel, so a
+//! size that covers the monitor within that rounding counts as covered.
 
 /// What to do about one external resize of a fullscreen device's window.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ExternalResizeAction {
-    /// The window already covers the monitor; nothing to do.
+    /// The window covers the monitor already; nothing to do.
+    ///
+    /// Covering allows for the window manager's own rounding, so a rect it
+    /// answers a pixel larger than the monitor lands here rather than in a
+    /// re-assert that cannot win.
     Covered,
     /// Re-apply the monitor rect.
     Reassert,
@@ -31,6 +40,33 @@ pub enum ExternalResizeAction {
 /// re-assert per frame. Refilled whenever the window is seen covered and on
 /// every fullscreen Reset.
 const REASSERT_BUDGET: u8 = 8;
+
+/// Pixels a window may exceed the monitor by and still count as covering it.
+///
+/// A window rect makes a round trip through the window manager's own
+/// coordinate space, and a monitor dimension that does not land on that
+/// space's grid can come back a pixel or two larger than the rect that was
+/// asked for. Such a window covers the display, which is what the fullscreen
+/// rect is for, and re-asserting the monitor rect only repeats the round
+/// trip: without the slack the guard spends its budget on a window that was
+/// never wrong and ends the session with the give-up warning.
+const COVER_SLACK: u32 = 2;
+
+/// `true` when `size` covers `monitor`, the window manager's rounding allowed for.
+///
+/// Covering is not equality: a size at least as large as the monitor on both
+/// axes, by no more than the window manager's rounding, is what a fullscreen
+/// window has to hold. Anything smaller on either axis leaves the desktop
+/// showing, and anything larger than that is a size the game chose.
+#[must_use]
+pub const fn covers_monitor(size: (u32, u32), monitor: (u32, u32)) -> bool {
+    covers_axis(size.0, monitor.0) && covers_axis(size.1, monitor.1)
+}
+
+/// One axis of [`covers_monitor`].
+const fn covers_axis(size: u32, monitor: u32) -> bool {
+    size >= monitor && size - monitor <= COVER_SLACK
+}
 
 /// Ping-pong guard for [`ExternalResizeAction`] decisions.
 ///
@@ -70,7 +106,7 @@ impl ExternalResizeGuard {
     /// `incoming` is the window's new client size, `monitor` the monitor
     /// rect it is supposed to cover, both in pixels.
     pub fn decide(&mut self, incoming: (u32, u32), monitor: (u32, u32)) -> ExternalResizeAction {
-        if incoming == monitor {
+        if covers_monitor(incoming, monitor) {
             self.reset();
             return ExternalResizeAction::Covered;
         }

--- a/windows/core/src/fullscreen_resize/tests.rs
+++ b/windows/core/src/fullscreen_resize/tests.rs
@@ -5,8 +5,12 @@
 //! clamp size earns exactly one re-assert and its repeat is suppressed, and
 //! covering the monitor or calling `reset` refills the budget. The budget caps
 //! the alternating-clamp pathology instead of re-asserting every frame.
+//! Covering allows for the window manager's rounding, so the rules are pinned
+//! against a rect a pixel larger than the monitor as well as an exact one.
 
-use super::{ExternalResizeAction, ExternalResizeGuard, REASSERT_BUDGET};
+use super::{
+    COVER_SLACK, ExternalResizeAction, ExternalResizeGuard, REASSERT_BUDGET, covers_monitor,
+};
 
 const MONITOR: (u32, u32) = (3456, 2234);
 
@@ -14,6 +18,40 @@ const MONITOR: (u32, u32) = (3456, 2234);
 fn a_covered_window_is_left_alone() {
     let mut g = ExternalResizeGuard::new();
     assert_eq!(g.decide(MONITOR, MONITOR), ExternalResizeAction::Covered);
+}
+
+#[test]
+fn a_window_manager_rounding_up_still_counts_as_covered() {
+    let mut g = ExternalResizeGuard::new();
+    // The rect a window manager answers with when a monitor dimension does
+    // not land on its coordinate grid. It covers the display, so re-asserting
+    // the monitor rect would only repeat that round trip.
+    let rounded = (MONITOR.0, MONITOR.1 + 1);
+    assert_eq!(g.decide(rounded, MONITOR), ExternalResizeAction::Covered);
+    assert_eq!(g.decide(rounded, MONITOR), ExternalResizeAction::Covered);
+}
+
+#[test]
+fn covering_the_monitor_takes_a_size_from_the_monitor_up_to_the_slack() {
+    let (width, height) = MONITOR;
+    let slack = COVER_SLACK;
+    assert!(covers_monitor(MONITOR, MONITOR));
+    assert!(covers_monitor((width + slack, height + slack), MONITOR));
+    // One pixel short on either axis leaves the desktop showing.
+    assert!(!covers_monitor((width - 1, height), MONITOR));
+    assert!(!covers_monitor((width, height - 1), MONITOR));
+    // Beyond the slack the size is the game's own, not the window manager's.
+    assert!(!covers_monitor((width + slack + 1, height), MONITOR));
+    assert!(!covers_monitor((width, height + slack + 1), MONITOR));
+}
+
+#[test]
+fn a_window_larger_than_the_slack_is_reasserted() {
+    let mut g = ExternalResizeGuard::new();
+    // A mode's outer rect that overshoots the monitor is a size the game
+    // chose, so the monitor rect is re-applied over it.
+    let oversize = (MONITOR.0 + 64, MONITOR.1 + 64);
+    assert_eq!(g.decide(oversize, MONITOR), ExternalResizeAction::Reassert);
 }
 
 #[test]

--- a/windows/tests/tests/device.rs
+++ b/windows/tests/tests/device.rs
@@ -963,15 +963,21 @@ fn fullscreen_window_reasserts_monitor_rect_after_external_resize() {
         "the app-set rect survives its own SetWindowPos call",
     );
 
+    // Coverage, not equality: this is the first rect in the test the window
+    // manager has had a chance to answer, and its answer can be a pixel
+    // larger than the monitor when a monitor dimension does not land on its
+    // coordinate grid. Such a window covers the display, which is what a
+    // fullscreen window owes, so the assertion reads the same rule the
+    // re-cover does.
     assert!(h.pump(), "no WM_QUIT expected");
     let rect = h.window_rect();
-    assert_eq!(
-        (
-            u32::try_from(rect.right - rect.left).expect("width is positive"),
-            u32::try_from(rect.bottom - rect.top).expect("height is positive")
-        ),
-        (screen_w, screen_h),
-        "processing window events re-covers the monitor",
+    let covered = (
+        u32::try_from(rect.right - rect.left).expect("width is positive"),
+        u32::try_from(rect.bottom - rect.top).expect("height is positive"),
+    );
+    assert!(
+        mtld3d_core::fullscreen_resize::covers_monitor(covered, (screen_w, screen_h)),
+        "processing window events re-covers the monitor: {covered:?} against ({screen_w}, {screen_h})",
     );
     let (bb_hr, bb) = h.back_buffer(0).desc();
     assert_eq!(bb_hr, D3D_OK, "GetDesc after the external resize");


### PR DESCRIPTION
## Symptoms

`device::fullscreen_window_reasserts_monitor_rect_after_external_resize` fails intermittently under machine load, asserting `(1728, 1118)` against the expected `(1728, 1117)`, preceded by `the window manager keeps re-sizing the fullscreen window (1728x1118); leaving it, the back buffer keeps its size and present scales the frame`. Version stamps match and the test passes on re-run.

## Root cause

`ExternalResizeGuard::decide` counted a window as covering the monitor only when its size equalled the monitor rect exactly. The warning above says what the window manager answered instead: the re-asserted 1728x1117 rect came back as a 1728x1118 window, one pixel taller than the monitor. The guard read that as another external resize, re-asserted the monitor rect, got the same answer, and then took its ping-pong exit and left the window alone, which is the documented give-up path. The window covered the display the whole time, but the test compared it against `GetSystemMetrics` for equality, so whether it passed depended on whether the window manager's answer landed inside the message pump the test drives or after it.

Why the answer is a pixel larger is conjecture: a window rect makes a round trip through the window manager's own coordinate space, and a monitor dimension that does not land on that space's grid comes back rounded up. The rect never came back short, and no re-assert can win against it, since re-applying the monitor rect only repeats the round trip.

## Changes

`mtld3d-core`: `fullscreen_resize` gains `covers_monitor`, the rule that a size at least as large as the monitor on both axes, by no more than two pixels, covers it. `decide` uses it in place of the equality test, so a rounding answer is `Covered` (and refills the re-assert budget) rather than `Reassert` followed by `Suppressed`. A size short on either axis, and a size larger than the slack (a mode outer rect the game picked), still earn their re-assert.

`windows/tests`: the end-to-end test asserts `covers_monitor` for the rect it reads after the pump, which is the one rect in the test the window manager has had a chance to answer. The rects the test reads before that, and the exact-equality assertions in the other fullscreen tests, are unchanged: those are read straight after our own `SetWindowPos`, before any answer, so equality is still the right assertion there.

## Alternatives

Poll the window rect until it is stable and assert the final value: it makes the test wait for an answer that may not come, and it would still assert equality against a rect the window manager will not produce.

Widen the assertion to a bare tolerance in the test only: leaves the layer fighting the window manager for a window that was never wrong, so the spurious give-up warning and its `SetWindowPos` pair stay in every fullscreen session on such a display.

Make the re-cover win by re-applying the monitor rect until it sticks: it cannot stick, and unbounded re-asserts are exactly what the guard exists to prevent.

## Verification

`make check` green. `make test` green: 785 host unit tests, 125 unix tests, 285 end-to-end tests per architecture (i686 and x86_64), 0 failures, 3 LEAK.

New unit tests in `windows/core/src/fullscreen_resize/tests.rs`: `a_window_manager_rounding_up_still_counts_as_covered` fails before the change (`Reassert` where `Covered` is expected) and passes after; `covering_the_monitor_takes_a_size_from_the_monitor_up_to_the_slack` and `a_window_larger_than_the_slack_is_reasserted` pin the edges of the new rule.

The one-pixel answer does not reproduce on this machine, whose Win32 monitor rect is 3456x2234 with `RetinaMode` on. Running the prefix with `RetinaMode` off reproduces the reported 1728x1117 geometry exactly; the window manager answered the monitor rect unchanged there across 45 runs of the failing test, 25 of them under ten spinning cores, so the fix is verified through the policy unit tests rather than through the flake itself. The end-to-end test was run 20 more times in that geometry after the change, all green.

Closes #108
