### PR TITLE
Guard the buffer/texture blits against Metal's copy preconditions

### DIFF
--- a/scripts/derive_inventory.txt
+++ b/scripts/derive_inventory.txt
@@ -13,6 +13,7 @@ unix/shared/src/lib.rs Thunks Clone,Copy,EnumCount,VariantArray
 unix/shared/src/mtl.rs AddressMode Clone,Copy,Debug,PartialEq,Eq,Hash,FromRepr
 unix/shared/src/mtl.rs BlendFactor Clone,Copy,Debug,PartialEq,Eq,Hash,FromRepr
 unix/shared/src/mtl.rs BlendOperation Clone,Copy,Debug,PartialEq,Eq,Hash,FromRepr
+unix/shared/src/mtl.rs BlockLayout Clone,Copy,Debug,PartialEq,Eq
 unix/shared/src/mtl.rs BorderColor Clone,Copy,Debug,PartialEq,Eq,Hash,FromRepr
 unix/shared/src/mtl.rs BufferKind Clone,Copy,Debug,PartialEq,Eq,Hash,FromRepr
 unix/shared/src/mtl.rs ClearQuadFlags Clone,Copy,Debug,PartialEq,Eq,Hash

--- a/unix/shared/src/mtl.rs
+++ b/unix/shared/src/mtl.rs
@@ -135,6 +135,109 @@ impl PixelFormat {
             _ => None,
         }
     }
+
+    /// The addressable block of this format: its pixel extent and its size.
+    ///
+    /// Uncompressed formats address one pixel per block, so the extent is
+    /// 1x1 and the size is the pixel size. The BC families address a 4x4
+    /// pixel block. A row of `w` pixels occupies `ceil(w / block width) *
+    /// block bytes`, which is what turns the pixel region of a buffer copy
+    /// into the byte footprint it reads or writes.
+    ///
+    /// The match is exhaustive on purpose: a new format has to state its
+    /// block rather than inherit a default that is wrong for a compressed
+    /// one.
+    #[must_use]
+    pub const fn block_layout(self) -> BlockLayout {
+        match self {
+            Self::A8Unorm | Self::R8Unorm => BlockLayout::pixel(1),
+            Self::R16Unorm
+            | Self::R16Float
+            | Self::Rg8Unorm
+            | Self::Rg8Snorm
+            | Self::B5G6R5Unorm
+            | Self::Abgr4Unorm
+            | Self::Bgr5A1Unorm => BlockLayout::pixel(2),
+            Self::R32Float
+            | Self::Rg16Unorm
+            | Self::Rg16Float
+            | Self::Bgra8Unorm
+            | Self::Bgra8UnormSrgb
+            | Self::Depth32Float => BlockLayout::pixel(4),
+            Self::Rg32Float
+            | Self::Rgba16Unorm
+            | Self::Rgba16Float
+            | Self::Depth32FloatStencil8 => BlockLayout::pixel(8),
+            Self::Rgba32Float => BlockLayout::pixel(16),
+            Self::Bc1Rgba | Self::Bc1RgbaSrgb | Self::Bc4RUnorm => BlockLayout::compressed(8),
+            Self::Bc2Rgba | Self::Bc2RgbaSrgb | Self::Bc3Rgba | Self::Bc3RgbaSrgb => {
+                BlockLayout::compressed(16)
+            }
+        }
+    }
+}
+
+/// The unit a pixel format addresses: its pixel extent and its byte size.
+///
+/// Sizing a copy in bytes goes through this rather than through a pixel
+/// size, because a block-compressed format has no per-pixel size: a BC1
+/// row of 3 pixels is one 8-byte block, the same as a row of 4.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlockLayout {
+    width: u32,
+    height: u32,
+    bytes: u32,
+}
+
+impl BlockLayout {
+    /// The layout of a format that is not on the mtld3d wire.
+    ///
+    /// One byte per pixel is the smallest footprint a format can have, so a
+    /// bounds check that falls back to it stays permissive: it never rejects
+    /// a copy whose real footprint it could not compute.
+    #[must_use]
+    pub const fn unmapped() -> Self {
+        Self::pixel(1)
+    }
+
+    /// Pixels one block spans horizontally.
+    #[must_use]
+    pub const fn width(self) -> u32 {
+        self.width
+    }
+
+    /// Pixels one block spans vertically.
+    #[must_use]
+    pub const fn height(self) -> u32 {
+        self.height
+    }
+
+    /// Bytes one block occupies.
+    #[must_use]
+    pub const fn bytes(self) -> u32 {
+        self.bytes
+    }
+
+    /// A format that addresses a single pixel of `bytes` bytes.
+    const fn pixel(bytes: u32) -> Self {
+        Self {
+            width: 1,
+            height: 1,
+            bytes,
+        }
+    }
+
+    /// A format that addresses a 4x4 pixel block of `bytes` bytes.
+    ///
+    /// Every block-compressed format mtld3d plumbs is a BC family member,
+    /// and all of them are 4x4.
+    const fn compressed(bytes: u32) -> Self {
+        Self {
+            width: 4,
+            height: 4,
+            bytes,
+        }
+    }
 }
 
 /// `MTLLoadAction` wire encoding for render-pass color/depth attachments.

