### PR TITLE
Fail a conformance leg on any Metal validation error it logs

### DIFF
--- a/unix/conformance/CONFORMANCE.md
+++ b/unix/conformance/CONFORMANCE.md
@@ -52,7 +52,11 @@ performance hint, not misuse (a resource bound to an encoder no draw went on to
 read, a state setter overwritten before the next draw), and a leg emits
 thousands of them, so leaving them on buried the error lines in output that
 looked identical. A `metal-validation:` line therefore means the layer
-committed API misuse, and a new one is a regression to chase.
+committed API misuse, so any of them fails the leg. The expected number is
+zero, kept as a constant in the runner next to the reporting code rather than
+in `baseline.txt`, which records machine-owned per-site counts and nothing
+else. There is no tolerance to keep in step: a leg that logs a line has started
+misusing Metal, and the fix is the misuse, not the number.
 
 This is **not** part of `make test`: many checks fail by design (see below), so
 it is a tracked-score tool, not a pass/fail gate on zero. The runner exits
@@ -64,6 +68,11 @@ baseline.txt overstate reality, and the surplus becomes a budget a later
 regression can hide in. The fix for a stale baseline is `make
 conformance-baseline` plus the matching triage edit here, not a code hunt. The
 `flaky` and `ceiling` classes are the two tolerances (see below).
+
+Metal validation is the third verdict, and it is independent of the counts: a
+leg that logged any `metal-validation:` line exits non-zero even when every
+site holds its pin, because API misuse is invisible to a pass/fail count. A
+`--update-baseline` or `--repeat` run never gates, so neither one applies it.
 
 ## What the baseline records — and where classes live
 

