### PR TITLE
Measure a texture blit's bytesPerImage in block rows

### DIFF
--- a/unix/shared/src/blit_geometry.rs
+++ b/unix/shared/src/blit_geometry.rs
@@ -1,0 +1,40 @@
+//! Row geometry shared by both directions of a Metal texture blit.
+//!
+//! Metal measures a texture copy in *block* rows, not pixel rows. For a
+//! block-compressed level one row of `bytes_per_row` covers `block_height`
+//! pixel rows, so a slice is `ceil(height / block_height)` rows long, not
+//! `height`. An uncompressed format has a block height of 1 and the same
+//! formula collapses to the familiar `bytes_per_row * height`.
+//!
+//! Both directions derive the value here: the PE-side upload jobs building a
+//! `CopyBufferToTexture` blit command, and the unix-side `copyFromTexture:
+//! toBuffer:` readback. The unix side has no format table, so the block height
+//! travels to it on the readback thunk's parameters.
+
+/// Number of block rows a `height`-pixel region covers.
+///
+/// `block_height` is the source format's block height: 1 for an uncompressed
+/// format, 4 for the BC family. Zero is read as 1, so a caller that leaves the
+/// field at its default gets the uncompressed answer rather than a division
+/// trap.
+#[must_use]
+pub const fn block_rows(height: u32, block_height: u32) -> u32 {
+    if block_height <= 1 {
+        height
+    } else {
+        height.div_ceil(block_height)
+    }
+}
+
+/// Byte size of one image slice, for Metal's `bytesPerImage` argument.
+///
+/// `bytes_per_row` is the stride of a single block row, already in the layout
+/// the blit reads (padded strides included), and `height` is the region height
+/// in pixels.
+#[must_use]
+pub const fn bytes_per_image(bytes_per_row: u32, height: u32, block_height: u32) -> u32 {
+    bytes_per_row.saturating_mul(block_rows(height, block_height))
+}
+
+#[cfg(test)]
+mod tests;

--- a/unix/shared/src/blit_geometry/tests.rs
+++ b/unix/shared/src/blit_geometry/tests.rs
@@ -1,0 +1,59 @@
+//! Unit tests for the block-row geometry a Metal texture blit is measured in.
+//!
+//! The cases that matter are the ones where a pixel-row count and a block-row count
+//! disagree: a 4x4-block format at a height that is a multiple of the block height, at
+//! a height that is not, and at a height below one block. An uncompressed format
+//! (block height 1, and the degenerate 0) has to keep answering `bytes_per_row *
+//! height`, since every existing caller relies on that.
+
+use super::{block_rows, bytes_per_image};
+
+/// An uncompressed format counts pixel rows, and an unset block height reads as one.
+#[test]
+fn uncompressed_counts_pixel_rows() {
+    assert_eq!(block_rows(0, 1), 0);
+    assert_eq!(block_rows(1, 1), 1);
+    assert_eq!(block_rows(17, 1), 17);
+    assert_eq!(block_rows(256, 0), 256);
+
+    assert_eq!(bytes_per_image(1024, 256, 1), 1024 * 256);
+    assert_eq!(bytes_per_image(4, 1, 1), 4);
+    assert_eq!(bytes_per_image(1024, 256, 0), 1024 * 256);
+}
+
+/// A 4x4-block format counts block rows, rounding a partial row up.
+#[test]
+fn compressed_counts_block_rows() {
+    assert_eq!(block_rows(4, 4), 1);
+    assert_eq!(block_rows(8, 4), 2);
+    assert_eq!(block_rows(256, 4), 64);
+
+    // A 256x256 BC1 level: 64 blocks across at 8 bytes each is a 512-byte
+    // block row, and 64 block rows make the level 32 KiB, not 128 KiB.
+    assert_eq!(bytes_per_image(512, 256, 4), 512 * 64);
+    // A single 4x4 BC1 block is the whole slice.
+    assert_eq!(bytes_per_image(8, 4, 4), 8);
+}
+
+/// A height that is not a multiple of the block height rounds up to a whole block row.
+#[test]
+fn partial_block_row_rounds_up() {
+    assert_eq!(block_rows(1, 4), 1);
+    assert_eq!(block_rows(2, 4), 1);
+    assert_eq!(block_rows(5, 4), 2);
+    assert_eq!(block_rows(7, 4), 2);
+    assert_eq!(block_rows(9, 4), 3);
+
+    // The bottom of a BC1 mip chain: 2x2 and 1x1 levels each still occupy one
+    // 8-byte block.
+    assert_eq!(bytes_per_image(8, 2, 4), 8);
+    assert_eq!(bytes_per_image(8, 1, 4), 8);
+    // A 16x6 BC1 sub-rect spans two block rows of 4 blocks.
+    assert_eq!(bytes_per_image(32, 6, 4), 64);
+}
+
+/// An overflowing product saturates rather than wrapping to a short slice.
+#[test]
+fn overflow_saturates() {
+    assert_eq!(bytes_per_image(u32::MAX, 8, 4), u32::MAX);
+}