--- a/unix/shared/src/mtl/tests.rs
+++ b/unix/shared/src/mtl/tests.rs
@@ -133,6 +133,50 @@ fn srgb_twin_table() {
     assert_eq!(ColorSpacePolicy::from_repr(2), None);
 }
 
+/// Block layouts: the BC families address 4x4 pixels, everything else one.
+#[test]
+fn block_layout_table() {
+    for (format, bytes) in [
+        (PixelFormat::A8Unorm, 1),
+        (PixelFormat::R8Unorm, 1),
+        (PixelFormat::B5G6R5Unorm, 2),
+        (PixelFormat::Bgra8Unorm, 4),
+        (PixelFormat::Bgra8UnormSrgb, 4),
+        (PixelFormat::Depth32Float, 4),
+        (PixelFormat::Rgba16Float, 8),
+        (PixelFormat::Rgba32Float, 16),
+    ] {
+        let block = format.block_layout();
+        assert_eq!(block.width(), 1, "{format:?} addresses one pixel");
+        assert_eq!(block.height(), 1, "{format:?} addresses one pixel");
+        assert_eq!(block.bytes(), bytes, "{format:?} pixel size");
+    }
+
+    // BC1 and BC4 pack a 4x4 block into 8 bytes, BC2 and BC3 into 16.
+    for (format, bytes) in [
+        (PixelFormat::Bc1Rgba, 8),
+        (PixelFormat::Bc1RgbaSrgb, 8),
+        (PixelFormat::Bc4RUnorm, 8),
+        (PixelFormat::Bc2Rgba, 16),
+        (PixelFormat::Bc2RgbaSrgb, 16),
+        (PixelFormat::Bc3Rgba, 16),
+        (PixelFormat::Bc3RgbaSrgb, 16),
+    ] {
+        let block = format.block_layout();
+        assert_eq!(block.width(), 4, "{format:?} spans four pixels");
+        assert_eq!(block.height(), 4, "{format:?} spans four pixels");
+        assert_eq!(block.bytes(), bytes, "{format:?} block size");
+    }
+
+    // A format the wire does not carry sizes as the smallest thing it could
+    // be, so a bounds check built on it never rejects a legal copy.
+    let unmapped = BlockLayout::unmapped();
+    assert_eq!(
+        (unmapped.width(), unmapped.height(), unmapped.bytes()),
+        (1, 1, 1)
+    );
+}
+
 #[test]
 fn texture_usage_bits_match_legacy_wire() {
     // Wire-encoding pin: RENDER_TARGET is bit 0, DEPTH_STENCIL is bit 1.

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -13,7 +13,7 @@ use mtld3d_shared::{
     BlitCommand, BlitCommandType, Command, CommandType, ExtraColorDesc, MetalHandle,
     NullTextureKind, PassDescriptor, SubmitFrameParams,
     mtl::{
-        CullMode, IndexType, LoadAction, PixelFormat, PrimitiveType, StoreAction,
+        BlockLayout, CullMode, IndexType, LoadAction, PixelFormat, PrimitiveType, StoreAction,
         VisibilityResultMode,
     },
     mtl_handle::{
@@ -1180,6 +1180,10 @@ enum CopyRejectReason {
     SourceRegionOutOfBounds,
     /// The region leaves the addressed destination mip level.
     DestinationRegionOutOfBounds,
+    /// The source buffer is shorter than the rows and slices the copy reads.
+    SourceBufferTooShort,
+    /// The destination buffer is shorter than the rows and slices the copy writes.
+    DestinationBufferTooShort,
 }
 
 impl CopyRejectReason {
@@ -1199,20 +1203,26 @@ impl CopyRejectReason {
             Self::DestinationLevelMissing => "the destination has no such mip level",
             Self::SourceRegionOutOfBounds => "the region leaves the source mip level",
             Self::DestinationRegionOutOfBounds => "the region leaves the destination mip level",
+            Self::SourceBufferTooShort => "the source buffer is shorter than the copy reads",
+            Self::DestinationBufferTooShort => {
+                "the destination buffer is shorter than the copy writes"
+            }
         }
     }
 }
 
-/// One end of a texture-to-texture blit, as the live `MTLTexture` describes it.
+/// The texture end of a blit copy, as the live `MTLTexture` describes it.
 ///
-/// `width` and `height` are the base level's, `level` the mip level the copy
-/// addresses and `levels` the texture's level count, so the addressed extent
-/// is derived here rather than passed in alongside them.
+/// `width`, `height` and `depth` are the base level's, `level` the mip level
+/// the copy addresses and `levels` the texture's level count, so the
+/// addressed extent is derived here rather than passed in alongside them.
 struct CopyEndpoint {
     pixel_format: MTLPixelFormat,
     sample_count: usize,
     width: usize,
     height: usize,
+    /// Slice count of the base level: one outside a volume texture.
+    depth: usize,
     level: usize,
     levels: usize,
     origin_x: usize,
@@ -1229,13 +1239,22 @@ impl CopyEndpoint {
         let h = self.height >> self.level;
         Some((if w == 0 { 1 } else { w }, if h == 0 { 1 } else { h }))
     }
+
+    /// Slices in the addressed mip level, or `None` when it does not exist.
+    const fn level_depth(&self) -> Option<usize> {
+        if self.level >= self.levels {
+            return None;
+        }
+        let d = self.depth >> self.level;
+        Some(if d == 0 { 1 } else { d })
+    }
 }
 
 impl core::fmt::Display for CopyEndpoint {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
-            "{:?} samples={} level={}/{} origin={},{} size={}x{}",
+            "{:?} samples={} level={}/{} origin={},{} size={}x{}x{}",
             self.pixel_format,
             self.sample_count,
             self.level,
@@ -1243,7 +1262,8 @@ impl core::fmt::Display for CopyEndpoint {
             self.origin_x,
             self.origin_y,
             self.width,
-            self.height
+            self.height,
+            self.depth
         )
     }
 }
@@ -1312,6 +1332,174 @@ fn copy_texture_reject(
     }
     if !region_fits((dst.origin_x, dst.origin_y), region, dst_extent) {
         return Some(CopyRejectReason::DestinationRegionOutOfBounds);
+    }
+    None
+}
+
+/// The buffer end of a blit copy between an `MTLBuffer` and an `MTLTexture`.
+///
+/// `offset` is where the first row starts, `bytes_per_row` the stride between
+/// rows of blocks and `bytes_per_image` the stride between slices, all as the
+/// copy was encoded; `length` is the live `MTLBuffer`'s own length.
+struct CopyBufferEndpoint {
+    length: usize,
+    offset: usize,
+    bytes_per_row: usize,
+    bytes_per_image: usize,
+}
+
+impl core::fmt::Display for CopyBufferEndpoint {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "len={} offset={} bytesPerRow={} bytesPerImage={}",
+            self.length, self.offset, self.bytes_per_row, self.bytes_per_image
+        )
+    }
+}
+
+/// The region a buffer/texture copy transfers, in texture pixels.
+///
+/// `depth` is the slice count the copy walks: one for a 2D texture, the box
+/// depth for a volume.
+struct CopyRegion {
+    width: usize,
+    height: usize,
+    depth: usize,
+}
+
+impl core::fmt::Display for CopyRegion {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}x{}x{}", self.width, self.height, self.depth)
+    }
+}
+
+/// Block layout of a live texture's pixel format.
+///
+/// Every format an mtld3d texture can carry is on the wire, so the fallback
+/// is unreachable; it sizes a copy as one byte per pixel, which keeps the
+/// bounds check permissive rather than refusing a copy it cannot measure.
+fn copy_block_layout(format: MTLPixelFormat) -> BlockLayout {
+    let Some(wire) = u32::try_from(format.0)
+        .ok()
+        .and_then(PixelFormat::from_repr)
+    else {
+        mtld3d_shared::log_once_warn_by!(
+            target: crate::LOG_TARGET,
+            key: format.0 as u64,
+            "copy guard: pixel format {format:?} is not on the mtld3d wire, \
+             sizing its blocks as one byte per pixel"
+        );
+        return BlockLayout::unmapped();
+    };
+    wire.block_layout()
+}
+
+/// Whether the region placed at the endpoint's origin stays inside its level.
+///
+/// The level extent is rounded up to the block grid first: a compressed level
+/// narrower than one block still addresses a whole block, so a copy covering
+/// it names the block extent and not the level's. On an uncompressed format
+/// the rounding is the identity.
+fn level_holds_region(
+    texture: &CopyEndpoint,
+    region: &CopyRegion,
+    extent: (usize, usize),
+    block: BlockLayout,
+) -> bool {
+    let block_w = usize::try_from(block.width()).expect("block extent fits usize");
+    let block_h = usize::try_from(block.height()).expect("block extent fits usize");
+    let bounds = (
+        extent.0.next_multiple_of(block_w),
+        extent.1.next_multiple_of(block_h),
+    );
+    region_fits(
+        (texture.origin_x, texture.origin_y),
+        (region.width, region.height),
+        bounds,
+    ) && texture.level_depth().is_some_and(|d| region.depth <= d)
+}
+
+/// Byte offset, exclusive, the copy stops at in the buffer.
+///
+/// The strides cover every row but the last one of the last slice, which is
+/// only as long as the region's own blocks: that is where the copy stops, not
+/// at the end of a padded row. `None` when the arithmetic overflows, which is
+/// itself a reason to refuse the copy.
+fn buffer_copy_end(
+    buffer: &CopyBufferEndpoint,
+    region: &CopyRegion,
+    block: BlockLayout,
+) -> Option<usize> {
+    let block_w = usize::try_from(block.width()).ok()?;
+    let block_h = usize::try_from(block.height()).ok()?;
+    let block_bytes = usize::try_from(block.bytes()).ok()?;
+    let rows = region.height.div_ceil(block_h);
+    let cols = region.width.div_ceil(block_w);
+    if rows == 0 || cols == 0 || region.depth == 0 {
+        return Some(buffer.offset);
+    }
+    let last_row = cols.checked_mul(block_bytes)?;
+    let slice = buffer
+        .bytes_per_row
+        .checked_mul(rows - 1)?
+        .checked_add(last_row)?;
+    let span = buffer
+        .bytes_per_image
+        .checked_mul(region.depth - 1)?
+        .checked_add(slice)?;
+    buffer.offset.checked_add(span)
+}
+
+/// Whether the buffer holds every byte a copy of `region` touches.
+fn buffer_holds_region(
+    buffer: &CopyBufferEndpoint,
+    region: &CopyRegion,
+    block: BlockLayout,
+) -> bool {
+    buffer_copy_end(buffer, region, block).is_some_and(|end| end <= buffer.length)
+}
+
+/// Reject a buffer-to-texture copy `copyFromBuffer:` would not accept.
+///
+/// `None` means the upload is safe to encode. `block` is the destination
+/// format's, since the region and the source rows are both laid out in it.
+fn copy_buffer_to_texture_reject(
+    src: &CopyBufferEndpoint,
+    dst: &CopyEndpoint,
+    region: &CopyRegion,
+    block: BlockLayout,
+) -> Option<CopyRejectReason> {
+    let Some(extent) = dst.level_extent() else {
+        return Some(CopyRejectReason::DestinationLevelMissing);
+    };
+    if !level_holds_region(dst, region, extent, block) {
+        return Some(CopyRejectReason::DestinationRegionOutOfBounds);
+    }
+    if !buffer_holds_region(src, region, block) {
+        return Some(CopyRejectReason::SourceBufferTooShort);
+    }
+    None
+}
+
+/// Reject a texture-to-buffer copy `copyFromTexture:toBuffer:` would not accept.
+///
+/// The mirror of `copy_buffer_to_texture_reject`: the same two bounds with
+/// the roles of the two ends swapped.
+fn copy_texture_to_buffer_reject(
+    src: &CopyEndpoint,
+    dst: &CopyBufferEndpoint,
+    region: &CopyRegion,
+    block: BlockLayout,
+) -> Option<CopyRejectReason> {
+    let Some(extent) = src.level_extent() else {
+        return Some(CopyRejectReason::SourceLevelMissing);
+    };
+    if !level_holds_region(src, region, extent, block) {
+        return Some(CopyRejectReason::SourceRegionOutOfBounds);
+    }
+    if !buffer_holds_region(dst, region, block) {
+        return Some(CopyRejectReason::DestinationBufferTooShort);
     }
     None
 }
