### PR TITLE
Back the frame dump's texture readback with a PageBox

### DIFF
--- a/windows/d3d9/src/device/frame_dump.rs
+++ b/windows/d3d9/src/device/frame_dump.rs
@@ -11,6 +11,7 @@
 use core::ffi::c_void;
 
 use log::info;
+use mtld3d_core::page_box::PageBox;
 use mtld3d_shared::MetalHandle;
 use mtld3d_types::{
     D3DRS_ALPHABLENDENABLE, D3DRS_ALPHAFUNC, D3DRS_ALPHAREF, D3DRS_ALPHATESTENABLE, D3DRS_BLENDOP,
@@ -229,7 +230,10 @@ impl DeviceInner {
                 }
                 let bytes_per_row = t.width * bpp;
                 let len = bytes_per_row as usize * t.height as usize;
-                let mut buf = vec![0u8; len];
+                // The unix side wraps the destination in `newBufferWithBytesNoCopy`,
+                // which takes a page-aligned base and a page-multiple length, so the
+                // destination is a `PageBox` and the wrapper sees its padded length.
+                let mut buf = PageBox::new_zeroed(len);
                 let hr = super::blit_handle_to_systemmem(
                     self,
                     &super::SystemMemReadback {
@@ -237,7 +241,7 @@ impl DeviceInner {
                         // MTLTexture handle from the encoder texture cache.
                         tex_handle: unsafe { MetalHandle::new(h) },
                         dst_ptr: buf.as_mut_ptr() as u64,
-                        dst_len: len as u64,
+                        dst_len: buf.len() as u64,
                         level: 0,
                         slice: 0,
                         width: t.width,
@@ -255,10 +259,13 @@ impl DeviceInner {
                     continue;
                 }
                 let full = format!("{label}{what}");
+                // The blit writes the image rows from the start of the backing; the
+                // page padding past them is not part of the texture.
+                let image = &buf.as_slice()[..len];
                 if bpp == 2 {
-                    frame_dump_log_readback_f16(&full, &buf);
+                    frame_dump_log_readback_f16(&full, image);
                 } else {
-                    frame_dump_log_readback(&full, t, &buf);
+                    frame_dump_log_readback(&full, t, image);
                 }
             }
         }


### PR DESCRIPTION
## Symptoms

No user-visible failure today. The Ctrl+Shift+D frame dump reads back every depth texture a draw sampled and every extra render target, and the destination it hands the unix side violates the contract that destination has to meet. Metal is free to reject the wrap, in which case the dump logs `[dump] readback <label>: blit failed 0x...` for every noted texture instead of the statistics line.

## Root cause

`DeviceInner::frame_dump_run_readbacks` allocated the destination as `vec![0u8; len]` and put that pointer and that unpadded length on the wire. `BlitTextureToBufferParams` documents `dst_ptr` as page-aligned and `dst_len` as a page multiple, because the unix side wraps the region in `newBufferWithBytesNoCopy:length:options:deallocator:`, which requires both. Every other caller of the blit passes a `PageBox`: a system-memory surface's own backing, or a system-memory texture level's staging, both sized through `PageBox`. The dump was the one caller relying on the allocator handing out a page-aligned block for a request that happens to be a large power-of-two multiple.

## Changes

`windows/d3d9/src/device/frame_dump.rs`: the readback destination is a `PageBox::new_zeroed(len)`, `dst_len` is the box's padded length rather than the image length, and the two log helpers are handed `&buf.as_slice()[..len]` so the statistics and the sampled pixels cover the image rows only, not the page padding behind them.

## Alternatives

Round the `Vec` up to a page multiple and align it by hand: reimplements `PageBox` at the call site and leaves the alignment half unsolved, since `Vec<u8>` has no alignment guarantee above 1.

Add a debug assertion in `blit_handle_to_systemmem` that the destination is page-backed: worth having, but it pins a contract for all callers rather than fixing this one, so it belongs in its own change.

Leave it as is because the dump is diagnostics-only: the failure mode is that the diagnostic goes silent exactly when it is being used to chase a rendering bug.

## Verification

`make check` clean (fmt, clippy nursery + pedantic on both PE targets and native, `audit: clean (236 files)`, doc).

`make test` green: 789 `mtld3d-core` unit tests, 125 `mtld3d-unix` unit tests, and the end-to-end suite at 289 tests per architecture, i686 and x86_64, 0 FAIL, 0 SIGABRT, 0 TIMEOUT, 2 and 3 benign leaky lines.

The frame dump is armed only by the Ctrl+Shift+D chord, so no test drives it and no assertion changes state across this fix. The invariant it now satisfies is `PageBox`'s own, pinned by `uninit_alloc_is_page_aligned_and_page_sized` and `length_rounds_up_to_page_multiple` in `windows/core/src/page_box/tests.rs`, and the sibling readback paths that already met it stay covered by the `GetRenderTargetData` and `GetFrontBufferData` cases in `windows/tests/tests/render_target.rs`.

Closes #152
