### PR TITLE
Cross-check windows/tests/tests against the COVERAGE.md table

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -22,6 +22,7 @@ Most of this document is enforced by `make check`: `cargo +nightly fmt --check`,
 | `DefaultHasher` / `RandomState` = 0 (content hashes are xxh3) | §FxHash for maps, xxh3 for content |
 | `mod.rs` files = 0 | §Module style |
 | Inline `#[cfg(test)] mod tests { … }` blocks = 0 | §Unit tests live in `<stem>/tests.rs` |
+| Every `windows/tests/tests/*.rs` file has a row in `windows/tests/COVERAGE.md`, and every row a file | §End-to-end tests are listed in `COVERAGE.md` |
 | Release hygiene (see below) | §Release hygiene |
 
 Every finding names the section it came from. The confined-pattern checks compare **sets of files**, not counts, so moving an exception to a new file fails even though the count is unchanged — which is the point: each of those files earned its exception with an argument recorded here, and a new one needs a new argument.
@@ -113,6 +114,12 @@ Carry the cfg predicate verbatim. `perf.rs` declares `#[cfg(all(test, perf_track
 Two things do not move. A `#[cfg(test)]` helper that is an inherent method on a production type stays in the parent next to that type (`passes.rs` keeps a test-only `emit_scissor`), as does a `#[cfg(test)] pub fn` the tests import through `super::` (`log_helpers.rs` keeps `first_seen`).
 
 Watch relative paths on the way out: `include_str!` resolves against the containing file, so a path that was `../tests/fixtures/x.txt` inline becomes `../../tests/fixtures/x.txt` one directory down.
+
+## End-to-end tests are listed in `COVERAGE.md`
+
+`windows/tests/COVERAGE.md` is the index of the end-to-end suite: one row per file in `windows/tests/tests/`, saying what that file pins. It is how a reader finds whether a behaviour is already covered, and how a reviewer sees what a change is claiming, so it is only useful while it is complete. `make audit` matches it against the directory in both directions: a test file with no row fails, and a row naming a file that is not there fails too. A new test file lands with its row in the same change, and a deleted one takes its row with it.
+
+The row is one sentence per behaviour the file pins, not a summary of the file. A test added to an existing file extends that file's row rather than adding a new one.
 
 ## No `pub(crate)` — use module hierarchy
 

--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -17,6 +17,8 @@ set -eu
 cd "$(git rev-parse --show-toplevel)"
 
 INVENTORY=scripts/derive_inventory.txt
+COVERAGE=windows/tests/COVERAGE.md
+COVERAGE_TESTS=windows/tests/tests
 
 # Files permitted to hold each narrowly-scoped exception. These are sets, not
 # counts: a new site fails even if an old one was deleted in the same change.
@@ -105,6 +107,27 @@ inline_tests() {
             printf "%s:%d: %s\n", FILENAME, FNR, $0
         }
     ' "$@"