@@ -1402,6 +1590,45 @@ fn encode_leading_blits(
                     );
                     continue;
                 };
+                let region = CopyRegion {
+                    width: cmd.region_w as usize,
+                    height: cmd.region_h as usize,
+                    depth: cmd.depth as usize,
+                };
+                let source = CopyBufferEndpoint {
+                    length: buffer.length(),
+                    offset: to_usize(cmd.src_offset),
+                    bytes_per_row: to_usize(cmd.bytes_per_row),
+                    bytes_per_image: cmd.bytes_per_image as usize,
+                };
+                let destination = CopyEndpoint {
+                    pixel_format: texture.pixelFormat(),
+                    sample_count: texture.sampleCount(),
+                    width: texture.width(),
+                    height: texture.height(),
+                    depth: texture.depth(),
+                    level: cmd.mip_level as usize,
+                    levels: texture.mipmapLevelCount(),
+                    origin_x: cmd.origin_x as usize,
+                    origin_y: cmd.origin_y as usize,
+                };
+                let block = copy_block_layout(destination.pixel_format);
+                if let Some(reason) =
+                    copy_buffer_to_texture_reject(&source, &destination, &region, block)
+                {
+                    let reason_text = reason.as_str();
+                    let src_handle = cmd.src_handle;
+                    let dst_handle = cmd.dst_handle;
+                    mtld3d_shared::log_once_warn_by!(
+                        target: crate::LOG_TARGET,
+                        key: reason.key(),
+                        "encode_leading_blits: {reason_text}, upload skipped. \
+                         src handle={src_handle:#x} {source}, \
+                         dst handle={dst_handle:#x} {destination}, \
+                         region {region}"
+                    );
+                    continue;
+                }
                 mtld3d_shared::crumb!("blit:buf2tex", cmd.src_handle, cmd.dst_handle);
                 // `depth` is the slice count (1 for a 2D texture, >1 for a
                 // volume/3D texture) and `bytes_per_image` the per-slice byte
