### PR TITLE
Regenerate the derive inventory after a rebase duplicated its lines

### DIFF
--- a/scripts/derive_inventory.txt
+++ b/scripts/derive_inventory.txt
@@ -149,13 +149,7 @@ windows/core/src/stretch_rect.rs RejectReason Clone,Copy,Debug,PartialEq,Eq
 windows/core/src/stretch_rect.rs StretchRegion Clone,Copy,Debug,PartialEq,Eq
 windows/core/src/texture_flags.rs TextureFlags Clone,Copy,Debug,Default,PartialEq,Eq
 windows/core/src/texture_staging.rs LockAction Debug,Clone,Copy,PartialEq,Eq
-windows/core/src/texture_staging.rs LockAction Debug,Clone,Copy,PartialEq,Eq
-windows/core/src/texture_staging.rs LockAction Debug,Clone,Copy,PartialEq,Eq
 windows/core/src/texture_staging.rs MipShape Debug,Clone,Copy,PartialEq,Eq
-windows/core/src/texture_staging.rs MipShape Debug,Clone,Copy,PartialEq,Eq
-windows/core/src/texture_staging.rs MipShape Debug,Clone,Copy,PartialEq,Eq
-windows/core/src/texture_staging.rs PreserveKind Debug,Clone,Copy,PartialEq,Eq
-windows/core/src/texture_staging.rs PreserveKind Debug,Clone,Copy,PartialEq,Eq
 windows/core/src/texture_staging.rs PreserveKind Debug,Clone,Copy,PartialEq,Eq
 windows/core/src/upload_pass.rs UploadDecode Clone,Copy,Debug,PartialEq,Eq
 windows/core/src/upload_recovery.rs UploadFate Clone,Copy,Debug,PartialEq,Eq


### PR DESCRIPTION
## Symptoms

`scripts/audit.sh` on `main` lists the `texture_staging.rs` entries for `MipShape` and `PreserveKind` as unexpected extra lines, so `make check` is red.

## Root cause

A rebase auto-merged `scripts/derive_inventory.txt` from both sides of a conflict and kept the same insertion three times.

## Changes

`scripts/derive_inventory.txt` regenerated with `scripts/audit.sh --update-derives`. No code change.

## Alternatives

None: the file is generated.

## Verification

`scripts/audit.sh` is clean after the change.

Closes #245
