### PR TITLE
Log the skipped-precondition arms of the lockable RT staging sync

### DIFF
--- a/windows/d3d9/src/surface.rs
+++ b/windows/d3d9/src/surface.rs
@@ -2738,24 +2738,41 @@ fn lockable_rt_readback_fill(inner: &mut SurfaceInner, bpp: u32) {
     let (width, height) = (inner.standalone_width, inner.standalone_height);
     let tex_handle = inner.live_color_handle();
     if bpp == 0 || width == 0 || height == 0 || tex_handle.is_null() {
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "lockable RT read-back skipped: bpp={bpp} extent={width}x{height} color_handle={:#x} (staging left as-is)",
+            tex_handle.raw()
+        );
         return;
     }
     let bytes_per_row = mtld3d_core::format::linear_row_pitch(width, bpp);
     let needed = (bytes_per_row as usize).saturating_mul(height as usize);
     if needed == 0 {
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "lockable RT read-back skipped: zero byte size for {width}x{height} at {bpp} bpp (staging left as-is)"
+        );
         return;
     }
     let device_ptr = inner.device_inner;
     if device_ptr.is_null() {
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "lockable RT read-back skipped: surface has no owning device (staging left as-is)"
+        );
         return;
     }
     // Borrow the staging (the blit destination) and the device separately;
     // `device_inner` is a distinct allocation from the `system_memory` PageBox,
     // so the two raw-pointer derefs never overlap.
     let Some(page) = inner.system_memory.as_mut() else {
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "lockable RT read-back skipped: surface carries no CPU staging buffer"
+        );
         return;
     };
     if page.len() < needed {
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "lockable RT read-back skipped: staging {} bytes, {needed} needed for {width}x{height} at {bpp} bpp (staging left as-is)",
+            page.len()
+        );
         return;
     }
     let dst_ptr = page.as_mut_ptr() as u64;
@@ -2814,20 +2831,34 @@ fn lockable_rt_readback_fill(inner: &mut SurfaceInner, bpp: u32) {
 /// never disagree.
 fn lockable_rt_upload(inner: &mut SurfaceInner) {
     let Some(fmt) = mtld3d_core::format::map_d3d_format(inner.standalone_format) else {
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "lockable RT staging upload skipped: unmapped surface format {:#x} (colour texture left as-is)",
+            inner.standalone_format
+        );
         return;
     };
     let bpp = fmt.bytes_per_pixel();
     let (width, height) = (inner.standalone_width, inner.standalone_height);
     let color_handle = inner.live_color_handle().raw();
     if bpp == 0 || width == 0 || height == 0 || color_handle == 0 {
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "lockable RT staging upload skipped: bpp={bpp} extent={width}x{height} color_handle={color_handle:#x} (colour texture left as-is)"
+        );
         return;
     }
     let Some(page) = inner.system_memory.as_ref() else {
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "lockable RT staging upload skipped: surface carries no CPU staging buffer"
+        );
         return;
     };
     let pitch = mtld3d_core::format::linear_row_pitch(width, bpp);
     let needed = (pitch as usize).saturating_mul(height as usize);
     if page.len() < needed {
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "lockable RT staging upload skipped: staging {} bytes, {needed} needed for {width}x{height} at {bpp} bpp (colour texture left as-is)",
+            page.len()
+        );
         return;
     }
     // Copy the `pitch * height` bytes the lock just received into a heap buffer
@@ -2835,6 +2866,9 @@ fn lockable_rt_upload(inner: &mut SurfaceInner) {
     // must not borrow the surface's staging (no-thunk rule).
     let bytes: Vec<u8> = page.as_slice()[..needed].to_vec();
     if inner.device_inner.is_null() {
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "lockable RT staging upload skipped: surface has no owning device (colour texture left as-is)"
+        );
         return;
     }
     // SAFETY: `inner.device_inner` was stamped at `Self::new` from a live


### PR DESCRIPTION
## Symptoms

A lockable render target keeps its pixels in two places: the renderable colour texture and the CPU staging buffer a `LockRect` or a `GetDC` hands out. Both directions of the sync between them give up silently. `lockable_rt_readback_fill` has five early returns with no log line (a combined zero bytes-per-pixel / zero extent / null colour handle guard, a zero byte size, a null owning device, a missing staging buffer, and a staging buffer smaller than the surface), and its write half `lockable_rt_upload` has five more. When one fires, the `LockRect` still returns `D3D_OK` and the caller reads stale or zero-initialised bytes, or the pixels it wrote never reach the GPU texture, with nothing in the log naming the precondition that failed. Only the blit-failure path logged (`lockable RT LockRect read-back: BlitTextureToBuffer failed status=...`).

## Root cause

The guards were written as defence in depth and never given the one-shot warn every fallback carries (`docs/CONVENTIONS.md`: no silent failures).

## Changes

`windows/d3d9/src/surface.rs`: each early return in `lockable_rt_readback_fill` and in `lockable_rt_upload` now fires a `log_once_warn!` that names the precondition and prints the values behind it (bytes per pixel, extent, colour handle, staging length against the length needed). The control flow is unchanged: every arm still returns exactly where it did, and the lock or the DC still succeeds.

The rest of the file was swept for the same shape. Left alone: `readback_full_backbuffer` (four silent `None` returns) and `dc_pixels` (five silent `None` returns), both of which return through `GetDC`'s already-logged `no host pixel store` reject and are the subject of separate work; the `LockRect` / `UnlockRect` / `GetDC` / `ReleaseDC` rejects that return `D3DERR_INVALIDCALL` for an invalid application call, which are the documented D3D9 result rather than a fallback; and `teardown_gdi_dc`'s null check, which is a documented no-op on a surface holding no DC.

## Alternatives

Split the combined `bpp == 0 || width == 0 || height == 0 || handle.is_null()` guard into one arm per precondition: rejected, the values are in the message and the extra branches buy nothing.

Promote the arms to a returned error so `LockRect` reports `D3DERR_INVALIDCALL`: rejected, that is a behaviour change for a set of conditions `CreateRenderTarget` already validates, and it belongs in its own change if it is ever wanted.

## Verification

`make check` clean (fmt, clippy nursery + pedantic on both PE targets and native, audit clean over 234 files, doc). `make test`: 787 + 125 host unit tests passed, and both end-to-end legs 290/290 PASS (i686 with 2 LEAK, x86_64 with 3 LEAK, all in `buffers`), no FAIL, SIGABRT or TIMEOUT.

No test accompanies the change: it adds log lines and no observable behaviour. Every arm is unreachable through the public API, because `CreateRenderTarget` validates the format mapping and the extent before it attaches the staging and sizes that staging at exactly `width * height * bpp`, and both callers of the two helpers are gated on `is_lockable_render_target` (staging present, colour handle non-null). The lines exist so that a future path that breaks one of those invariants names itself in the log instead of surfacing as stale pixels.

Closes #147