@@ -1410,8 +1637,8 @@ fn encode_leading_blits(
                 // the values this call computed implicitly before the fields
                 // existed — so the 2D copy is byte-identical.
                 // SAFETY: objc2 typed binding; `buffer` and `texture` are
-                // retained Metal objects live for the call; geometry is
-                // bounds-checked by the PE side via the wire contract.
+                // retained Metal objects live for the call; the geometry
+                // cleared `copy_buffer_to_texture_reject` above.
                 unsafe {
                     blit.copyFromBuffer_sourceOffset_sourceBytesPerRow_sourceBytesPerImage_sourceSize_toTexture_destinationSlice_destinationLevel_destinationOrigin(
                         &buffer,
@@ -1470,6 +1697,7 @@ fn encode_leading_blits(
                     sample_count: src.sampleCount(),
                     width: src.width(),
                     height: src.height(),
+                    depth: src.depth(),
                     level: cmd.mip_level as usize,
                     levels: src.mipmapLevelCount(),
                     origin_x: cmd.origin_x as usize,
@@ -1480,6 +1708,7 @@ fn encode_leading_blits(
                     sample_count: dst.sampleCount(),
                     width: dst.width(),
                     height: dst.height(),
+                    depth: dst.depth(),
                     level: cmd.dst_mip_level as usize,
                     levels: dst.mipmapLevelCount(),
                     origin_x: dst_x,
@@ -2406,11 +2635,10 @@ pub struct BlitArgs {
 /// Resolve a render-resolution source up to the size the caller's coordinates assume.
 ///
 /// Returns `Some(resolved)` when a resolve happened, `None` to read the source
-/// as-is, which is both the default-scale path and the fallback when the
-/// resolve cannot be set up. Reading as-is after a declined resolve yields a
-/// smaller image than requested, so it warns rather than failing the call: a
-/// wrong-sized readback is recoverable for the game, a failed `LockRect` often
-/// is not.
+/// as-is, which is both the default-scale path and the fallback if `MetalFX`
+/// declines. At the default scale the source already holds what the caller
+/// asked for; after a declined resolve it does not, and the copy guard below
+/// refuses the read rather than letting it run off the end of the texture.
 fn resolve_readback_source(
     cmd_buf: &ProtocolObject<dyn MTLCommandBuffer>,
     device: &ProtocolObject<dyn MTLDevice>,
@@ -2575,6 +2803,45 @@ pub fn blit_texture_to_buffer(args: &BlitArgs) -> bool {
     let source = resolve_readback_source(&cmd_buf, &device, &texture, source_width, source_height);
     let texture = source.as_deref().unwrap_or(&*texture);
 
+    let bytes_per_image = (bytes_per_row as usize) * (height as usize);
+    let region = CopyRegion {
+        width: width as usize,
+        height: height as usize,
+        depth: 1,
+    };
+    let src_endpoint = CopyEndpoint {
+        pixel_format: texture.pixelFormat(),
+        sample_count: texture.sampleCount(),
+        width: texture.width(),
+        height: texture.height(),
+        depth: texture.depth(),
+        level: mip_level as usize,
+        levels: texture.mipmapLevelCount(),
+        origin_x: origin_x as usize,
+        origin_y: origin_y as usize,
+    };
+    let destination = CopyBufferEndpoint {
+        length: dst_buffer.length(),
+        offset: 0,
+        bytes_per_row: bytes_per_row as usize,
+        bytes_per_image,
+    };
+    let block = copy_block_layout(src_endpoint.pixel_format);
+    // Checked before the encoder exists so a rejection leaves no encoder to
+    // close. A declined `MetalFX` resolve lands here: the caller asked for
+    // more pixels than the render-resolution source holds.
+    if let Some(reason) = copy_texture_to_buffer_reject(&src_endpoint, &destination, &region, block)
+    {
+        let reason_text = reason.as_str();
+        mtld3d_shared::log_once_warn_by!(
+            target: crate::LOG_TARGET,
+            key: reason.key(),
+            "blit_texture_to_buffer: {reason_text}, readback skipped. \
+             src {src_endpoint}, dst {destination}, region {region}"
+        );
+        return false;
+    }
+
     let Some(blit) = cmd_buf.blitCommandEncoder() else {
         error!(target: LOG_TARGET, "blit_texture_to_buffer: blitCommandEncoder() nil");
         return false;
@@ -2584,9 +2851,9 @@ pub fn blit_texture_to_buffer(args: &BlitArgs) -> bool {
         blit.setLabel(Some(&label));
     }
 
-    let bytes_per_image = (bytes_per_row as usize) * (height as usize);
     // SAFETY: objc2 typed binding; `texture`/`dst_buffer` are retained Metal
-    // objects live for the call; geometry is caller-bounded.
+    // objects live for the call; the geometry cleared
+    // `copy_texture_to_buffer_reject` above.
     unsafe {
         blit.copyFromTexture_sourceSlice_sourceLevel_sourceOrigin_sourceSize_toBuffer_destinationOffset_destinationBytesPerRow_destinationBytesPerImage(
             texture,

--- a/unix/unix/src/metal/command/tests.rs
+++ b/unix/unix/src/metal/command/tests.rs
@@ -9,12 +9,19 @@
 //! `copy_texture_reject` is checked against each condition Metal validates on
 //! `copyFromTexture:`, plus the pairs it accepts: an identical pair, a sub-rect inside a
 //! mip level, and a linear format against its sRGB twin.
+//!
+//! The buffer/texture pair, `copy_buffer_to_texture_reject` and its readback mirror, is
+//! checked on both of its bounds: the region against the addressed mip level, rounded up
+//! to the block grid so a compressed level below one block still takes a whole block, and
+//! the buffer against the rows and slices the strides walk.
 
+use mtld3d_shared::mtl::{BlockLayout, PixelFormat};
 use objc2_metal::MTLPixelFormat;
 
 use super::{
-    CopyEndpoint, CopyRejectReason, PresentGeometry, PresentRoute, SETTLED_PRESENTS,
-    copy_texture_reject, geometry_settled, present_route,
+    CopyBufferEndpoint, CopyEndpoint, CopyRegion, CopyRejectReason, PresentGeometry, PresentRoute,
+    SETTLED_PRESENTS, copy_buffer_to_texture_reject, copy_texture_reject,
+    copy_texture_to_buffer_reject, geometry_settled, present_route,
 };
 
 /// Matching extents take the blit whether or not `MetalFX` exists.
@@ -186,6 +193,7 @@ fn endpoint(size: usize) -> CopyEndpoint {
         sample_count: 1,
         width: size,
         height: size,
+        depth: 1,
         level: 0,
         levels: 1,
         origin_x: 0,
@@ -313,10 +321,280 @@ fn every_reject_reason_has_a_distinct_key() {
         CopyRejectReason::DestinationLevelMissing,
         CopyRejectReason::SourceRegionOutOfBounds,
         CopyRejectReason::DestinationRegionOutOfBounds,
+        CopyRejectReason::SourceBufferTooShort,
+        CopyRejectReason::DestinationBufferTooShort,
     ];
     let mut keys: Vec<u64> = reasons.iter().map(|r| r.key()).collect();
     keys.sort_unstable();
     keys.dedup();
     assert_eq!(keys.len(), reasons.len());
     assert!(reasons.iter().all(|r| !r.as_str().is_empty()));
+}
+
+/// A `BGRA8` staging buffer holding `rows` tightly packed rows of `size` pixels.
+fn upload_buffer(size: usize, rows: usize) -> CopyBufferEndpoint {
+    CopyBufferEndpoint {
+        length: size * 4 * rows,
+        offset: 0,
+        bytes_per_row: size * 4,
+        bytes_per_image: size * 4 * rows,
+    }
+}
+
+/// A single-slice region of `w` by `h` pixels.
+const fn region(w: usize, h: usize) -> CopyRegion {
+    CopyRegion {
+        width: w,
+        height: h,
+        depth: 1,
+    }
+}
+
+/// The block layout every `BGRA8` upload in these tests is measured in.
+fn bgra8_block() -> BlockLayout {
+    PixelFormat::Bgra8Unorm.block_layout()
+}
+
+/// A whole-level upload out of a buffer that holds exactly the level.
+#[test]
+fn a_matching_upload_is_accepted() {
+    assert_eq!(
+        copy_buffer_to_texture_reject(
+            &upload_buffer(256, 256),
+            &endpoint(256),
+            &region(256, 256),
+            bgra8_block(),
+        ),
+        None
+    );
+}
+
+/// An overhanging destination is rejected before Metal sees it.
+///
+/// This is the shape Metal reports as a destination origin plus a source width
+/// exceeding the level's width.
+#[test]
+fn an_upload_overhanging_the_level_is_rejected() {
+    let mut dst = endpoint(256);
+    dst.origin_x = 128;
+    assert_eq!(
+        copy_buffer_to_texture_reject(
+            &upload_buffer(256, 256),
+            &dst,
+            &region(256, 256),
+            bgra8_block(),
+        ),
+        Some(CopyRejectReason::DestinationRegionOutOfBounds)
+    );
+    // Half the width still fits at that origin.
+    assert_eq!(
+        copy_buffer_to_texture_reject(
+            &upload_buffer(256, 256),
+            &dst,
+            &region(128, 256),
+            bgra8_block(),
+        ),
+        None
+    );
+}
+
+/// Bounds are the addressed level's extent, not the base level's.
+#[test]
+fn an_upload_is_bounded_by_the_addressed_level() {
+    let mut dst = endpoint(256);
+    dst.levels = 9;
+    dst.level = 2;
+    assert_eq!(
+        copy_buffer_to_texture_reject(&upload_buffer(64, 64), &dst, &region(64, 64), bgra8_block(),),
+        None
+    );
+    assert_eq!(
+        copy_buffer_to_texture_reject(
+            &upload_buffer(128, 128),
+            &dst,
+            &region(65, 64),
+            bgra8_block(),
+        ),
+        Some(CopyRejectReason::DestinationRegionOutOfBounds)
+    );
+}
+
+/// A level past the end of the chain has no extent to upload into.
+#[test]
+fn an_upload_to_a_missing_level_is_rejected() {
+    let mut dst = endpoint(256);
+    dst.level = 1;
+    assert_eq!(
+        copy_buffer_to_texture_reject(&upload_buffer(1, 1), &dst, &region(1, 1), bgra8_block(),),
+        Some(CopyRejectReason::DestinationLevelMissing)
+    );
+}
+
+/// One byte short of the rows the strides walk is a reject.
+#[test]
+fn a_short_source_buffer_is_rejected() {
+    assert_eq!(
+        copy_buffer_to_texture_reject(
+            &upload_buffer(256, 256),
+            &endpoint(256),
+            &region(256, 256),
+            bgra8_block(),
+        ),
+        None
+    );
+    let mut short = upload_buffer(256, 256);
+    short.length -= 1;
+    assert_eq!(
+        copy_buffer_to_texture_reject(&short, &endpoint(256), &region(256, 256), bgra8_block()),
+        Some(CopyRejectReason::SourceBufferTooShort)
+    );
+}
+
+/// The copy stops at the last row's own pixels, not at the end of its stride.
+///
+/// A sub-rect at the right edge of the last row of a staging buffer starts that
+/// row part-way in, so charging it a whole stride would reject an upload whose
+/// bytes the buffer holds.
+#[test]
+fn the_last_row_is_bounded_by_its_pixels_not_its_stride() {
+    let mut src = upload_buffer(256, 256);
+    src.offset = 255 * 256 * 4 + 128 * 4;
+    let mut dst = endpoint(512);
+    dst.origin_x = 128;
+    dst.origin_y = 255;
+    assert_eq!(
+        copy_buffer_to_texture_reject(&src, &dst, &region(128, 1), bgra8_block()),
+        None
+    );
+    // One pixel more than the 512 bytes left in the buffer.
+    assert_eq!(
+        copy_buffer_to_texture_reject(&src, &dst, &region(129, 1), bgra8_block()),
+        Some(CopyRejectReason::SourceBufferTooShort)
+    );
+}
+
+/// Compressed rows are counted in blocks, so a `BC1` level needs an eighth of the bytes.
+#[test]
+fn a_compressed_upload_counts_block_rows() {
+    let block = PixelFormat::Bc1Rgba.block_layout();
+    let mut dst = endpoint(128);
+    dst.pixel_format = MTLPixelFormat::BC1_RGBA;
+    // 32 block rows of 32 blocks, 8 bytes each.
+    let exact = CopyBufferEndpoint {
+        length: 256 * 32,
+        offset: 0,
+        bytes_per_row: 256,
+        bytes_per_image: 256 * 32,
+    };
+    assert_eq!(
+        copy_buffer_to_texture_reject(&exact, &dst, &region(128, 128), block),
+        None
+    );
+    let short = CopyBufferEndpoint {
+        length: 256 * 32 - 1,
+        offset: 0,
+        bytes_per_row: 256,
+        bytes_per_image: 256 * 32,
+    };
+    assert_eq!(
+        copy_buffer_to_texture_reject(&short, &dst, &region(128, 128), block),
+        Some(CopyRejectReason::SourceBufferTooShort)
+    );
+}
+
+/// A compressed level below one block still addresses a whole block.
+#[test]
+fn a_compressed_level_under_one_block_takes_a_whole_block() {
+    let block = PixelFormat::Bc1Rgba.block_layout();
+    let mut dst = endpoint(4);
+    dst.pixel_format = MTLPixelFormat::BC1_RGBA;
+    dst.levels = 3;
+    dst.level = 2;
+    let one_block = CopyBufferEndpoint {
+        length: 8,
+        offset: 0,
+        bytes_per_row: 8,
+        bytes_per_image: 8,
+    };
+    // The level is one pixel; the copy names the 4x4 block that holds it.
+    assert_eq!(
+        copy_buffer_to_texture_reject(&one_block, &dst, &region(4, 4), block),
+        None
+    );
+    // Two blocks wide is past the level however the extent is rounded.
+    assert_eq!(
+        copy_buffer_to_texture_reject(&one_block, &dst, &region(8, 4), block),
+        Some(CopyRejectReason::DestinationRegionOutOfBounds)
+    );
+}
+
+/// A volume upload reads one slice stride per slice past the first.
+#[test]
+fn a_volume_upload_counts_every_slice() {
+    let mut dst = endpoint(32);
+    dst.depth = 4;
+    let box_region = CopyRegion {
+        width: 32,
+        height: 32,
+        depth: 4,
+    };
+    let exact = CopyBufferEndpoint {
+        length: 32 * 4 * 32 * 4,
+        offset: 0,
+        bytes_per_row: 32 * 4,
+        bytes_per_image: 32 * 4 * 32,
+    };
+    assert_eq!(
+        copy_buffer_to_texture_reject(&exact, &dst, &box_region, bgra8_block()),
+        None
+    );
+    let three_slices = CopyBufferEndpoint {
+        length: 32 * 4 * 32 * 3,
+        offset: 0,
+        bytes_per_row: 32 * 4,
+        bytes_per_image: 32 * 4 * 32,
+    };
+    assert_eq!(
+        copy_buffer_to_texture_reject(&three_slices, &dst, &box_region, bgra8_block()),
+        Some(CopyRejectReason::SourceBufferTooShort)
+    );
+    // The same box against a texture that has one slice.
+    assert_eq!(
+        copy_buffer_to_texture_reject(&exact, &endpoint(32), &box_region, bgra8_block()),
+        Some(CopyRejectReason::DestinationRegionOutOfBounds)
+    );
+}
+
+/// The readback mirror reports the texture as the source and the buffer as the destination.
+#[test]
+fn a_readback_reports_the_ends_the_other_way_round() {
+    assert_eq!(
+        copy_texture_to_buffer_reject(
+            &endpoint(256),
+            &upload_buffer(256, 256),
+            &region(256, 256),
+            bgra8_block(),
+        ),
+        None
+    );
+    // The caller asks for more pixels than the source holds, which is what a
+    // declined resolve of a render-resolution frame leaves behind.
+    assert_eq!(
+        copy_texture_to_buffer_reject(
+            &endpoint(128),
+            &upload_buffer(256, 256),
+            &region(256, 256),
+            bgra8_block(),
+        ),
+        Some(CopyRejectReason::SourceRegionOutOfBounds)
+    );
+    assert_eq!(
+        copy_texture_to_buffer_reject(
+            &endpoint(256),
+            &upload_buffer(256, 255),
+            &region(256, 256),
+            bgra8_block(),
+        ),
+        Some(CopyRejectReason::DestinationBufferTooShort)
+    );
 }


### PR DESCRIPTION
## Symptoms

The `visual` conformance leg logs a Metal API validation failure on every run, with `MTL_DEBUG_LAYER=1` (which `make conformance` sets):

```
  [i686/visual] metal-validation: (destinationOrigin.x + sourceSize.width)(N) must be <= width(N).
```

The layer reports it and continues. Promoted to an error, or on a driver that enforces it, the same copy aborts the process; without the layer it is undefined.

## Root cause

The `CopyBufferToTexture` arm of `encode_leading_blits` retained the buffer and the texture and then issued `copyFromBuffer:sourceOffset:sourceBytesPerRow:sourceBytesPerImage:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:` with whatever geometry the wire carried. Nothing on the unix side compared the destination origin plus the region against the addressed mip level, and nothing compared the source buffer's length against the rows and slices the strides walk. `copyFromTexture:toTexture:` gained that predicate in the texture-to-texture change this branch builds on; the buffer arms did not.

The overhanging caller is a transposed `UpdateTexture` pair, clipped at its source in the separate `dirty_rect` change. With the guard in place the same run reports the copy it skipped, which names the shape: a 4x2 region landing on a 2x4 level.

```
WARN mtld3d::unix] encode_leading_blits: the region leaves the destination mip level, upload skipped. src handle=0x600001353f00 len=16384 offset=0 bytesPerRow=16 bytesPerImage=32, dst handle=0x7fefa9f96fe0 MTLPixelFormat(80) samples=1 level=0/2 origin=0,0 size=2x4x1, region 4x2x1
```

The synchronous readback (`blit_texture_to_buffer`, `copyFromTexture:toBuffer:`) has the same gap on the other side, and a documented way to reach it: when a `MetalFX` resolve of a render-resolution frame declines, the function warns and reads the source as-is, so the copy then asks for more pixels than the source holds.

## Changes

`unix/unix/src/metal/command.rs` gains `copy_buffer_to_texture_reject` and its mirror `copy_texture_to_buffer_reject`, built from the same `CopyEndpoint` and `CopyRejectReason` as the texture-to-texture predicate. Each checks that the addressed mip level exists, that the origin plus the region stays inside it, and that the buffer holds every byte the copy touches. `CopyRejectReason` gains `SourceBufferTooShort` and `DestinationBufferTooShort`; `CopyEndpoint` gains the texture's slice count, so a region that walks more slices than the level has is rejected too and a volume's geometry appears in the log line.

The level extent is rounded up to the block grid before the comparison, so a compressed level below one block still admits the whole block the copy has to name. The buffer bound counts `bytes_per_row` for every row of blocks but the last one of the last slice, and `bytes_per_image` for every slice but the last: the last row is only as long as its own blocks, which is what the copy reads. A stride wide enough to overflow the arithmetic fails the check instead of wrapping.

The `CopyBufferToTexture` arm logs once per reason and skips the copy, as the texture-to-texture arm does. The readback logs once per reason and returns false, which is how every other precondition in that function reports, and which the caller already maps to `D3DERR_INVALIDCALL`. The check runs before the blit encoder is created so a rejection leaves no encoder to close.

`PixelFormat` in `unix/shared/src/mtl.rs` gains `block_layout`, returning the pixel extent and byte size of one addressable block, since a block-compressed format has no per-pixel size to compute a row from. The match is exhaustive, so a new format has to state its block rather than inherit a default that is wrong for a compressed one.

## Alternatives

Trusting the PE side to bound the geometry: that is the state this fixes, and the wire has no way to express the destination extent the unix side already holds on the live `MTLTexture`.

Clamping the region to the level instead of skipping the copy: a clamped upload writes the wrong pixels into the right texture, which is harder to diagnose than a missing upload and a warn line. The readback is the one place clamping would arguably fit, since the caller could keep render-resolution pixels, but that is a separate decision about what a declined resolve should return.

Checking `sourceBytesPerImage` times the slice count, which is how the wire sizes it for a 2D copy: it charges the last row a full stride, so a sub-rect that starts part-way into the buffer's last row would be refused although Metal reads it.

## Verification

`make check`, `make test` and `make conformance` are green. `make test`: 820 core and types unit tests, 146 unix unit tests, and 296 end-to-end tests on each of i686 and x86_64, 1558 passing, 0 failing, 4 leaky.

`make conformance-isolate ONLY=visual ARCH=i686 REPEAT=1` on the parent commit prints the `(destinationOrigin.x + sourceSize.width)` validation line; on this commit it is gone, and the raw log carries the `upload skipped` warn quoted above in its place. `make conformance` reports no regressions on either architecture and no `must be <=` line in any of the eight legs. The three device.c sites that move (4475, 4480, 15088) are the flaky and ceiling pins, tolerated by the runner and not re-recorded.

Ten unit tests in `unix/unix/src/metal/command/tests.rs` cover the predicates, none of which can pass on the parent commit because the functions they call do not exist there: `an_upload_overhanging_the_level_is_rejected` is the conformance shape, and the rest pin the block-grid rounding (`a_compressed_level_under_one_block_takes_a_whole_block`), the block-row byte count (`a_compressed_upload_counts_block_rows`), the slice count (`a_volume_upload_counts_every_slice`), the last-row bound (`the_last_row_is_bounded_by_its_pixels_not_its_stride`) and the readback mirror (`a_readback_reports_the_ends_the_other_way_round`). `block_layout_table` in `unix/shared/src/mtl/tests.rs` pins the block table.

Closes #163
