### PR TITLE
Drop GetDC's shim page for a store tighter than its DIB

### DIFF
--- a/windows/d3d9/src/surface.rs
+++ b/windows/d3d9/src/surface.rs
@@ -241,7 +241,6 @@ impl Direct3DSurface9 {
             metal_msaa_srgb_handle,
             multi_sample,
             readback: None,
-            dc_shim: None,
             system_memory: None,
             flags: SurfaceFlags::empty(),
             private_data: PrivateDataStore::default(),
@@ -299,7 +298,6 @@ impl Direct3DSurface9 {
             metal_msaa_srgb_handle: MetalHandle::NULL,
             multi_sample,
             readback: None,
-            dc_shim: None,
             system_memory: None,
             flags: SurfaceFlags::empty(),
             private_data: PrivateDataStore::default(),
@@ -347,7 +345,6 @@ impl Direct3DSurface9 {
             metal_msaa_srgb_handle: MetalHandle::NULL,
             multi_sample: SurfaceMultiSample::NONE,
             readback: None,
-            dc_shim: None,
             system_memory: None,
             flags: SurfaceFlags::empty(),
             private_data: PrivateDataStore::default(),
@@ -394,7 +391,6 @@ impl Direct3DSurface9 {
             metal_msaa_srgb_handle: MetalHandle::NULL,
             multi_sample: SurfaceMultiSample::NONE,
             readback: None,
-            dc_shim: None,
             system_memory: None,
             flags: SurfaceFlags::empty(),
             private_data: PrivateDataStore::default(),
@@ -444,7 +440,6 @@ impl Direct3DSurface9 {
             metal_msaa_srgb_handle: MetalHandle::NULL,
             multi_sample: SurfaceMultiSample::NONE,
             readback: None,
-            dc_shim: None,
             system_memory: None,
             flags: SurfaceFlags::CONTAINER_CACHED,
             private_data: PrivateDataStore::default(),
@@ -498,7 +493,6 @@ impl Direct3DSurface9 {
             metal_msaa_srgb_handle: MetalHandle::NULL,
             multi_sample: SurfaceMultiSample::NONE,
             readback: None,
-            dc_shim: None,
             system_memory: None,
             flags: SurfaceFlags::CONTAINER_CACHED,
             private_data: PrivateDataStore::default(),
@@ -546,7 +540,6 @@ impl Direct3DSurface9 {
             metal_msaa_srgb_handle: MetalHandle::NULL,
             multi_sample: SurfaceMultiSample::NONE,
             readback: None,
-            dc_shim: None,
             system_memory: None,
             flags: SurfaceFlags::OWNS_PARENT_TEXTURE,
             private_data: PrivateDataStore::default(),
@@ -596,7 +589,6 @@ impl Direct3DSurface9 {
             metal_msaa_srgb_handle: MetalHandle::NULL,
             multi_sample: SurfaceMultiSample::NONE,
             readback: None,
-            dc_shim: None,
             system_memory: Some(backing),
             flags: SurfaceFlags::empty(),
             private_data: PrivateDataStore::default(),
@@ -1148,16 +1140,6 @@ struct SurfaceInner {
     /// `UnlockRect`. Persists across the Lock so the game can read the returned
     /// pointer.
     readback: Option<PageBox>,
-    /// Page-aligned DIB the held `GetDC` draws into when the store is too tight.
-    ///
-    /// GDI steps a DIB by the row length rounded up to a dword and rejects a
-    /// pitch below it, so a store whose rows are tighter than that cannot be
-    /// handed to GDI as it stands. `GetDC` then seeds this page with the
-    /// store's rows at the DIB stride and wraps it instead; `ReleaseDC` copies
-    /// the rows back and drops it. `None` whenever the store's own pitch
-    /// already carries the DIB stride, which every store a surface resolves
-    /// through `linear_row_pitch` does.
-    dc_shim: Option<PageBox>,
     /// Backing store for a `D3DPOOL_SYSTEMMEM` offscreen plain surface.
     ///
     /// From `CreateOffscreenPlainSurface`. Allocated full-size at creation;
@@ -3019,71 +3001,6 @@ fn dc_dib_pitch(px: &SurfacePixels) -> Option<u32> {
     ))
 }
 
-/// Seed a page at the DIB stride from a pixel store on a tighter one.
-///
-/// `height` rows `dib_pitch` bytes apart, each carrying that row's
-/// `src_pitch` bytes from the store. Zero-filled, so the padding past the end
-/// of a row reads as black instead of as whatever the allocator left there.
-/// `None` for an empty geometry or a byte size that overflows.
-fn dc_shim_page(px: &SurfacePixels, dib_pitch: usize) -> Option<PageBox> {
-    let rows = px.height as usize;
-    let len = dib_pitch.checked_mul(rows)?;
-    if len == 0 || px.src_pitch == 0 {
-        return None;
-    }
-    let mut page = PageBox::new_zeroed(len);
-    for row in 0..rows {
-        // SAFETY: `bits` is a live store of `height` rows of `src_pitch` bytes
-        // (the caller checked it non-null), so row `row` starts in bounds.
-        let src_ptr = unsafe { px.bits.add(row * px.src_pitch) };
-        // SAFETY: `page` holds `rows * dib_pitch` bytes, so row `row` starts in
-        // bounds and `src_pitch <= dib_pitch` bytes of it are addressable.
-        let dst_ptr = unsafe { page.as_mut_ptr().add(row * dib_pitch) };
-        // SAFETY: both rows are in bounds (above), and the store and the page
-        // are distinct allocations, so the ranges cannot overlap.
-        unsafe { core::ptr::copy_nonoverlapping(src_ptr, dst_ptr, px.src_pitch) };
-    }
-    Some(page)
-}
-
-/// Copy a shim page's rows back into the store its DC stood in for.
-///
-/// The reverse of [`dc_shim_page`], `src_pitch` bytes per row, leaving the
-/// DIB's row padding behind. A surface that can no longer resolve the store or
-/// its DIB stride keeps the pixels it has: the drawing is lost either way, and
-/// a partial copy would be worse.
-fn dc_shim_write_back(inner: &SurfaceInner, page: &PageBox) {
-    let resolved = inner
-        .dc_pixels()
-        .and_then(|px| dc_dib_pitch(&px).map(|pitch| (px, pitch as usize)));
-    let Some((px, dib_pitch)) = resolved else {
-        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
-            "IDirect3DSurface9::ReleaseDC: no pixel store left to copy the DIB back into");
-        return;
-    };
-    let rows = px.height as usize;
-    if px.bits.is_null()
-        || px.src_pitch > dib_pitch
-        || page.logical_len() < dib_pitch.saturating_mul(rows)
-    {
-        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
-            "IDirect3DSurface9::ReleaseDC: the DIB no longer covers the surface store, drawing dropped");
-        return;
-    }
-    for row in 0..rows {
-        // SAFETY: `page` holds `rows * dib_pitch` bytes (checked above), so row
-        // `row` starts in bounds and `src_pitch <= dib_pitch` bytes of it are
-        // addressable.
-        let src_ptr = unsafe { page.as_ptr().add(row * dib_pitch) };
-        // SAFETY: `bits` is a live store of `rows` rows of `src_pitch` bytes,
-        // so row `row` starts in bounds.
-        let dst_ptr = unsafe { px.bits.add(row * px.src_pitch) };
-        // SAFETY: both rows are in bounds (above), and the page and the store
-        // are distinct allocations, so the ranges cannot overlap.
-        unsafe { core::ptr::copy_nonoverlapping(src_ptr, dst_ptr, px.src_pitch) };
-    }
-}
-
 impl SurfaceInner {
     /// True for the implicit backbuffer surface only when it is lockable.
     ///
@@ -3336,25 +3253,17 @@ extern "system" fn surface_get_dc(this: *mut c_void, hdc: *mut *mut c_void) -> i
     if px.bits.is_null() {
         return D3DERR_INVALIDCALL;
     }
-    // GDI rejects a pitch below the DIB stride outright, so a store on a
-    // tighter one gets a page of its own at the DIB stride, seeded from its
-    // rows, and `ReleaseDC` copies whatever GDI drew back into it. A store
-    // already carrying the DIB stride is aliased directly, no copy either way.
-    let mut shim = None;
-    let (bits, pitch) = if px.src_pitch < dib_pitch as usize {
-        let Some(mut page) = dc_shim_page(&px, dib_pitch as usize) else {
-            mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
-                "IDirect3DSurface9::GetDC: no page for the DIB the store is too tight for → INVALIDCALL");
-            return D3DERR_INVALIDCALL;
-        };
-        let bits = page.as_mut_ptr();
-        shim = Some(page);
-        (bits, dib_pitch)
-    } else {
-        let Ok(pitch) = u32::try_from(px.src_pitch) else {
-            return D3DERR_INVALIDCALL;
-        };
-        (px.bits, pitch)
+    // Every store a surface resolves is sized and strided by
+    // `linear_row_pitch`, the rounding GDI derives the DIB stride from, so the
+    // store's own pitch is the DIB's and the DIB aliases it directly. GDI
+    // rejects a pitch below the DIB stride outright, so a store that ever came
+    // in tighter would have to be copied through a page of its own.
+    debug_assert!(
+        px.src_pitch >= dib_pitch as usize,
+        "a device context resolved a pixel store tighter than its DIB stride"
+    );
+    let Ok(pitch) = u32::try_from(px.src_pitch) else {
+        return D3DERR_INVALIDCALL;
     };
 
     // Wrap the pixel store resolved above in a memory DC + DIB via
@@ -3367,7 +3276,7 @@ extern "system" fn surface_get_dc(this: *mut c_void, hdc: *mut *mut c_void) -> i
     // `D3DKMTCreateDCFromMemory` reports the real failure via its status).
     let device_dc = unsafe { CreateCompatibleDC(core::ptr::null_mut()) };
     let mut desc = D3DKMT_CREATEDCFROMMEMORY {
-        p_memory: bits.cast::<c_void>(),
+        p_memory: px.bits.cast::<c_void>(),
         format: px.d3d_format,
         width: px.width,
         height: px.height,
@@ -3390,10 +3299,6 @@ extern "system" fn surface_get_dc(this: *mut c_void, hdc: *mut *mut c_void) -> i
         return D3DERR_INVALIDCALL;
     }
 
-    // The DIB the call wrapped is the shim page, so it has to outlive the DC:
-    // park it on the surface, where `ReleaseDC` finds it. A rejected call above
-    // dropped it on the way out, leaving the surface's slot empty.
-    inner.dc_shim = shim;
     // The DC now maps the level, so nothing may release the staging under it
     // until `ReleaseDC` drops the pin.
     pin_dc_texture_level(inner, true);
@@ -3467,11 +3372,6 @@ extern "system" fn surface_release_dc(this: *mut c_void, hdc: *mut c_void) -> i3
         }
     }
     teardown_gdi_dc(held);
-    // A store too tight for a DIB was drawn into through a shim page, so what
-    // GDI drew lives there alone: copy the rows back before the page goes.
-    if let Some(page) = inner.dc_shim.take() {
-        dc_shim_write_back(inner, &page);
-    }
     // The DC's DIB aliased a lockable render target's CPU staging, so whatever
     // GDI drew is in the staging alone: push it to the colour texture the way
     // `UnlockRect` does, or the next read-back overwrites it with the pixels


### PR DESCRIPTION
## Symptoms

No user-visible symptom. `windows/d3d9/src/surface.rs` carries a shim page for `GetDC` over a pixel store whose row pitch is below the DIB stride GDI derives: `dc_shim_page`, `dc_shim_write_back`, the `dc_shim` field on `SurfaceInner`, and the `if px.src_pitch < dib_pitch` branch in `surface_get_dc`. Nothing can take that branch, so the code is unreachable and the copies it describes never run.

## Root cause

Every store `dc_pixels` resolves is strided by `linear_row_pitch`, which is the same `width * bytes per pixel` rounded up to a dword that GDI computes for a DIB of that width and bit count. A texture level (and a cube face) takes its `mip_bytes_per_row` from `compute_mip_size`, which strides an uncompressed level by `linear_row_pitch`; a `D3DPOOL_SYSTEMMEM` / `D3DPOOL_SCRATCH` offscreen plain and a lockable render target size their backing at `linear_row_pitch(width, bpp) * height`; the back buffer's `GetDC` snapshot page is allocated and read back at `linear_row_pitch(width, bpp)`. The DIB stride is `linear_row_pitch(px.width, bit_count / 8)` over the same width, and for every format that is both GDI-representable (`dc_format_info`) and creatable (`lookup_d3d_format`), namely A8R8G8B8, X8R8G8B8, R5G6B5 and A1R5G5B5, `bytes_per_pixel * 8 == bit_count`. The two remaining `dc_format_info` arms, R8G8B8 and X1R5G5B5, have no format mapping at all, so no surface of either can exist and `dc_pixels` rejects them before the stride is ever compared. Compressed formats have no GDI mapping and are rejected by `dc_dib_pitch`. The depth-texture create path is the one place that fills `mip_bytes_per_row` without the dword rounding, and it keeps no staging, so `lock_box` returns `None` and the call ends in `INVALIDCALL`.

## Changes

`windows/d3d9/src/surface.rs`: remove `dc_shim_page` and `dc_shim_write_back`, the `dc_shim` field and its eight initialisers, the shim branch in `surface_get_dc`, and the write-back in `surface_release_dc`. `GetDC` now wraps `px.bits` at `px.src_pitch` directly. The `INVALIDCALL` paths for a surface with no host pixel store, a format with no GDI mapping, and a null store are unchanged, and a `debug_assert!` stands where the branch was so a store that ever comes in tighter than its DIB aborts a debug build rather than being silently mis-strided. A release build hands GDI the tight pitch, which `D3DKMTCreateDCFromMemory` rejects, so the call still fails rather than reading past the end of a row.

## Alternatives

Keep the shim as defence in depth: rejected, dead code that no test can reach is not defence, and the assert states the invariant where a reader needs it.

Replace the branch with `log_once_warn!` plus `INVALIDCALL` instead of an assert: rejected, that is a runtime cost on every `GetDC` for a condition the type of the stores rules out, and it would turn a bug into a quiet rejection instead of a loud one.

## Verification

`make check` clean (fmt, clippy on both PE targets and native, audit over 256 files, doc).

`make test`: 1889 PASS, 6 LEAK, 0 FAIL / SIGABRT / TIMEOUT. The e2e suite ran 398 tests per architecture, i686 and x86_64, all passing with 3 leaky each; the unit suites ran 948 and 151 tests, all passing. Every `GetDC` test appears once per architecture, including `get_dc_on_an_odd_width_16_bit_texture_level_round_trips_a_texel`, `get_dc_on_an_odd_width_16_bit_lockable_render_target_reaches_the_last_row`, `get_dc_on_a_default_offscreen_plain_round_trips_through_gdi`, `get_dc_on_a_lockable_render_target_round_trips_through_the_gpu` and the back-buffer `GetDC` cases in `implicit_surface`. Those tests build with debug assertions on, so they exercise the new assert across all four store classes and would abort if any of them resolved a store below its DIB stride.

No new test: the change removes an unreachable path and adds no behaviour, and the tests above already pin what stays. No conformance run: the change touches no render, state or shader-emission path.

Closes #287
