### PR TITLE
Mark the autogen ColorFill mip-chain e2e test as a test

### DIFF
--- a/windows/tests/tests/render_target.rs
+++ b/windows/tests/tests/render_target.rs
@@ -2196,6 +2196,11 @@ fn a_back_buffer_sized_lockable_render_target_keeps_its_reported_extent() {
     );
 }
 
+/// A `ColorFill` into an autogen-mipmap render target regenerates its chain.
+///
+/// The fill lands on level 0 through the GPU path, so the lower levels have
+/// to be rebuilt from it before the next sample reads them.
+#[test]
 fn color_fill_autogen_render_target_regenerates_the_mip_chain() {
     // The runtime owns a D3DUSAGE_AUTOGENMIPMAP texture's mip chain, so a
     // ColorFill into level 0 regenerates it. Seed the chain red through a


### PR DESCRIPTION
## Symptoms

`make check` is red on `main`: the PE clippy legs deny the `dead_code` warning on `color_fill_autogen_render_target_regenerates_the_mip_chain` in `windows/tests/tests/render_target.rs`, and the test PR #239 added never ran.

## Root cause

The function landed without its `#[test]` attribute.

## Changes

`windows/tests/tests/render_target.rs`: the attribute and a doc comment in the file's shape are added. Nothing else changes.

## Alternatives

None.

## Verification

`cargo clippy -p mtld3d-tests --all-targets --target i686-pc-windows-msvc` with warnings denied is clean; the test appears once per architecture in `make test` and passes (it exercised the GPU ColorFill and autogen paths PR #239 pinned).

Closes #248