--- a/unix/shared/src/commands.rs
+++ b/unix/shared/src/commands.rs
@@ -578,8 +578,8 @@ pub enum BlitCommandType {
 ///   `bytes_per_row` / `src_offset` describe the copy. `depth` is the
 ///   slice count (1 for a 2D texture, >1 for a volume/3D texture) and
 ///   `bytes_per_image` is the byte stride between slices (for a 2D copy
-///   it equals `bytes_per_row * region_h`, matching the implicit
-///   single-slice size). `dst_offset` / `byte_size` unused.
+///   it is the single slice's own size). `dst_offset` / `byte_size`
+///   unused.
 /// - `CopyTextureToTexture`: `src_handle` / `dst_handle` = textures,
 ///   `mip_level` selects the mip. `origin_x` / `origin_y` are the
 ///   *source* origin; `region_w` / `region_h` are the region size; the
@@ -657,9 +657,10 @@ pub struct CopyBufferToTextureInfo {
     pub depth: u32,
     /// Byte stride between slices.
     ///
-    /// For a 2D copy (`depth == 1`) callers pass `bytes_per_row * region_h` —
-    /// the implicit single-slice size. For a volume it is the box's slice
-    /// pitch.
+    /// For a 2D copy (`depth == 1`) callers pass the single slice's own size:
+    /// `bytes_per_row` times the region's *block*-row count, which is its pixel
+    /// height only for an uncompressed format. For a volume it is the box's
+    /// slice pitch.
     pub bytes_per_image: u32,
 }
 

--- a/unix/shared/src/lib.rs
+++ b/unix/shared/src/lib.rs
@@ -1,5 +1,6 @@
 use strum::{EnumCount, VariantArray};
 
+pub mod blit_geometry;
 mod commands;
 pub mod crumb;
 pub mod ffi_boundary;

--- a/unix/shared/src/params.rs
+++ b/unix/shared/src/params.rs
@@ -1084,8 +1084,13 @@ pub struct BlitTextureToBufferParams {
     ///
     /// See [`Self::source_width`].
     pub source_height: u32, // in
-    /// Explicit tail padding to the 8-byte stride.
-    pub pad0: u32,
+    /// Block height of the source format: 1 uncompressed, 4 for the BC family.
+    ///
+    /// `bytes_per_row` is the stride of one *block* row, so a slice is
+    /// `ceil(height / block_height)` rows rather than `height`. The unix side
+    /// has no format table and derives the blit's `bytesPerImage` from this
+    /// through [`crate::blit_geometry::bytes_per_image`].
+    pub block_height: u32, // in
 }
 
 impl Thunk for BlitTextureToBufferParams {

--- a/unix/shared/src/params/tests.rs
+++ b/unix/shared/src/params/tests.rs
@@ -50,9 +50,8 @@ fn set_display_sync_enabled_layout() {
 #[test]
 fn blit_texture_to_buffer_layout() {
     use super::BlitTextureToBufferParams;
-    // 3*u64 (handles) + 2*u64 (dst ptr/len) + 9*u32
-    // = 24 + 16 + 36 = 76, which the explicit pad0 rounds to 80, a
-    // multiple of the align-8.
+    // 3*u64 (handles) + 2*u64 (dst ptr/len) + 10*u32
+    // = 24 + 16 + 40 = 80, a multiple of the align-8.
     assert_eq!(core::mem::align_of::<BlitTextureToBufferParams>(), 8);
     assert_eq!(core::mem::size_of::<BlitTextureToBufferParams>(), 80);
 }

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -496,6 +496,7 @@ pub extern "C" fn blit_texture_to_buffer_handler(args: *mut c_void) -> i32 {
         bytes_per_row: params.bytes_per_row,
         source_width: params.source_width,
         source_height: params.source_height,
+        block_height: params.block_height,
     };
     if metal::blit_texture_to_buffer(&blit_args) {
         STATUS_SUCCESS

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -2633,6 +2633,11 @@ pub struct BlitArgs {
     pub source_width: u32,
     /// Full logical height the sub-rect coordinates are measured in.
     pub source_height: u32,
+    /// Block height of the source format.
+    ///
+    /// See `BlitTextureToBufferParams::block_height`. `bytes_per_row` is the
+    /// stride of one block row, so the slice size counts block rows.
+    pub block_height: u32,
 }
 
 /// Resolve a render-resolution source up to the size the caller's coordinates assume.
@@ -2743,6 +2748,7 @@ pub fn blit_texture_to_buffer(args: &BlitArgs) -> bool {
         bytes_per_row,
         source_width,
         source_height,
+        block_height,
     } = *args;
 
     if dst_ptr == 0 || dst_len == 0 || width == 0 || height == 0 {
@@ -2855,6 +2861,11 @@ pub fn blit_texture_to_buffer(args: &BlitArgs) -> bool {
         blit.setLabel(Some(&label));
     }
 
+    // `height` is in pixels but `bytes_per_row` strides one block row, so the
+    // slice size counts block rows. The two agree only for an uncompressed
+    // format, where the block height is 1.
+    let bytes_per_image =
+        mtld3d_shared::blit_geometry::bytes_per_image(bytes_per_row, height, block_height) as usize;
     // SAFETY: objc2 typed binding; `texture`/`dst_buffer` are retained Metal
     // objects live for the call; the geometry cleared
     // `copy_texture_to_buffer_reject` above.

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -6257,7 +6257,9 @@ pub fn blit_handle_to_systemmem(device_inner: &DeviceInner, read: &SystemMemRead
         bytes_per_row: read.bytes_per_row,
         source_width: read.full_width,
         source_height: read.full_height,
-        pad0: 0,
+        // Render-target colour formats are all uncompressed, so a block row is
+        // a pixel row.
+        block_height: 1,
     };
     let status = unix_call(&mut params);
     if status != 0 {

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -347,7 +347,8 @@ pub struct TextureUploadJob {
     /// Byte stride between slices (the box slice pitch).
     ///
     /// Only read by the volume blit path; the 2D path derives its
-    /// single-slice `bytes_per_image` from `src_pitch * region_h` instead.
+    /// single-slice `bytes_per_image` from the region's block-row count
+    /// instead.
     pub slice_pitch: u32,
 }
 
@@ -6585,18 +6586,18 @@ impl FrameEncoder {
         }
 
         // Compute the blit descriptor against the staging buffer's
-        // src_pitch stride. `num_blit_rows` is the row count the GPU
-        // will actually read — pixel rows for uncompressed, block rows
-        // (rounded up) for compressed. Carried through alongside `info`
-        // so the alignment-pad branch below knows how many source rows
-        // to repack.
+        // src_pitch stride. The format's block height is carried through
+        // alongside `info` because a Metal blit is measured in block rows,
+        // not pixel rows: it turns `region_h` into the row count the GPU
+        // actually reads, both for the alignment-pad repack below and for
+        // the slice size the copy is given.
         let staging_buffer_handle =
             self.get_or_create_staging_buffer(job.info.texture_id, job.staging_index, &job.arc);
         if staging_buffer_handle == 0 {
             return false;
         }
 
-        let (info, num_blit_rows) = if job.bytes_per_pixel == 0 {
+        let (info, block_height) = if job.bytes_per_pixel == 0 {
             // Compressed (BC1/2/3). Sub-rect must land on the block
             // grid; otherwise fall back to a full-mip blit from the
             // start of the staging buffer. Both variants are correct
@@ -6631,7 +6632,7 @@ impl FrameEncoder {
                     depth: 1,
                     bytes_per_image: 0,
                 };
-                (info, job.region_h.div_ceil(bh))
+                (info, bh)
             } else {
                 mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
                     "run_texture_upload_blit: compressed sub-rect ({}+{},{}+{}) unaligned to {}×{} block grid → full-mip fallback",
@@ -6656,7 +6657,7 @@ impl FrameEncoder {
                     depth: 1,
                     bytes_per_image: 0,
                 };
-                (info, mip_h.div_ceil(bh))
+                (info, bh)
             }
         } else {
             // Uncompressed path. Sub-rect offset is
@@ -6677,8 +6678,9 @@ impl FrameEncoder {
                 depth: 1,
                 bytes_per_image: 0,
             };
-            (info, job.region_h)
+            (info, 1)
         };
+        let num_blit_rows = mtld3d_shared::blit_geometry::block_rows(info.region_h, block_height);
 
         // `copyFromBuffer:toTexture:` requires `sourceBytesPerRow` to
         // be ≥ `device.minimumLinearTextureAlignmentForPixelFormat`
@@ -6699,13 +6701,16 @@ impl FrameEncoder {
             info
         };
 
-        // Single-slice (`depth == 1`) copy: `bytes_per_image` is
-        // `bytes_per_row * region_h` computed off the *final*
-        // (post-padding) row stride — the exact value the unix blit
-        // derived implicitly before the field existed, so the 2D wire is
-        // byte-identical.
+        // Single-slice (`depth == 1`) copy: `bytes_per_image` is the slice's
+        // block-row count times the *final* (post-padding) row stride. For a
+        // compressed level that is `block_height` times smaller than the
+        // pixel-row product.
         let info = CopyBufferToTextureInfo {
-            bytes_per_image: info.bytes_per_row.saturating_mul(info.region_h),
+            bytes_per_image: mtld3d_shared::blit_geometry::bytes_per_image(
+                info.bytes_per_row,
+                info.region_h,
+                block_height,
+            ),
             ..info
         };
         self.frame_blit_commands

--- a/windows/d3d9/src/surface.rs
+++ b/windows/d3d9/src/surface.rs
@@ -2420,7 +2420,8 @@ fn backbuffer_lock_readback(
         // the game expects and `bytes_per_row` above stays logical.
         source_width: full_w,
         source_height: full_h,
-        pad0: 0,
+        // BGRA8 back buffer: a block row is a pixel row.
+        block_height: 1,
     };
     let status = unix_call(&mut params);
     if status != 0 {
@@ -2486,7 +2487,8 @@ fn readback_full_backbuffer(inner: &mut SurfaceInner) -> Option<(u32, u32, u32)>
         // this seeds is the size `GetDC` promised.
         source_width: w,
         source_height: h,
-        pad0: 0,
+        // BGRA8 back buffer: a block row is a pixel row.
+        block_height: 1,
     };
     if unix_call(&mut params) != 0 {
         return None;
@@ -2787,7 +2789,9 @@ fn lockable_rt_readback_fill(inner: &mut SurfaceInner, bpp: u32) {
         // texture and the unix side skips the resolve.
         source_width: width,
         source_height: height,
-        pad0: 0,
+        // A lockable render target has a non-zero `bpp`, so its format is
+        // uncompressed and a block row is a pixel row.
+        block_height: 1,
     };
     let status = unix_call(&mut params);
     if status != 0 {

--- a/windows/d3d9/src/texture.rs
+++ b/windows/d3d9/src/texture.rs
@@ -3477,7 +3477,9 @@ fn materialize_subresource_from_gpu(ti: &mut TextureInner, face: u32, level: usi
         // that scale, already matches it.
         source_width: ti.mip_width(0),
         source_height: ti.mip_height(0),
-        pad0: 0,
+        // A block-compressed level strides by block rows, so the slice size
+        // counts them the same way `needed` above does.
+        block_height: ti.block_h.max(1),
     };
     let status = unix_call(&mut params);
     if status != 0 {


### PR DESCRIPTION
## Symptoms

No user-visible symptom today, and no log line: every path that reaches either blit with a block-compressed format is a single-slice (`depth == 1`) copy, and Metal derives the slice size itself in that case rather than reading `bytesPerImage`. The value is wrong all the same, by a factor of the format's block height, and it is the value a compressed volume or array copy would be measured by.

## Root cause

Both directions of the texture blit multiplied the row stride by the *pixel* height. `bytes_per_row` strides one **block** row, so for BC1/2/3 (4x4 blocks) a slice is `ceil(height / 4)` rows, not `height`, and the product came out four times the real image size.

The readback direction (`blit_texture_to_buffer` in `unix/unix/src/metal/command.rs`) computed `bytes_per_row * height` with no way to do better: the unix side carries no format table, and the readback thunk's parameters never told it the block height. The upload direction (`run_texture_upload_blit` in `windows/d3d9/src/encoder.rs`) already computed the correct block-row count for the alignment-pad repack, then threw it away and used `region_h` for the slice size. `run_volume_upload_blit` was unaffected: it recovers the row count by dividing the box's slice pitch by its row pitch, which is already a block-row count.

## Changes

`mtld3d-shared` gains a `blit_geometry` module with `block_rows(height, block_height)` and `bytes_per_image(bytes_per_row, height, block_height)`. It lives in the shared crate rather than in `mtld3d-core` because both workspaces need it, and a block height of 0 or 1 answers the uncompressed result so no caller has to special-case an uncompressed format.

`BlitTextureToBufferParams` carries the source format's `block_height` (plus an explicit `pad0` to keep the struct an 8-byte multiple), threaded through `BlitArgs` to the blit, which now derives `bytesPerImage` through the helper. The four readback call sites are all uncompressed (the BGRA8-pinned back buffer twice, `GetRenderTargetData` / `GetFrontBufferData`, and a lockable render target, whose non-zero bytes-per-pixel is what selects that path) and pass 1.

`run_texture_upload_blit` carries the block height out of its per-format branches instead of a pre-divided row count, and derives both the repack row count and the copy's `bytes_per_image` from it through the same helper. The stale descriptions of the old formula on `CopyBufferToTextureInfo::bytes_per_image` and `TextureUploadJob::slice_pitch` are corrected.

## Alternatives

Compute `bytes_per_image` on the PE side and put that on the wire, as `CopyBufferToTextureInfo` already does: rejected because the rest of `BlitTextureToBufferParams` is a description of the image (origin, extent, row stride), not of a Metal argument, and a block height fits that family while a pre-derived slice size does not.

Give the unix side its own format table so nothing new crosses the wire: rejected, it duplicates `format.rs` on the far side of the boundary and is exactly the drift the one-home rule for wire values exists to prevent.

Leave the readback direction alone since every caller is uncompressed today: rejected, the released-level lock refill (#100) is the next caller and it reads compressed levels.

## Verification

`make check` clean. `make test` green: 782 `mtld3d-core` and 129 `mtld3d-shared` host unit tests, and 285 end-to-end tests on each of i686 and x86_64 (1476 `PASS` lines, 5 `LEAK`, 0 `FAIL` / `SIGABRT` / `TIMEOUT`, every test name appearing exactly once per architecture). `make conformance` reports no regressions on either architecture; the only movement is the known-flaky `device.c:4475` / `device.c:4480` and the `device.c:15088` ceiling all reading below their pins, so the baseline is not re-recorded.

The behaviour is pinned by `blit_geometry::tests`, four tests over the 1x1 and 4x4 block cases including heights that are not a multiple of the block height. `compressed_counts_block_rows` and `partial_block_row_rounds_up` fail against the old `bytes_per_row * height` formula (`bytes_per_image(512, 256, 4)` reads 128 KiB instead of the level's real 32 KiB) and pass after.

There is no end-to-end test because no compressed readback is reachable through the API today: `GetRenderTargetData` and `GetFrontBufferData` need a render-target source, which cannot be block-compressed; a `LockRect` on a compressed texture is answered from the CPU staging with no GPU readback at all; and the released-level lock refill that would read a DXT1 cube face back has not landed. The upload direction is reachable (`textures::dxt1_block_samples_solid_color`, `textures::managed_dxt_cube_keeps_faces_independent`) but cannot fail on this: those tests run with the Metal validation layer on and pass both before and after, because the layer does not check `bytesPerImage` for a single-slice copy.

Closes #119
