### PR TITLE
Drop the dead let _ = pool in device_create_volume_texture

### DIFF
--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -4682,7 +4682,6 @@ extern "system" fn device_create_volume_texture(
     shared_handle: *mut c_void,
 ) -> i32 {
     let _timer = device_timer(this, DeviceSubCategory::Misc);
-    let _ = pool;
     trace!(
         target: LOG_TARGET,
         "IDirect3DDevice9::CreateVolumeTexture({width}x{height}x{depth}, fmt={format})"


### PR DESCRIPTION
## Symptoms

No runtime symptom: `device_create_volume_texture` opens with `let _ = pool;`, which reads as a declaration that the `pool` parameter is unused when it is not.

## Root cause

The statement sits between the perf timer and the trace line, before any of the parameter's real uses. `pool` is read three times further down in the same function: the scratch-only rejection of block-compressed and packed-YUV formats (`pool != D3DPOOL_SCRATCH`), the D3DUSAGE_DYNAMIC rejection on the managed and scratch pools, and the `d3d_pool` field of the volume texture that gets created. A discard of a value that is used afterwards suppresses no lint, so the line is pure noise.

## Changes

windows/d3d9: remove the `let _ = pool;` from `device_create_volume_texture`. Nothing else changes, so the diff is one deleted line and rebases cleanly onto the system-memory pool rework that also touches this function.

The rest of the tree was swept for the same shape (`let _ = <name>;` where the name is live). Three sites are kept because they are not the same thing:

- `windows/d3d9/src/swapchain.rs` in `swapchain_get_front_buffer_data` and `swapchain_get_raster_status`: `this` is genuinely unused in both stubs, so the discard is what keeps the unused-parameter lint quiet. Renaming the parameter to `_this` would be an unrelated style change to code this fix does not need to touch.
- `windows/core/src/perf.rs` in the row renderer: `cursor` is a local whose final `+=` is never read back, and the discard is what silences `unused_assignments`.

`unix/unix/src/metal/present.rs` keeps five discards of the library and function objects with a comment stating that the pipeline states own what Metal needs; they document a lifetime invariant rather than silence a lint, and are left alone.

## Alternatives

Rename the parameter to `_pool` and keep the discard: wrong, because the parameter is read and the underscore would then be a lie.

Sweep the swapchain stubs to `_this` in the same change: rejected as an unrelated cleanup in a branch that exists for one line.

## Verification

`make check` is green (fmt-check, clippy nursery and pedantic on both PE targets and native, audit clean at 234 files, doc). `make test` is green with exit code 0 and no `FAIL`, `SIGABRT` or `TIMEOUT` line: 782 passed in mtld3d-core, 125 passed in the unix crates, and 285 passed per end-to-end architecture with the same 285 test names on i686 and x86_64 (1 benign leak on i686, 3 on x86_64).

There is no new test. Removing a statement that discards a live value cannot change behaviour, so there is no assertion that would fail before the change and pass after; the existing volume-texture coverage in the end-to-end suite is what pins the pool-dependent rejections that the parameter feeds.

`make conformance` was not run: the change is in COM wiring and touches no render, state or shader-emission path.

Closes #107
