### PR TITLE
Document create_depth_texture_path's actual levels handling

### DIFF
--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -4263,8 +4263,8 @@ fn create_texture_path(info: &TextureCreateArgs) -> i32 {
     // binds its surface as the depth target during the shadow pass, and
     // samples it as a regular texture during the lit pass. Mapping table
     // `map_d3d_format` is color-only — depth formats route through
-    // `map_d3d_depth_format` and a constrained create path (no staging,
-    // no mip chain, fixed levels=1).
+    // `map_d3d_depth_format` and a create path of their own: no CPU staging,
+    // and a mip chain, when one is asked for, that only the GPU can fill.
     if mtld3d_core::format::is_depth_format(format) {
         return create_depth_texture_path(&DepthTextureCreateInfo {
             this,
@@ -4494,25 +4494,37 @@ struct DepthTextureCreateInfo {
 
 /// Sub-path of `device_create_texture` for depth-format textures (sampleable shadow maps).
 ///
-/// D3D9 spec accepts `CreateTexture(format=Dxx, usage=D3DUSAGE_DEPTHSTENCIL)`
-/// — the resulting texture is bindable as a depth attachment via
-/// `IDirect3DTexture9::GetSurfaceLevel` + `SetDepthStencilSurface`, AND
-/// sampleable in shaders. Without it, games that bump shadow quality
-/// silently fail to allocate shadow maps and the lit pass samples stale
-/// texture-slot contents (visible flicker).
+/// D3D9 accepts `CreateTexture(format=Dxx, usage=D3DUSAGE_DEPTHSTENCIL)`: the
+/// resulting texture is bindable as a depth attachment through
+/// `IDirect3DTexture9::GetSurfaceLevel` + `SetDepthStencilSurface` and
+/// sampleable in shaders. Without it, games that bump shadow quality silently
+/// fail to allocate shadow maps and the lit pass samples stale texture-slot
+/// contents (visible flicker). The colour mapping table `map_d3d_format`
+/// carries no depth entries, so a depth format routes through
+/// `map_d3d_depth_format` and this path instead.
 ///
-/// Constraints (`ConvertD3D9DepthFormat` path):
-/// - `usage` must include `D3DUSAGE_DEPTHSTENCIL`. Color-only depth
-///   textures aren't a thing.
-/// - `pool` must be `D3DPOOL_DEFAULT` — depth textures live on the GPU
+/// Rejected with `D3DERR_INVALIDCALL`:
+/// - `usage` without `D3DUSAGE_DEPTHSTENCIL`. A depth format is creatable
+///   only as a depth attachment.
+/// - `pool` other than `D3DPOOL_DEFAULT`. Depth textures live on the GPU
 ///   only.
-/// - `levels` must be 1. Shadow maps don't carry mip chains; Metal's
-///   `generateMipmaps` rejects depth formats anyway.
-/// - No DYNAMIC / RENDERTARGET / AUTOGENMIPMAP — incompatible with
-///   depth attachments.
+/// - `D3DUSAGE_DYNAMIC`, `D3DUSAGE_RENDERTARGET`, `D3DUSAGE_AUTOGENMIPMAP`.
+///   None of the three fits a depth attachment: there is no CPU upload path,
+///   the colour and depth usages are exclusive, and Metal's `generateMipmaps`
+///   refuses depth formats.
+/// - A format with no `map_d3d_depth_format` entry.
 ///
-/// The created texture has no PE-side staging buffer (`LockRect` is
-/// rejected at the texture level — see `texture::texture_lock_rect`).
+/// `levels` follows the colour path's rule: 0 requests the full chain down to
+/// one texel (`compute_mip_count`), and any other value is the level count,
+/// taken as given. A mip chain on a depth texture is an engine's depth
+/// pyramid, every level rendered into through `GetSurfaceLevel(n)` bound as
+/// the depth attachment, because with `generateMipmaps` unavailable nothing
+/// else can fill one.
+///
+/// The created texture has no PE-side staging buffer, so its per-level
+/// tracking arrays are sized from the level count rather than from the
+/// staging vector, and `LockRect` is rejected at the texture level (see
+/// `texture::texture_lock_rect`).
 fn create_depth_texture_path(info: &DepthTextureCreateInfo) -> i32 {
     let DepthTextureCreateInfo {
         this,


### PR DESCRIPTION
## Symptoms

The doc block on `create_depth_texture_path` in `windows/d3d9/src/device.rs` lists as a constraint that "`levels` must be 1. Shadow maps don't carry mip chains; Metal's `generateMipmaps` rejects depth formats anyway." The body does the opposite: it expands `levels == 0` to `compute_mip_count(width, height)`, takes any other value as the level count, and sizes `mip_widths`, `mip_heights` and `mip_bytes_per_row` from the result so `GetLevelDesc` reports every level and the texture-memory charge covers the whole chain. The one-line summary at the call site repeats the same claim, calling the depth path "a constrained create path (no staging, no mip chain, fixed levels=1)". A reader looking for how a depth pyramid is allocated is told the path refuses to allocate one.

The block also cited a `ConvertD3D9DepthFormat` path that exists nowhere in the tree.

## Root cause

Documentation drift. The path was documented for the single-level shadow map, then grew mip-chain handling without the block being revisited. No behaviour is affected.

## Changes

`windows/d3d9/src/device.rs`: rewrite the doc block on `create_depth_texture_path` to state what it does today. It now names the four `D3DERR_INVALIDCALL` rejects the body applies (no `D3DUSAGE_DEPTHSTENCIL`, a pool other than `D3DPOOL_DEFAULT`, any of `D3DUSAGE_DYNAMIC` / `D3DUSAGE_RENDERTARGET` / `D3DUSAGE_AUTOGENMIPMAP`, and a format with no `map_d3d_depth_format` entry), the `levels` rule it shares with the colour path (0 requests the full chain, any other value is the level count taken as given), why a depth chain has to be filled by the caller through `GetSurfaceLevel(n)` rather than by `generateMipmaps`, and that the absent staging buffer is what makes the per-level arrays size from the level count and `LockRect` an INVALIDCALL. The dangling `ConvertD3D9DepthFormat` reference is dropped.

The comment at the call site is corrected in the same change: it is a summary of this same function and carried the same `fixed levels=1` claim.

## Alternatives

Fix only the `levels` bullet and leave the rest: rejected, the surrounding bullets were shaped as constraints of a single-level path and read as a contradiction once the levels bullet says otherwise.

Leave the call-site comment for a separate change: rejected, it is the same false statement about the same function, and closing the issue while it stands leaves the reader with the claim the issue is about.

## Verification

Documentation only, no behaviour change, so no test moves. `make check` passes: fmt-check, clippy (nursery + pedantic, warnings denied) on both PE targets and native, `audit: clean (256 files)`, and the doc leg, which is what would catch a broken intra-doc link in the new block.

Closes #299
