### PR TITLE
Guard the texture-to-texture blit against Metal's copy preconditions

### DIFF
--- a/scripts/derive_inventory.txt
+++ b/scripts/derive_inventory.txt
@@ -43,6 +43,7 @@ unix/shared/src/params.rs StencilFaceParams Clone,Copy,Debug,PartialEq,Eq
 unix/shared/src/params.rs VertexAttrDesc Clone,Copy
 unix/unix/src/metal/clear_quad.rs ClearQuadKey Hash,PartialEq,Eq,Clone,Copy
 unix/unix/src/metal/command.rs BlitSite Clone,Copy
+unix/unix/src/metal/command.rs CopyRejectReason Clone,Copy,PartialEq,Eq,Debug
 unix/unix/src/metal/command.rs PresentGeometry Clone,Copy,PartialEq,Eq
 unix/unix/src/metal/command.rs PresentRoute Clone,Copy,PartialEq,Eq,Debug
 unix/unix/src/metal/macdrv.rs ColorspaceFlags Clone,Copy,Debug,Default,PartialEq,Eq

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -36,7 +36,7 @@ use objc2_quartz_core::CAMetalDrawable;
 
 use crate::{
     LOG_TARGET,
-    metal::{handle::IntoRetained, null_texture},
+    metal::{handle::IntoRetained, null_texture, texture::mtl_pixel_format},
 };
 
 /// `Retained<ProtocolObject<dyn MTLCommandBuffer>>` is not `Send`/`Sync` in objc2.
@@ -1159,6 +1159,163 @@ const fn pixel_format_supports_mipgen(fmt: MTLPixelFormat) -> bool {
     )
 }
 
