### PR TITLE
Walk subroutine bodies in uses_dynamic_int_constants

### DIFF
--- a/windows/core/src/dxso/emit/tests.rs
+++ b/windows/core/src/dxso/emit/tests.rs
@@ -2194,6 +2194,104 @@ fn defi_int_constant_stays_a_baked_local_without_vs_i() {
 }
 
 #[test]
+fn dynamic_int_constant_inside_a_subroutine_declares_vs_i() {
+    // vs_3_0 {
+    //   dcl_position v0;
+    //   dcl_position oT0;
+    //   call l0;
+    //   ret;
+    //   label l0;
+    //     rep i0;
+    //       mov oT0, v0;
+    //     endrep;
+    //   ret;
+    // }
+    // The only iN read sits in the subroutine body, which `call`
+    // inline-expands into the entry point, so the emitted body references
+    // vs_i and the signature has to declare it.
+    let bc = vec![
+        VS3_HEADER,
+        opcode_token(OP_DCL, 2),
+        dcl_usage_token(DCL_POSITION, 0),
+        dst_token(TYPE_INPUT, 0, 0xF, false),
+        opcode_token(OP_DCL, 2),
+        dcl_usage_token(DCL_POSITION, 0),
+        dst_token(TYPE_TEXCOORDOUT, 0, 0xF, false),
+        opcode_token(OP_CALL, 1),
+        src_token(TYPE_LABEL, 0, SWIZ_IDENTITY, 0),
+        opcode_token(OP_RET, 0),
+        opcode_token(OP_LABEL, 1),
+        src_token(TYPE_LABEL, 0, SWIZ_IDENTITY, 0),
+        opcode_token(OP_REP, 1),
+        src_token(TYPE_CONSTINT, 0, SWIZ_IDENTITY, 0),
+        opcode_token(OP_MOV, 2),
+        dst_token(TYPE_TEXCOORDOUT, 0, 0xF, false),
+        src_token(TYPE_INPUT, 0, SWIZ_IDENTITY, 0),
+        opcode_token(OP_ENDREP, 0),
+        opcode_token(OP_RET, 0),
+        END_TOKEN,
+    ];
+    let vs = parse(&bc).expect("VS3 parse");
+    assert!(
+        vs.uses_dynamic_int_constants(),
+        "an iN read reachable only through a call is still a dynamic integer constant"
+    );
+    let vs_msl = emit_vs_programmable(&vs).expect("emit VS3");
+    assert!(
+        vs_msl.contains(&format!(
+            "constant int4 *vs_i [[buffer({VS_INT_CONST_SLOT})]]"
+        )),
+        "the inlined `rep i0` must declare the vs_i buffer:\n{vs_msl}"
+    );
+    assert!(
+        vs_msl.contains("vs_i[0]"),
+        "the inlined `rep i0` counter must read vs_i[0]:\n{vs_msl}"
+    );
+    // The substring assertions above cannot see an undeclared argument;
+    // Metal refuses the source outright when the body names vs_i and the
+    // signature does not.
+    metal_compile_or_fail(&vs_msl);
+}
+
+#[test]
+fn dynamic_int_constant_inside_a_subroutine_declares_ps_i() {
+    // ps_3_0 { call l0; ret; label l0; rep i0; mov oC0, c0; endrep; ret; }
+    let bc = vec![
+        PS3_HEADER,
+        opcode_token(OP_CALL, 1),
+        src_token(TYPE_LABEL, 0, SWIZ_IDENTITY, 0),
+        opcode_token(OP_RET, 0),
+        opcode_token(OP_LABEL, 1),
+        src_token(TYPE_LABEL, 0, SWIZ_IDENTITY, 0),
+        opcode_token(OP_REP, 1),
+        src_token(TYPE_CONSTINT, 0, SWIZ_IDENTITY, 0),
+        opcode_token(OP_MOV, 2),
+        dst_token(TYPE_COLOROUT, 0, 0xF, false),
+        src_token(TYPE_CONST, 0, SWIZ_IDENTITY, 0),
+        opcode_token(OP_ENDREP, 0),
+        opcode_token(OP_RET, 0),
+        END_TOKEN,
+    ];
+    let ps = parse(&bc).expect("PS3 parse");
+    assert!(
+        ps.uses_dynamic_int_constants(),
+        "an iN read reachable only through a call is still a dynamic integer constant"
+    );
+    let ps_msl = emit_ps_programmable(&ps, VariantKey::default()).expect("emit PS3");
+    assert!(
+        ps_msl.contains(&format!(
+            "constant int4 *ps_i [[buffer({PS_INT_CONST_SLOT})]]"
+        )),
+        "the inlined `rep i0` must declare the ps_i file:\n{ps_msl}"
+    );
+    assert!(
+        ps_msl.contains("ps_i[0]"),
+        "the inlined `rep i0` counter must read ps_i[0]:\n{ps_msl}"
+    );
+    metal_compile_or_fail(&ps_msl);
+}
+
+#[test]
 fn rep_emits_for_loop_without_al() {
     // vs_3_0 { defi i0, 8, 0, 0, 0; rep i0; mov r0, r1; endrep; ... }
     let bc = vec![

--- a/windows/core/src/dxso/ir.rs
+++ b/windows/core/src/dxso/ir.rs
@@ -449,16 +449,22 @@ impl DxsoProgram {
     /// `defi` constants are baked into the MSL as locals, but a dynamic `iN`
     /// (typically a `loop aL, iN` / `rep iN` counter) needs the runtime
     /// integer-constant buffer uploaded and bound; draws that bind such a
-    /// shader gate that bind on this flag.
+    /// shader gate that bind on this flag, and the emitter gates the
+    /// declaration of the `vs_i` / `ps_i` argument on it. Subroutine bodies
+    /// count: a `call` inline-expands them into the entry point, so a `rep
+    /// iN` reached only through a `call` still reads the argument.
     #[must_use]
     pub fn uses_dynamic_int_constants(&self) -> bool {
         let defined: std::collections::BTreeSet<u16> =
             self.def_int_constants.iter().map(|d| d.reg.index).collect();
-        self.instructions.iter().any(|inst| {
-            inst.srcs
-                .iter()
-                .any(|s| s.reg.kind == RegKind::ConstInt && !defined.contains(&s.reg.index))
-        })
+        self.instructions
+            .iter()
+            .chain(self.subroutines.values().flatten())
+            .any(|inst| {
+                inst.srcs
+                    .iter()
+                    .any(|s| s.reg.kind == RegKind::ConstInt && !defined.contains(&s.reg.index))
+            })
     }
 
     /// Whether any instruction reads a boolean constant no `defb` defines.


### PR DESCRIPTION
## Symptoms

A shader whose only `rep iN` / `loop aL, iN` sits inside a subroutine reached through `call` emits MSL that names the integer-constant argument without declaring it, and Metal rejects the source at pipeline creation: `MSL failed Metal compilation: program_source:58:43: error: use of undeclared identifier 'vs_i'; did you mean 'vs_c'?`. The draw then has no pipeline at all, rather than a wrong bind.

## Root cause

`uses_dynamic_int_constants` in `windows/core/src/dxso/ir.rs` walked only `self.instructions`, unlike its boolean twin `uses_dynamic_bool_constants` and unlike `max_const_reg` / `max_const_index`, which all chain `self.subroutines.values().flatten()`. Both emitters gate the `vs_i` / `ps_i` argument on the predicate, while `call` / `callnz` inline-expand the labelled body into the entry point, so an `iN` read that lives only in a subroutine reaches the emitted body but not the signature.

## Changes

`uses_dynamic_int_constants` chains the subroutine bodies, so an `iN` with no `defi` counts wherever it is read. The doc comment records that the emitter argument declaration rides on the predicate and why subroutine bodies count.

The shader cache schema version is not bumped. The change alters emitted MSL only for shaders that previously failed to compile, and `resolve_vs_library` / `resolve_ps_library` write a cache record only after `compile_stage_library` returns handles, so an affected shader was never persisted: there is no on-disk entry the new MSL could contradict, and every other shader's MSL is byte-identical. Bumping would discard every user's warm cache for no correctness gain.

## Alternatives

Declare `vs_i` / `ps_i` unconditionally: rejected, it re-binds a buffer slot for every shader and undoes the constant-bind gating.

Hoist the subroutine walk into a shared helper used by all four predicates: rejected as a refactor wider than the bug, and the walks differ in what they inspect.

## Verification

`make check` clean (audit 256 files). `make test`: 950 core unit tests pass, 151 unix tests pass, and the e2e suite runs 400 tests per architecture with 400 passing on i686 (2 leaky) and 400 passing on x86_64 (3 leaky), no FAIL, SIGABRT or TIMEOUT. `make conformance` reports no regressions on either architecture; the only movement is `device.c:4475`, `device.c:4480` (both known flaky) and `device.c:15088` (below its ceiling pin) counting down, so the baseline is not re-recorded.

Two unit tests in `windows/core/src/dxso/emit/tests.rs` cover the fix: `dynamic_int_constant_inside_a_subroutine_declares_vs_i` and `dynamic_int_constant_inside_a_subroutine_declares_ps_i` build a `vs_3_0` / `ps_3_0` whose `rep i0` is inside a subroutine, assert the predicate fires, assert the emitted MSL declares and reads the argument, and finish with `metal_compile_or_fail` so an undeclared argument fails even if the substring assertions were to pass. Both fail before the change (the predicate assertion trips; with that assertion removed the Metal compile fails with the undeclared-identifier error above) and pass after.

Closes #293
