### PR TITLE
Move the V8U8 doc block onto the V8U8 test

### DIFF
--- a/windows/tests/tests/textures.rs
+++ b/windows/tests/tests/textures.rs
@@ -1674,12 +1674,6 @@ fn update_texture_accepts_a_single_slice_volume_pair() {
     assert_eq!(h.update_volume_texture_hr(&src, &dst), 0, "UpdateTexture");
 }
 
-/// `D3DFMT_V8U8` must sample its content, not black.
-///
-/// Signed two-channel, → `Rg8Snorm` with {R,G,1,1} swizzle. A 1x1 texel of
-/// signed (+1,+1) reads as (1,1,1,1) → white. Confirms `V8U8`
-/// create/upload/sample works in isolation (a full FF-alpha +
-/// per-texel-bias `V8U8` setup is not covered here).
 /// A level from `GetVolumeLevel` locked and written reaches the texture.
 ///
 /// The level shell forwards to the parent's per-level lock, so the write
@@ -1721,6 +1715,12 @@ fn volume_level_lock_box_writes_reach_the_texture() {
     }
 }
 
+/// `D3DFMT_V8U8` must sample its content, not black.
+///
+/// Signed two-channel, → `Rg8Snorm` with {R,G,1,1} swizzle. A 1x1 texel of
+/// signed (+1,+1) reads as (1,1,1,1) → white. Confirms `V8U8`
+/// create/upload/sample works in isolation (a full FF-alpha +
+/// per-texel-bias `V8U8` setup is not covered here).
 #[test]
 fn v8u8_signed_texture_samples_nonzero() {
     let h = Harness::new();


### PR DESCRIPTION
## Symptoms

In `windows/tests/tests/textures.rs` the doc comment describing the `D3DFMT_V8U8` signed-texture contract sat immediately above `volume_level_lock_box_writes_reach_the_texture`, so it documented the wrong test. `v8u8_signed_texture_samples_nonzero`, further down, carried no doc at all.

## Root cause

The block was inserted at the wrong offset when the V8U8 test was added. The volume lock-box test already had its own doc block, which followed directly underneath, so the two blocks ran together above a single test and nothing flagged it.

## Changes

`windows/tests/tests/textures.rs`: the six-line `D3DFMT_V8U8` block moves from above `volume_level_lock_box_writes_reach_the_texture` to above `v8u8_signed_texture_samples_nonzero`. Its text is unchanged, and the volume lock-box test keeps the doc block it already had.

## Alternatives

Rewriting the V8U8 text while moving it: rejected, the wording is accurate and an edit would obscure that this is a pure relocation.

## Verification

Comment-only change, no behaviour to test. `scripts/audit.sh --file windows/tests/tests/textures.rs` and `cargo +nightly fmt --check -p mtld3d-tests` are both clean. A reviewer judges by the diff: two hunks, one removing the block and one re-adding it verbatim.

Closes #148
