### PR TITLE
Name the D3D enum values the e2e presentation parameters restate

### DIFF
--- a/windows/tests/tests/device.rs
+++ b/windows/tests/tests/device.rs
@@ -15,10 +15,10 @@ use mtld3d_types::{
     D3DFMT_X8R8G8B8, D3DFMT_YUY2, D3DFVF_XYZ, D3DOK_NOAUTOGEN, D3DPOOL_DEFAULT, D3DPOOL_MANAGED,
     D3DPOOL_SCRATCH, D3DPOOL_SYSTEMMEM, D3DPRESENT_INTERVAL_IMMEDIATE, D3DPRESENT_INTERVAL_ONE,
     D3DPRESENT_PARAMETERS, D3DRS_FILLMODE, D3DRS_LIGHTING, D3DRTYPE_CUBETEXTURE, D3DRTYPE_SURFACE,
-    D3DRTYPE_TEXTURE, D3DUSAGE_AUTOGENMIPMAP, D3DUSAGE_DEPTHSTENCIL, D3DUSAGE_DYNAMIC,
-    D3DUSAGE_QUERY_FILTER, D3DUSAGE_QUERY_POSTPIXELSHADER_BLENDING, D3DUSAGE_QUERY_SRGBREAD,
-    D3DUSAGE_QUERY_SRGBWRITE, D3DUSAGE_QUERY_VERTEXTEXTURE, D3DUSAGE_QUERY_WRAPANDMIP,
-    D3DUSAGE_RENDERTARGET, D3DVIEWPORT9, DevCaps, TextureCaps,
+    D3DRTYPE_TEXTURE, D3DSWAPEFFECT_DISCARD, D3DUSAGE_AUTOGENMIPMAP, D3DUSAGE_DEPTHSTENCIL,
+    D3DUSAGE_DYNAMIC, D3DUSAGE_QUERY_FILTER, D3DUSAGE_QUERY_POSTPIXELSHADER_BLENDING,
+    D3DUSAGE_QUERY_SRGBREAD, D3DUSAGE_QUERY_SRGBWRITE, D3DUSAGE_QUERY_VERTEXTEXTURE,
+    D3DUSAGE_QUERY_WRAPANDMIP, D3DUSAGE_RENDERTARGET, D3DVIEWPORT9, DevCaps, TextureCaps,
 };
 
 #[test]
@@ -596,7 +596,7 @@ fn reset_bad_dims_rejected() {
         back_buffer_count: 1,
         multi_sample_type: 0,
         multi_sample_quality: 0,
-        swap_effect: 1, // D3DSWAPEFFECT_DISCARD (irrelevant — rejected on dims first)
+        swap_effect: D3DSWAPEFFECT_DISCARD,
         device_window: 0,
         windowed: 0,
         enable_auto_depth_stencil: 0,
@@ -746,7 +746,7 @@ const fn fullscreen_params(hwnd: usize, width: u32, height: u32) -> D3DPRESENT_P
         back_buffer_count: 1,
         multi_sample_type: 0,
         multi_sample_quality: 0,
-        swap_effect: 1, // D3DSWAPEFFECT_DISCARD
+        swap_effect: D3DSWAPEFFECT_DISCARD,
         device_window: hwnd,
         windowed: 0,
         enable_auto_depth_stencil: 0,

--- a/windows/tests/tests/render_target.rs
+++ b/windows/tests/tests/render_target.rs
@@ -2360,7 +2360,7 @@ fn surface_ops_contracts() {
         "CreateOffscreenPlainSurface(D3DPOOL_DEFAULT) succeeds",
     );
     assert_eq!(
-        h.create_offscreen_plain_surface_hr(64, 64, D3DFMT_A8R8G8B8, 1 /* D3DPOOL_MANAGED */),
+        h.create_offscreen_plain_surface_hr(64, 64, D3DFMT_A8R8G8B8, D3DPOOL_MANAGED),
         D3DERR_INVALIDCALL,
         "CreateOffscreenPlainSurface(D3DPOOL_MANAGED) is rejected",
     );


### PR DESCRIPTION
## Symptoms

`windows/tests/tests/device.rs` built both of its `D3DPRESENT_PARAMETERS` with `swap_effect: 1, // D3DSWAPEFFECT_DISCARD`, and `windows/tests/tests/render_target.rs` passed the rejected offscreen-plain pool as `1 /* D3DPOOL_MANAGED */`. A reader has to trust the comment, and a comment that drifts from the literal is silently wrong.

## Root cause

`mtld3d_types::D3DSWAPEFFECT_DISCARD` and `mtld3d_types::D3DPOOL_MANAGED` both exist and the rest of the suite already uses them; these call sites predate that habit.

## Changes

`device.rs` imports `D3DSWAPEFFECT_DISCARD` and uses it for `swap_effect` in `reset_bad_dims_rejected` and in the `fullscreen_params` helper. `render_target.rs` uses the `D3DPOOL_MANAGED` it already imports for the rejected `CreateOffscreenPlainSurface` pool.

The remaining literal of this shape in the suite is `create_render_target_hr(640, 480, 0 /* D3DFMT_UNKNOWN */)` in `render_target.rs`. `mtld3d_types` has no `D3DFMT_UNKNOWN`, so naming it means adding a public constant, which is outside a substitution; it is left alone.

## Alternatives

Add `D3DFMT_UNKNOWN` to `mtld3d-types` and sweep that call site too: rejected, it grows the public surface of another crate for a test-readability fix and belongs with whoever needs the constant.

## Verification

Substitution only: `D3DSWAPEFFECT_DISCARD` is 1 and `D3DPOOL_MANAGED` is 1, so no test can change behaviour and none is expected to fail before the change. The existing tests are the net: `device::reset_bad_dims_rejected`, `device::reset_fullscreen_adopts_monitor_rect_and_restores` (through `fullscreen_params`), and `render_target::surface_ops_contracts` each pass once per architecture.

`make check` clean (audit clean, 237 files). `make test` green: 810 unit tests, 125 conformance unit tests, and 293 e2e tests per architecture (i686 and x86_64), 1516 PASS, 5 LEAK, 0 FAIL, 0 SIGABRT, 0 TIMEOUT.

Closes #149