--- a/unix/conformance/src/isolate.rs
+++ b/unix/conformance/src/isolate.rs
@@ -99,7 +99,7 @@ fn characterize(
     for i in 1..=repeat {
         // Liveness to stderr — a full subtest can take many seconds.
         eprintln!("  [{arch}/{subtest}] run {i}/{repeat}…");
-        let result = run::run_subtest(wine, exe, arch, subtest)?;
+        let result = run::run_subtest(wine, exe, arch, subtest)?.result;
         agg.runs += 1;
         if result.crash {
             agg.crash_runs += 1;

--- a/unix/conformance/src/main.rs
+++ b/unix/conformance/src/main.rs
@@ -67,9 +67,11 @@ fn real_main() -> Result<ExitCode, String> {
     }
 
     let mut current: BTreeMap<(Arch, Subtest), SubtestResult> = BTreeMap::new();
+    let mut validation_errors = 0;
     for &subtest in &subtests {
-        let result = run::run_subtest(&config.wine, &config.exe, config.arch, subtest)?;
-        current.insert((config.arch, subtest), result);
+        let run = run::run_subtest(&config.wine, &config.exe, config.arch, subtest)?;
+        validation_errors += run.validation_errors;
+        current.insert((config.arch, subtest), run.result);
     }
 
     // Assets (baseline.txt) live in the crate directory by default; --assets
@@ -129,17 +131,37 @@ fn real_main() -> Result<ExitCode, String> {
     let classes = triage::load(&assets)?;
     let report = diff::diff(&baseline, &classes, &current);
     print!("{}", report.text);
+    Ok(verdict(&report, validation_errors))
+}
+
+/// Turn a run's diff report and its Metal-validation error count into an exit code.
+///
+/// Three independent verdicts, each fatal on its own: a regression vs the
+/// baseline, a baseline that overstates reality, and any Metal API-validation
+/// error line the leg logged. The validation gate is orthogonal to the per-site
+/// counts: a leg that starts misusing Metal while every count holds still has
+/// to fail.
+fn verdict(report: &diff::Report, validation_errors: usize) -> ExitCode {
+    let validation_failed = run::validation_gate_failed(validation_errors);
+    if validation_failed {
+        println!(
+            "conformance: METAL VALIDATION - {validation_errors} error line(s) logged; every \
+             metal-validation: line above is API misuse to fix"
+        );
+    }
     if report.regressed {
         println!("conformance: REGRESSIONS detected");
-        Ok(ExitCode::from(1))
     } else if report.stale {
         println!(
             "conformance: STALE BASELINE - some sites read below their pins; run `make conformance-baseline` and re-triage"
         );
-        Ok(ExitCode::from(1))
-    } else {
+    } else if !validation_failed {
         println!("conformance: no regressions vs baseline");
-        Ok(ExitCode::SUCCESS)
+    }
+    if validation_failed || report.regressed || report.stale {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
     }
 }
 

--- a/unix/conformance/src/run.rs
+++ b/unix/conformance/src/run.rs
@@ -6,6 +6,7 @@
 //! runner owns where a Wine install keeps its loader and its test binaries.
 
 use std::{
+    collections::BTreeSet,
     fs,
     io::Read,
     os::unix::process::ExitStatusExt,
@@ -29,6 +30,32 @@ use crate::{
 /// finish in seconds.
 const DEFAULT_TIMEOUT_SECS: u64 = 180;
 const HEADLESS_DLL_OVERRIDES: &str = "mscoree,mshtml=";
+
+/// How many Metal API-validation error lines a leg may log and still pass.
+///
+/// Zero. The layer's warnings are filtered out (see [`run_subtest`]), so every
+/// line that survives is real API misuse and has to read as a regression
+/// rather than as noise. The expectation lives beside the reporting code
+/// because `baseline.txt` is machine-owned per-site counts whose parser
+/// rejects anything else.
+const MAX_VALIDATION_ERRORS: usize = 0;
+
+/// One subtest's outcome.
+///
+/// The parsed per-site result, plus how many distinct Metal API-validation
+/// error lines the run logged for the caller to gate on.
+pub struct SubtestRun {
+    /// Failing sites, the crash bit and the marked-failure tallies.
+    pub result: SubtestResult,
+    /// Distinct Metal API-validation error messages the subtest logged.
+    pub validation_errors: usize,
+}
+
+/// Whether the Metal-validation error lines a run logged fail its leg.
+#[must_use]
+pub const fn validation_gate_failed(errors: usize) -> bool {
+    errors > MAX_VALIDATION_ERRORS
+}
 
 fn subtest_timeout() -> Duration {
     let secs = std::env::var("MTLD3D_CONFORMANCE_TIMEOUT_SECS")
@@ -70,7 +97,7 @@ pub fn run_subtest(
     exe: &Path,
     arch: Arch,
     subtest: Subtest,
-) -> Result<SubtestResult, String> {
+) -> Result<SubtestRun, String> {
     if !exe.is_file() {
         return Err(format!(
             "test exe not found: {}; a Wine SDK bundle carries these under \
@@ -167,9 +194,10 @@ pub fn run_subtest(
 
     // Surface Metal API-validation failures (the layer runs in `nslog` mode, so
     // these are logged rather than aborting). Deduplicated, address/number
-    // normalised, prefixed with the subtest — a standing watch for Metal misuse
-    // that the per-site pass/fail counts don't capture.
-    report_validation_errors(arch, subtest, &String::from_utf8_lossy(&stderr));
+    // normalised, prefixed with the subtest. The count is what gates the leg:
+    // the per-site pass/fail counts never capture Metal misuse.
+    let validation_errors =
+        report_validation_errors(arch, subtest, &String::from_utf8_lossy(&stderr));
 
     // A timeout is a hang — treat it like a fatal signal so it surfaces as a
     // crash (and a regression vs a clean baseline) rather than a silent count.
@@ -193,7 +221,10 @@ pub fn run_subtest(
     // set; a write failure is reported but never fails the run.
     save_raw_output(arch, subtest, &combined);
 
-    Ok(scan::parse_subtest_output(&combined, signaled))
+    Ok(SubtestRun {
+        result: scan::parse_subtest_output(&combined, signaled),
+        validation_errors,
+    })
 }
 
 /// Persist a subtest's raw output to `$MTLD3D_CONFORMANCE_RAW_DIR/<arch>-<subtest>.log`.
@@ -223,10 +254,23 @@ fn save_raw_output(arch: Arch, subtest: Subtest, combined: &str) {
 /// Print a deduplicated, number-normalised summary of any Metal API-validation messages.
 ///
 /// The subtest logged them rather than aborting — the layer runs in `nslog`
-/// mode. Volatile addresses and counts collapse to `N` so a repeated error
-/// reports once.
-fn report_validation_errors(arch: Arch, subtest: Subtest, stderr: &str) {
-    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+/// mode. Returns how many distinct messages were printed, which is what the
+/// leg gates on.
+fn report_validation_errors(arch: Arch, subtest: Subtest, stderr: &str) -> usize {
+    let seen = validation_errors(stderr);
+    for msg in &seen {
+        eprintln!("  [{arch}/{subtest}] metal-validation: {msg}");
+    }
+    seen.len()
+}
+
+/// The distinct Metal API-validation error messages in a subtest's stderr.
+///
+/// Volatile addresses and counts collapse to `N` so a repeated error reports
+/// once. The layer's warnings never reach here (the run switches them off), so
+/// every match is misuse.
+fn validation_errors(stderr: &str) -> BTreeSet<String> {
+    let mut seen: BTreeSet<String> = BTreeSet::new();
     for line in stderr.lines() {
         let l = line.trim();
         let is_validation = l.contains("does not match")
@@ -240,9 +284,7 @@ fn report_validation_errors(arch: Arch, subtest: Subtest, stderr: &str) {
             seen.insert(normalize_numbers(l));
         }
     }
-    for msg in &seen {
-        eprintln!("  [{arch}/{subtest}] metal-validation: {msg}");
-    }
+    seen
 }
 
 /// Collapse hex literals (`0x…`) and decimal runs to `N`.
@@ -272,3 +314,6 @@ fn normalize_numbers(s: &str) -> String {
     }
     out
 }
+
+#[cfg(test)]
+mod tests;

--- a/unix/conformance/src/run/tests.rs
+++ b/unix/conformance/src/run/tests.rs
@@ -1,0 +1,47 @@
+//! Unit tests for the Metal-validation reporting and its gate.
+//!
+//! The recogniser picks the layer's error lines out of a subtest's stderr,
+//! collapses volatile numbers so a repeated error reports once, and leaves
+//! ordinary Wine and Metal chatter alone. The gate then fails a leg for any
+//! line that survives: after the warning filter there is no benign one left.
+
+use super::{normalize_numbers, validation_errors, validation_gate_failed};
+
+/// Two draw-error lines the mismatched-sampler-type case used to log, verbatim.
+const MISMATCHED_SAMPLER: &str = "\
+0000:err:d3d9: something unrelated\n\
+Draw Errors Validation\n\
+Fragment Function(mtld3d_ps_sm3_29b0ab41fc8da9b1): incorrect type of texture (MTLTextureType2D) bound at Texture binding at index 0 (expect MTLTextureType3D) for s0[0].\n\
+Fragment Function(mtld3d_ps_sm3_fab23e4e59af0b3b): incorrect type of texture (MTLTextureType3D) bound at Texture binding at index 0 (expect MTLTextureType2D) for s0[0].\n";
+
+#[test]
+fn draw_error_lines_are_collected() {
+    let seen = validation_errors(MISMATCHED_SAMPLER);
+    assert_eq!(seen.len(), 3, "the banner and both draw errors: {seen:?}");
+    assert!(validation_gate_failed(seen.len()));
+}
+
+#[test]
+fn one_error_repeated_per_draw_reports_once() {
+    let line = "Buffer Validation: Insufficient buffer size at buffer binding at index 2";
+    let stderr = format!("{line} 0x600002a1c000\n{line} 0x600002b40480\n");
+    assert_eq!(validation_errors(&stderr).len(), 1);
+}
+
+#[test]
+fn ordinary_output_logs_nothing() {
+    let stderr = "\
+        d3d9_test.exe: 1234 tests executed (0 marked as todo, 0 failures), 3 skipped.\n\
+        visual.c:9100: Test failed: Got unexpected colour 0x00000000.\n\
+        Metal API Validation Enabled\n";
+    assert!(validation_errors(stderr).is_empty());
+    assert!(!validation_gate_failed(0));
+}
+
+#[test]
+fn numbers_and_addresses_collapse() {
+    assert_eq!(
+        normalize_numbers("texture at index 3 (0xdeadbeef) must be <= 16"),
+        "texture at index N (0xN) must be <= N"
+    );
+}


### PR DESCRIPTION
## Symptoms

A conformance leg printed the Metal API-validation errors its subtests logged and then ignored them:

```
  [i686/visual] metal-validation: Fragment Function(mtld3d_ps_sm3_N): incorrect type of texture (MTLTextureTypeND) bound at Texture binding at index N (expect MTLTextureTypeND) for sN[N].
  ...
conformance: no regressions vs baseline
```

The leg exited zero as long as the per-site failure counts held, so a change that started committing a new kind of API misuse passed the gate. The lines were a standing watch nobody was obliged to read.

## Root cause

Nothing consumed them. `run_subtest` reported the deduplicated lines as a side effect and returned only the parsed per-site result, so the count never reached the exit-code decision in `main`. Metal misuse is invisible to the per-site counts by construction: the validation layer logs in `nslog` mode precisely so it cannot abort a subtest or move its failure numbers.

## Changes

The runner now counts the distinct validation messages a subtest logged and returns them alongside the parsed result (`SubtestRun`). A diffing run sums the count over its four subtests and fails the leg when it is non-zero, independently of the diff verdict: a leg whose every site holds its pin still fails if it logged a line. The expected number is a constant next to the reporting code rather than a field in `baseline.txt`, which is machine-owned per-site counts with a parser that rejects anything else. It is zero and needs no tolerance, because the layer's warnings are already filtered out and every line that survives that filter is real misuse.

The message-recognising half of the reporting is now a pure function over a subtest's stderr, which is what the new unit tests drive. `--update-baseline` and `--repeat` runs are unaffected: neither gates.

`CONFORMANCE.md` gains the validation verdict in its description of how a run is judged, next to the regression and stale-baseline ones.

## Alternatives

A header field in `baseline.txt` holding the expected count: rejected, it changes the file's schema and its parser for a number whose only correct value is zero.

Gating inside `diff`: rejected, the diff compares per-site counts against a recorded baseline and validation output is neither.

Failing the subtest itself (crash bit) on a validation line: rejected, it would corrupt the per-site record and report Metal misuse as a Wine test crash.

## Verification

`make check` clean. `make test-unit`: 155 unix tests pass, including four new cases in `run::tests` (`draw_error_lines_are_collected`, `one_error_repeated_per_draw_reports_once`, `ordinary_output_logs_nothing`, `numbers_and_addresses_collapse`); the first two fail before the change, where neither the gate predicate nor the collector they call exists and no test covers the reporting path at all. The runner's baseline/CONFORMANCE.md sync test still passes.

`make conformance` green on both architectures, with no `metal-validation:` line on either leg, which is what lets the expectation be zero rather than a recorded tolerance. i686 device shows 4475 and 4480 down (flaky) and 15088 down (ceiling), x86_64 device the same three; visual, stateblock and d3d9ex match their pins on both.

The gate itself was exercised by feeding `report_validation_errors` one fabricated line and running the `d3d9ex` leg: the run printed `conformance: METAL VALIDATION - 1 error line(s) logged` and exited 1 while every site still read `ok`, which is the case the per-site diff cannot catch.

Closes #279
