### PR TITLE
Correct format_name's doc for the unmapped fallback

### DIFF
--- a/windows/core/src/format.rs
+++ b/windows/core/src/format.rs
@@ -123,9 +123,11 @@ impl FormatMapping {
 
 /// Friendly name for a D3DFMT_* code.
 ///
-/// Returns `"D3DFMT_<code>"` for formats not in the canonical mtld3d mapping
-/// table — keeps log lines readable for both supported and unmapped formats
-/// without callers needing to special-case "unknown".
+/// A mapped format renders as its bare name (`"A8R8G8B8"`); anything outside
+/// the canonical mtld3d mapping table renders as the fixed string
+/// `"D3DFMT_unknown"`. The function is `const` and returns a `&'static str`,
+/// so it cannot render the code itself: a log line that has to identify an
+/// unmapped format prints the raw code beside the name.
 #[must_use]
 pub const fn format_name(d3d_format: u32) -> &'static str {
     match d3d_format {

--- a/windows/core/src/format/tests.rs
+++ b/windows/core/src/format/tests.rs
@@ -7,7 +7,8 @@
 //! color and unknown formats stay unmapped. The colour side pins the
 //! wide-channel family (16-bit unorm and the floats): Metal format, pitch,
 //! and the missing-channel swizzle, plus `is_mapped_color_format` tracking
-//! the lookup table.
+//! the lookup table. `format_name` is pinned on both sides: a mapped name,
+//! and the fixed unknown fallback that callers log the raw code beside.
 
 use mtld3d_types::{D3DUSAGE_NONSECURE, D3DUSAGE_WRITEONLY};
 
@@ -23,7 +24,7 @@ use super::{
     D3DUSAGE_QUERY_LEGACYBUMPMAP, D3DUSAGE_QUERY_POSTPIXELSHADER_BLENDING, D3DUSAGE_QUERY_SRGBREAD,
     D3DUSAGE_QUERY_SRGBWRITE, D3DUSAGE_QUERY_VERTEXTEXTURE, D3DUSAGE_QUERY_WRAPANDMIP,
     D3DUSAGE_RENDERTARGET, D3DUSAGE_RTPATCHES, D3DUSAGE_SOFTWAREPROCESSING, PixelFormat,
-    StandaloneSurfaceKind, Swizzle, depth_format_bytes_per_pixel, is_depth_format,
+    StandaloneSurfaceKind, Swizzle, depth_format_bytes_per_pixel, format_name, is_depth_format,
     is_mapped_color_format, linear_row_pitch, map_d3d_depth_format, map_d3d_format,
     standalone_surface_bytes, surface_bytes, usage_allowed_for_rtype,
 };
@@ -141,6 +142,14 @@ fn is_mapped_color_format_tracks_the_lookup() {
         assert!(!is_mapped_color_format(fmt), "format {fmt}");
         assert!(map_d3d_format(fmt).is_none(), "format {fmt}");
     }
+}
+
+#[test]
+fn format_name_renders_mapped_names_and_a_fixed_unknown() {
+    assert_eq!(format_name(D3DFMT_A8R8G8B8), "A8R8G8B8");
+    // The fallback carries no code, so a caller that needs one logs it
+    // alongside the name.
+    assert_eq!(format_name(0xFFFF_FFFF), "D3DFMT_unknown");
 }
 
 #[test]


### PR DESCRIPTION
## Symptoms

`format_name` in `windows/core/src/format.rs` documents that a format outside the mapping table renders as `"D3DFMT_<code>"`, so a reader adding a log line expects the code to be in the string. The catch-all arm returns the fixed string `"D3DFMT_unknown"` instead, and a log line written against the doc identifies an unmapped format as `D3DFMT_unknown` with no way to tell which code was rejected.

## Root cause

The function is `const` and returns `&'static str`, so it cannot format a code into its result at all. The doc describes an interface the signature rules out, so the doc is the side that is wrong.

## Changes

`windows/core/src/format.rs`: the doc now states what the arms return, a bare name such as `"A8R8G8B8"` for a mapped format and the fixed `"D3DFMT_unknown"` for anything else, and why (`const fn` returning `&'static str`), and records the contract callers follow: a log line that has to identify an unmapped format prints the raw code beside the name.

The one caller, the `StretchRect` format-mismatch rejection in `windows/d3d9/src/device.rs`, already prints both (`src={} 0x{:x}, dst={} 0x{:x}`), so no call site changes.

`windows/core/src/format/tests.rs`: `format_name_renders_mapped_names_and_a_fixed_unknown` pins both sides of the match, the mapped name and the fallback string.

## Alternatives

Add a non-const variant returning `String` for logging: rejected, the sole caller has the code in hand and formats it directly, so the allocation buys nothing.

Change the fallback to a code-bearing string: impossible without dropping `const` and `&'static str`, and the mapped arms return bare names without the `D3DFMT_` prefix anyway, so a code-bearing fallback would not match them either.

## Verification

`make check` clean. `make test` green: unit legs 810 (windows) and 125 (unix) passed, e2e 289 passed per architecture on i686 and x86_64, no FAIL, SIGABRT or TIMEOUT; the leaky lines are benign.

The new unit test is a pin, not a fail-then-pass proof: this change is documentation only and moves no behaviour. `fullscreen_window_reasserts_monitor_rect_after_external_resize` failed once on an unrelated one-pixel monitor-height mismatch (`left: (1728, 1118)`, `right: (1728, 1117)`) and passed on a repeat run of the same build; it is a window-manager race in that test, not a product of this change.

Closes #138