+}
+
+# The end-to-end suite's index, matched in both directions. Every test file has
+# a row in COVERAGE.md saying what it pins, and every row names a file that
+# exists: a file with no row is coverage nobody can find from the index, and a
+# row with no file claims coverage that no longer runs.
+#
+# The first cell of a table row is the file the row documents, so the row set is
+# the backticked `*.rs` name that opens a `|`-delimited line.
+coverage_matrix() {
+    rows=$(sed -n 's/^| *`\([^`]*\.rs\)` *|.*/\1/p' "$COVERAGE")
+    for file in $(git ls-files "$COVERAGE_TESTS/*.rs"); do
+        stem=${file##*/}
+        printf '%s\n' "$rows" | grep -qxF "$stem" ||
+            printf '%s: no row in %s\n' "$file" "$COVERAGE"
+    done
+    for row in $rows; do
+        [ -f "$COVERAGE_TESTS/$row" ] ||
+            printf '%s: row names `%s`, which is not a file in %s/\n' \
+                "$COVERAGE" "$row" "$COVERAGE_TESTS"
+    done
 }
 
 # Every type deriving Clone and/or Copy, as `path Type Derives`. The committed
@@ -277,6 +300,13 @@ confined '#\[allow\(' 'Warning suppressions' \
 modules=$(git ls-files '*/mod.rs' || true)
 if [ -n "$modules" ]; then
     report 'Module style: foo.rs + foo/, not foo/mod.rs' 'mod.rs file' "$modules"
+fi
+
+findings=$(coverage_matrix)
+if [ -n "$findings" ]; then
+    report 'End-to-end tests are listed in COVERAGE.md' \
+        "end-to-end coverage table drift: every $COVERAGE_TESTS/*.rs file needs a row in $COVERAGE, and every row needs its file" \
+        "$findings"
 fi
 
 # --- release hygiene ---------------------------------------------------------

--- a/windows/tests/COVERAGE.md
+++ b/windows/tests/COVERAGE.md
@@ -18,6 +18,10 @@ and rasterized spaces instead of staying in one of them.
 
 ## Covered behaviour by file
 
+`make audit` cross-checks this table against the files: every
+`windows/tests/tests/*.rs` needs a row, and every row needs its file. A new
+test file lands with its row in the same change.
+
 | File | Coverage |
 | --- | --- |
 | `smoke.rs` | Clear-to-colour fill; `DrawPrimitiveUP` triangle with interpolated diffuse. |


### PR DESCRIPTION
## Symptoms

`windows/tests/COVERAGE.md` is the per-file index of the end-to-end suite, maintained by hand and checked by nobody. It had drifted in both directions. Two test files, `implicit_surface.rs` and `snmalloc_drift.rs`, carried no row at all, so a reader asking whether the implicit-surface identity contract is covered found nothing in the index. One row, `` `clear_present.rs` | (folded into smoke/device - clear flags exercised via `clear`). ``, named a file that no longer exists, so the table claimed coverage that no longer runs.

## Root cause

`make audit` gates the grep-shaped conventions that a lint cannot express, including the `Clone`/`Copy` derive inventory and the doc-block shape, but it had no rule tying the test directory to its index. Nothing failed when a test file landed without a row, and nothing failed when a file was folded away and its row stayed.

## Changes

`scripts/audit.sh` gains `coverage_matrix`, run from the whole-tree audit. It reads the first cell of every `|`-delimited row in `windows/tests/COVERAGE.md` (the backticked `*.rs` name that opens the line) and matches that set against `git ls-files windows/tests/tests/*.rs` in both directions: a test file with no row is reported, and a row naming a file that is not in the directory is reported. Findings print through the existing `report()` shape and name the `docs/CONVENTIONS.md` section behind them, like every other rule. The check stays POSIX sh with no GNU extensions.

`docs/CONVENTIONS.md` gains the section the rule points at, "End-to-end tests are listed in `COVERAGE.md`", plus its row in the mechanical-audit table.

`windows/tests/COVERAGE.md` loses the stale `clear_present.rs` row and gains a sentence under the table heading saying the table is audited, so the requirement is visible where a new row gets written. This PR is stacked on #90, which adds the two missing rows.

## Alternatives

Match rows by test-function name rather than by file, so the table pins individual `#[test]`s. Rejected: the table is one row per file by design (a row is a sentence per behaviour, not a list of functions), and a per-function index would need rewriting on every test added.

Run the check in `--file` mode too, so an editor hook flags a new test file at edit time. Rejected for now: the per-file mode takes a path in whichever form the hook passes it, and the whole-tree run already fails the same gate, `make check`, that the commit has to pass.

Keep the `clear_present.rs` row as a note that the coverage moved. Rejected: the row says where the file went, which is history, not coverage, and the folded behaviour is already described by the `smoke.rs` and `device.rs` rows.

## Verification

`scripts/audit.sh` on the branch reports `audit: clean (234 files)`, and `make audit` agrees. Before the row was dropped, the same run reported the second half of the rule firing on the real drift: ``windows/tests/COVERAGE.md: row names `clear_present.rs`, which is not a file in windows/tests/tests/``.

Both directions were exercised by hand against the finished tree and the tree restored afterwards. Deleting the `implicit_surface.rs` row reports `windows/tests/tests/implicit_surface.rs: no row in windows/tests/COVERAGE.md`; staging a new `windows/tests/tests/newtest.rs` with no row reports it the same way; appending a `` `gone.rs` `` row reports ``row names `gone.rs`, which is not a file in windows/tests/tests/``. Each restores to a clean audit.

`scripts/audit.sh --file`, `--update-derives` and `--help` are unaffected: no Rust changed, so no build or test leg is involved.

Closes #103