+/// Why Metal would refuse a texture-to-texture blit.
+///
+/// `copyFromTexture:` validates every one of these itself: under
+/// `MTL_DEBUG_LAYER` a violation aborts the process, and without the layer
+/// the copy is undefined. The blit encoder tests them first and skips the
+/// copy, so a caller that sends a mismatched pair loses one copy rather than
+/// the process.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum CopyRejectReason {
+    /// The pixel formats are neither equal nor a linear/sRGB twin pair.
+    FormatMismatch,
+    /// The sample counts differ, which a blit copy cannot resolve.
+    SampleCountMismatch,
+    /// The source texture has no such mip level.
+    SourceLevelMissing,
+    /// The destination texture has no such mip level.
+    DestinationLevelMissing,
+    /// The region leaves the addressed source mip level.
+    SourceRegionOutOfBounds,
+    /// The region leaves the addressed destination mip level.
+    DestinationRegionOutOfBounds,
+}
+
+impl CopyRejectReason {
+    /// Stable `u64` key so `log_once_warn_by!` fires once per reason.
+    ///
+    /// Keying on the discriminant keeps the reasons distinct instead of
+    /// collapsing every later rejection into the first one seen.
+    const fn key(self) -> u64 {
+        self as u64
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::FormatMismatch => "source and destination pixel formats are incompatible",
+            Self::SampleCountMismatch => "source and destination sample counts differ",
+            Self::SourceLevelMissing => "the source has no such mip level",
+            Self::DestinationLevelMissing => "the destination has no such mip level",
+            Self::SourceRegionOutOfBounds => "the region leaves the source mip level",
+            Self::DestinationRegionOutOfBounds => "the region leaves the destination mip level",
+        }
+    }
+}
+
+/// One end of a texture-to-texture blit, as the live `MTLTexture` describes it.
+///
+/// `width` and `height` are the base level's, `level` the mip level the copy
+/// addresses and `levels` the texture's level count, so the addressed extent
+/// is derived here rather than passed in alongside them.
+struct CopyEndpoint {
+    pixel_format: MTLPixelFormat,
+    sample_count: usize,
+    width: usize,
+    height: usize,
+    level: usize,
+    levels: usize,
+    origin_x: usize,
+    origin_y: usize,
+}
+
+impl CopyEndpoint {
+    /// Extent of the addressed mip level, or `None` when it does not exist.
+    const fn level_extent(&self) -> Option<(usize, usize)> {
+        if self.level >= self.levels {
+            return None;
+        }
+        let w = self.width >> self.level;
+        let h = self.height >> self.level;
+        Some((if w == 0 { 1 } else { w }, if h == 0 { 1 } else { h }))
+    }
+}
+
+impl core::fmt::Display for CopyEndpoint {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{:?} samples={} level={}/{} origin={},{} size={}x{}",
+            self.pixel_format,
+            self.sample_count,
+            self.level,
+            self.levels,
+            self.origin_x,
+            self.origin_y,
+            self.width,
+            self.height
+        )
+    }
+}
+
+/// The sRGB-encoded twin of a pixel format the wire enum covers.
+fn srgb_twin_of(format: MTLPixelFormat) -> Option<MTLPixelFormat> {
+    let raw = u32::try_from(format.0).ok()?;
+    Some(mtl_pixel_format(PixelFormat::from_repr(raw)?.srgb_twin()?))
+}
+
+/// Whether `copyFromTexture:` accepts a copy between these two pixel formats.
+///
+/// Equal formats always. A linear format and its sRGB twin are the one
+/// unequal pair Metal accepts, being two encodings of one base format, and
+/// mtld3d creates an sRGB view next to every colour texture that has one.
+fn pixel_formats_copy_compatible(src: MTLPixelFormat, dst: MTLPixelFormat) -> bool {
+    if src == dst {
+        return true;
+    }
+    if srgb_twin_of(src) == Some(dst) {
+        return true;
+    }
+    srgb_twin_of(dst) == Some(src)
+}
+
+/// Whether a region placed at `origin` stays inside `extent`.
+const fn region_fits(
+    origin: (usize, usize),
+    region: (usize, usize),
+    extent: (usize, usize),
+) -> bool {
+    match (
+        origin.0.checked_add(region.0),
+        origin.1.checked_add(region.1),
+    ) {
+        (Some(right), Some(bottom)) => right <= extent.0 && bottom <= extent.1,
+        _ => false,
+    }
+}
+
+/// Reject a texture-to-texture copy `copyFromTexture:` would not accept.
+///
+/// `None` means the pair is copyable. One region serves both ends because a
+/// blit copy cannot resize, so it is bounds-checked against each of them.
+fn copy_texture_reject(
+    src: &CopyEndpoint,
+    dst: &CopyEndpoint,
+    region_w: usize,
+    region_h: usize,
+) -> Option<CopyRejectReason> {
+    if !pixel_formats_copy_compatible(src.pixel_format, dst.pixel_format) {
+        return Some(CopyRejectReason::FormatMismatch);
+    }
+    if src.sample_count != dst.sample_count {
+        return Some(CopyRejectReason::SampleCountMismatch);
+    }
+    let Some(src_extent) = src.level_extent() else {
+        return Some(CopyRejectReason::SourceLevelMissing);
+    };
+    let Some(dst_extent) = dst.level_extent() else {
+        return Some(CopyRejectReason::DestinationLevelMissing);
+    };
+    let region = (region_w, region_h);
+    if !region_fits((src.origin_x, src.origin_y), region, src_extent) {
+        return Some(CopyRejectReason::SourceRegionOutOfBounds);
+    }
+    if !region_fits((dst.origin_x, dst.origin_y), region, dst_extent) {
+        return Some(CopyRejectReason::DestinationRegionOutOfBounds);
+    }
+    None
+}
+
 /// Replay the frame's leading blit commands inside a single `MTLBlitCommandEncoder`.
 ///
 /// Runs before any render pass. Preserves ordering between
