### PR TITLE
Let the rejected surface LockRect leave pBits untouched in the lock-split test

### DIFF
--- a/windows/tests/tests/textures.rs
+++ b/windows/tests/tests/textures.rs
@@ -414,7 +414,12 @@ fn default_pool_texture_lock_splits_by_entry_point() {
         hr, D3DERR_INVALIDCALL,
         "surface LockRect on a static DEFAULT level"
     );
-    assert!(bits_null, "the rejected surface lock hands out no pointer");
+    // A rejected lock leaves the struct untouched, so the garbage seed the
+    // probe plants is still there and reads as a non-null pointer.
+    assert!(
+        !bits_null,
+        "the rejected surface lock leaves pBits untouched"
+    );
     let (hr, bits_null) = tex.lock_rect_probe(0, 0);
     assert_eq!(hr, 0, "texture LockRect serves the same level");
     assert!(!bits_null, "the served lock hands out a pointer");


### PR DESCRIPTION
## Symptoms

`textures::default_pool_texture_lock_splits_by_entry_point` fails on `main` on both architectures: the rejected `IDirect3DSurface9::LockRect` on a static `D3DPOOL_DEFAULT` level returns `D3DERR_INVALIDCALL` as expected, but the test then asserts the probe read a null `pBits`.

## Root cause

`lock_rect_probe` seeds `D3DLOCKED_RECT.pBits` with a garbage pointer so that a rejection which leaves the struct untouched reads as "not null". The test was written against a helper that seeded null and was flipped to the current helper's polarity when it was rebased, which turned the rejected-lock assertion into its opposite.

## Changes

`windows/tests/tests/textures.rs`: the rejected-lock assertion now states what D3D9 does, the struct is left untouched (so the seed is still there), and says why. The served-lock and `D3DUSAGE_DYNAMIC` assertions are unchanged.

## Alternatives

Drop the pointer assertion on the rejected lock: it would pass, but it stops pinning that a rejection does not write the struct.

## Verification

`make test` in a private tree: the test passes once per architecture, no other change in per-test results.

Closes #275
