### PR TITLE
Drop an em dash from a shader test doc comment

### DIFF
--- a/windows/tests/tests/shaders.rs
+++ b/windows/tests/tests/shaders.rs
@@ -728,7 +728,7 @@ fn vertex_texture_fetch_reads_the_bound_slot() {
     assert_eq!(h.clear_texture(257), 0, "unbind slot");
 }
 
-/// `ps_2_0`: `def c0, 0, 0, 1, 1; mov oC0, c0;` — opaque blue with no buffer read.
+/// `ps_2_0`: `def c0, 0, 0, 1, 1; mov oC0, c0;`, opaque blue with no buffer read.
 ///
 /// A `def`-declared row is translated into a shader-local literal, so this
 /// program never reads the pixel constant buffer whatever the game uploads


### PR DESCRIPTION
## Symptoms

`windows/tests/tests/shaders.rs` gained a doc comment with an em dash in PR #290; the repository's prose rule forbids them.

## Root cause

The rule is not enforced by the audit for test files, so the line slipped through the gates.

## Changes

One doc comment in `windows/tests/tests/shaders.rs` uses a comma instead. No code change.

## Alternatives

Extend the audit to grep test files for em dashes: worth its own change if this keeps recurring.

## Verification

`grep -c '—' windows/tests/tests/shaders.rs` is 0; the file builds.