@@ -1308,6 +1465,47 @@ fn encode_leading_blits(
                 // are unaffected.
                 let dst_x = (cmd.dst_offset & 0xFFFF_FFFF) as usize;
                 let dst_y = ((cmd.dst_offset >> 32) & 0xFFFF_FFFF) as usize;
+                let src_endpoint = CopyEndpoint {
+                    pixel_format: src.pixelFormat(),
+                    sample_count: src.sampleCount(),
+                    width: src.width(),
+                    height: src.height(),
+                    level: cmd.mip_level as usize,
+                    levels: src.mipmapLevelCount(),
+                    origin_x: cmd.origin_x as usize,
+                    origin_y: cmd.origin_y as usize,
+                };
+                let dst_endpoint = CopyEndpoint {
+                    pixel_format: dst.pixelFormat(),
+                    sample_count: dst.sampleCount(),
+                    width: dst.width(),
+                    height: dst.height(),
+                    level: cmd.dst_mip_level as usize,
+                    levels: dst.mipmapLevelCount(),
+                    origin_x: dst_x,
+                    origin_y: dst_y,
+                };
+                let region_w = cmd.region_w;
+                let region_h = cmd.region_h;
+                if let Some(reason) = copy_texture_reject(
+                    &src_endpoint,
+                    &dst_endpoint,
+                    region_w as usize,
+                    region_h as usize,
+                ) {
+                    let reason_text = reason.as_str();
+                    let src_handle = cmd.src_handle;
+                    let dst_handle = cmd.dst_handle;
+                    mtld3d_shared::log_once_warn_by!(
+                        target: crate::LOG_TARGET,
+                        key: reason.key(),
+                        "encode_leading_blits: {reason_text}, copy skipped. \
+                         src handle={src_handle:#x} {src_endpoint}, \
+                         dst handle={dst_handle:#x} {dst_endpoint}, \
+                         region {region_w}x{region_h}"
+                    );
+                    continue;
+                }
                 mtld3d_shared::crumb!("blit:tex2tex", cmd.src_handle, cmd.dst_handle);
                 // SAFETY: objc2 typed binding; `src`/`dst` are retained Metal
                 // textures live for the call; geometry comes from a packed

--- a/unix/unix/src/metal/command/tests.rs
+++ b/unix/unix/src/metal/command/tests.rs
@@ -1,12 +1,21 @@
-//! Unit tests for present routing and the geometry settle filter.
+//! Unit tests for present routing, the geometry settle filter and the blit copy guard.
 //!
 //! `present_route` is checked across the geometries a present can produce: equal extents
 //! copy, an enlargement in both axes reaches `MetalFX` only if it exists, and anything
 //! else falls to the stretch shader. The settle tests pin the other half of the decision,
 //! that a scaler is spent on a geometry that held still rather than on a ratio, which is
 //! what keeps a window drag from building one scaler per frame.
+//!
+//! `copy_texture_reject` is checked against each condition Metal validates on
+//! `copyFromTexture:`, plus the pairs it accepts: an identical pair, a sub-rect inside a
+//! mip level, and a linear format against its sRGB twin.
 
-use super::{PresentGeometry, PresentRoute, SETTLED_PRESENTS, geometry_settled, present_route};
+use objc2_metal::MTLPixelFormat;
+
+use super::{
+    CopyEndpoint, CopyRejectReason, PresentGeometry, PresentRoute, SETTLED_PRESENTS,
+    copy_texture_reject, geometry_settled, present_route,
+};
 
 /// Matching extents take the blit whether or not `MetalFX` exists.
 #[test]
@@ -168,4 +177,146 @@ fn a_changed_geometry_restarts_the_count() {
         SETTLED_PRESENTS <= 2,
         "returning to a geometry starts its count over, it does not resume"
     );
+}
+
+/// A square `BGRA8` texture with one mip level, copied from its origin.
+fn endpoint(size: usize) -> CopyEndpoint {
+    CopyEndpoint {
+        pixel_format: MTLPixelFormat::BGRA8Unorm,
+        sample_count: 1,
+        width: size,
+        height: size,
+        level: 0,
+        levels: 1,
+        origin_x: 0,
+        origin_y: 0,
+    }
+}
+
+/// A pair that agrees on everything copies.
+#[test]
+fn a_matching_pair_is_accepted() {
+    assert_eq!(
+        copy_texture_reject(&endpoint(256), &endpoint(256), 256, 256),
+        None
+    );
+}
+
+/// Differing sample counts are the case the RESZ resolve exists for.
+#[test]
+fn a_sample_count_change_is_rejected() {
+    let mut src = endpoint(256);
+    src.sample_count = 4;
+    assert_eq!(
+        copy_texture_reject(&src, &endpoint(256), 256, 256),
+        Some(CopyRejectReason::SampleCountMismatch)
+    );
+}
+
+/// Two unrelated formats of the same size are still a reject.
+#[test]
+fn a_format_change_is_rejected() {
+    let mut dst = endpoint(256);
+    dst.pixel_format = MTLPixelFormat::RGBA8Unorm;
+    assert_eq!(
+        copy_texture_reject(&endpoint(256), &dst, 256, 256),
+        Some(CopyRejectReason::FormatMismatch)
+    );
+}
+
+/// A linear format and its sRGB twin are two views of one base format.
+#[test]
+fn an_srgb_twin_is_accepted_in_either_direction() {
+    let mut srgb = endpoint(256);
+    srgb.pixel_format = MTLPixelFormat::BGRA8Unorm_sRGB;
+    assert_eq!(copy_texture_reject(&endpoint(256), &srgb, 256, 256), None);
+    assert_eq!(copy_texture_reject(&srgb, &endpoint(256), 256, 256), None);
+}
+
+/// The format check runs before the sample-count check, so it reports first.
+#[test]
+fn a_pair_that_differs_in_both_reports_the_format() {
+    let mut src = endpoint(256);
+    src.pixel_format = MTLPixelFormat::RGBA8Unorm;
+    src.sample_count = 4;
+    assert_eq!(
+        copy_texture_reject(&src, &endpoint(256), 256, 256),
+        Some(CopyRejectReason::FormatMismatch)
+    );
+}
+
+/// The region is bounds-checked against the source as well as the destination.
+#[test]
+fn a_region_leaving_either_end_is_rejected() {
+    assert_eq!(
+        copy_texture_reject(&endpoint(128), &endpoint(256), 256, 256),
+        Some(CopyRejectReason::SourceRegionOutOfBounds)
+    );
+    assert_eq!(
+        copy_texture_reject(&endpoint(256), &endpoint(128), 256, 256),
+        Some(CopyRejectReason::DestinationRegionOutOfBounds)
+    );
+}
+
+/// The origin counts towards the bound, so a sub-rect can still overrun.
+#[test]
+fn an_offset_sub_rect_is_bounded_by_the_origin() {
+    let mut src = endpoint(256);
+    src.origin_x = 128;
+    src.origin_y = 128;
+    assert_eq!(copy_texture_reject(&src, &endpoint(256), 128, 128), None);
+    assert_eq!(
+        copy_texture_reject(&src, &endpoint(256), 129, 128),
+        Some(CopyRejectReason::SourceRegionOutOfBounds)
+    );
+}
+
+/// Bounds are the addressed mip level's extent, not the base level's.
+#[test]
+fn the_bound_is_the_addressed_mip_level() {
+    let mut src = endpoint(256);
+    src.levels = 9;
+    src.level = 2;
+    let mut dst = endpoint(64);
+    dst.levels = 7;
+    assert_eq!(copy_texture_reject(&src, &dst, 64, 64), None);
+    assert_eq!(
+        copy_texture_reject(&src, &dst, 65, 64),
+        Some(CopyRejectReason::SourceRegionOutOfBounds)
+    );
+}
+
+/// A level past the end of either chain has no extent to copy through.
+#[test]
+fn a_missing_mip_level_is_rejected() {
+    let mut src = endpoint(256);
+    src.level = 1;
+    assert_eq!(
+        copy_texture_reject(&src, &endpoint(256), 1, 1),
+        Some(CopyRejectReason::SourceLevelMissing)
+    );
+    let mut dst = endpoint(256);
+    dst.level = 1;
+    assert_eq!(
+        copy_texture_reject(&endpoint(256), &dst, 1, 1),
+        Some(CopyRejectReason::DestinationLevelMissing)
+    );
+}
+
+/// Each reason keys its own one-shot warn.
+#[test]
+fn every_reject_reason_has_a_distinct_key() {
+    let reasons = [
+        CopyRejectReason::FormatMismatch,
+        CopyRejectReason::SampleCountMismatch,
+        CopyRejectReason::SourceLevelMissing,
+        CopyRejectReason::DestinationLevelMissing,
+        CopyRejectReason::SourceRegionOutOfBounds,
+        CopyRejectReason::DestinationRegionOutOfBounds,
+    ];
+    let mut keys: Vec<u64> = reasons.iter().map(|r| r.key()).collect();
+    keys.sort_unstable();
+    keys.dedup();
+    assert_eq!(keys.len(), reasons.len());
+    assert!(reasons.iter().all(|r| !r.as_str().is_empty()));
 }


### PR DESCRIPTION
## Symptoms

No shipped caller reaches this today, so there is no reproducible game symptom. The failure mode it removes is the one Metal reports as `-[MTLDebugBlitCommandEncoder copyFromTexture:...]` validation, for example `(destinationOrigin.x + sourceSize.width) must be <= width` or a sample-count / pixel-format complaint: under `MTL_DEBUG_LAYER` that aborts the process, and with the layer off the copy is undefined and can write outside the destination level.

## Root cause

The `CopyTextureToTexture` arm of `encode_leading_blits` called `copyFromTexture:` with whatever the wire `BlitCommand` carried. It trusted the PE side to have already established that the two textures agree on sample count and pixel format and that the region fits inside the addressed mip level of both. The PE side does establish it for the callers that exist (`StretchRect` routes a cross-Metal-format or resized pair to the render quad, and the RESZ, depth-alias and depth-snapshot copies are full-surface same-format pairs), but the unix side had no check of its own, so any future caller that got it wrong took down the process instead of losing a copy.

## Changes

`unix/unix/src/metal/command.rs` gains `copy_texture_reject`, a pure predicate over a `CopyEndpoint` per end (pixel format, sample count, base extent, addressed level, level count, origin) plus the shared region. It returns a `CopyRejectReason` for each condition Metal validates: incompatible pixel formats, differing sample counts, a mip level past the end of either chain, and a region that leaves either level. A linear format and its sRGB twin are treated as compatible, since they are two encodings of one base format and every colour texture that has a twin gets an eager view of it.

The blit arm builds both endpoints from the live `MTLTexture` and, on a rejection, logs once per reason through `log_once_warn_by!` (naming both handles, both formats, both sample counts, both levels and extents, and the region) and skips the copy. The unix side has no blit-reject counter to charge, so the log line is the only signal.

## Alternatives

Compare only sample count and pixel format and leave the region to the PE side: the region is the condition the callers already vary (sub-rect `StretchRect`), so checking it costs one comparison and closes the wider hole.

Require exact pixel-format equality: it would reject a linear-to-sRGB-twin copy that Metal itself accepts, turning a valid future copy into a silent skip.

Resolve a sample-count mismatch here rather than skipping it: a blit encoder cannot resolve, and the render-pass resolve that can is where a multisampled copy belongs.

## Verification

`make check` clean. `make test` green with no fail-fast truncation: 820/820 in the Windows host-native workspace, 135/135 in the unix workspace (the ten new tests among them), 296/296 end-to-end on i686 and 296/296 on x86_64, 1545 `PASS` and 2 benign `LEAK` lines across the run.

Ten unit tests in `unix/unix/src/metal/command/tests.rs` pin the predicate, all of them new with the predicate: `a_matching_pair_is_accepted`, `a_sample_count_change_is_rejected`, `a_format_change_is_rejected`, `an_srgb_twin_is_accepted_in_either_direction`, `a_pair_that_differs_in_both_reports_the_format`, `a_region_leaving_either_end_is_rejected`, `an_offset_sub_rect_is_bounded_by_the_origin`, `the_bound_is_the_addressed_mip_level`, `a_missing_mip_level_is_rejected`, `every_reject_reason_has_a_distinct_key`. There is no fail-then-pass end-to-end test because no PE-side path can emit a mismatched pair, which is the property the guard exists to keep true.

`make conformance` reports no regressions on either architecture: `i686/device` 775 to 772 and `x86_64/device` 773 to 770, all three deltas the tolerated flaky and ceiling sites (`device.c:4475`, `device.c:4480`, `device.c:15088`); `visual`, `stateblock` and `d3d9ex` unchanged on both. The baseline is not re-recorded, since re-recording on a run where those sites read zero would drop their pins.

Closes #158
