### PR TITLE
Settle the test prefix before the first test process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,6 +393,18 @@ configure-test-prefix:
 	$(WINE) reg add 'HKCU\Software\Wine\WineDbg' /v ShowCrashDialog /t REG_DWORD /d 0 /f >/dev/null 2>&1
 	$(WINE) reg add 'HKCU\Software\Wine\X11 Driver' /v EmulateModeset /t REG_SZ /d Y /f >/dev/null 2>&1
 	$(WINE) reg add 'HKCU\Software\Wine\Mac Driver' /v RetinaMode /t REG_SZ /d Y /f >/dev/null 2>&1
+	# A wineserver session enumerates the display once, when its desktop
+	# starts, and serves that geometry to every process in it afterwards. The
+	# session the first `reg add` boots to create the prefix enumerates it
+	# before RetinaMode is written, so a test process attaching to that session
+	# reads monitor geometry in the point space rather than the physical-pixel
+	# one the keys above pin. End it, so the next session enumerates with the
+	# keys in place: `-k` shuts the server down cleanly, flushing the registry
+	# on the way out, and `-w` covers the case where it had to be killed
+	# outright. Both precede the persistent server below, which never
+	# terminates on its own, so a `-w` after it would never return.
+	-$(WINESERVER) -k >/dev/null 2>&1
+	-$(WINESERVER) -w >/dev/null 2>&1
 	# Pre-boot a persistent wineserver so individual test processes attach to it
 	# instead of each paying boot cost (and briefly holding its stdio). Both
 	# lines detach stdio: the persistent server (and the winedevice.exe residents

--- a/unix/conformance/CONFORMANCE.md
+++ b/unix/conformance/CONFORMANCE.md
@@ -242,6 +242,17 @@ validate against a mode list because no mode is set). The harness pins
 emulated mode switching and Retina mode so window-management assertions use a
 stable physical-pixel coordinate space.
 
+Both pins are registry values, and a wineserver session enumerates the display
+once, when its desktop starts, and serves that geometry to every process in it
+afterwards. A pin therefore only takes effect in a session that started after
+it was written, and the session that creates a prefix predates them by
+construction, so `configure-test-prefix` ends that session once the keys are
+in. Without it the first leg in a fresh prefix runs against monitor geometry
+in the point space: `test_window_position` 15023 and `test_reset_fullscreen`
+4903 fail outright, and the desktop-mode `ceiling` sites read 0 because the
+mode change the test asks for is accepted, exactly as on the CI runner's
+virtual display.
+
 Two refinements landed 2026-08 after the CI runner exposed them (its virtual
 display accepts the mode changes this machine's macdrv rejects, so the tests
 walk further):


### PR DESCRIPTION
## Symptoms

The first `make conformance-i686` in a brand-new `WINEPREFIX` diverges from the baseline; the second leg in the same prefix, and every leg after it, matches. On a fresh prefix the leg reports two new failing sites and thirteen `ceiling` sites dropping to 0:

```
i686/device  baseline(failed=770 crash=0) current(failed=754 crash=0) REGRESSION
  device.c:4161  2 -> 0  ceiling (below the pin, tolerated)
  device.c:4903  0 -> 1  REGRESSION (new failing site, untriaged)
  device.c:5509  1 -> 0  ceiling (below the pin, tolerated)
  ...
  device.c:15023  0 -> 1  REGRESSION (new failing site, untriaged)
```

The raw messages are `device.c:15023: Test failed: Adapter 0: Expect window rect (0,0)-(1728,1117), got (0,1)-(1727,1117).` (`test_window_position`) and `device.c:4903: Test failed: Received unexpected WM_SIZE message.` (`test_reset_fullscreen`). The same prefix, warmed, reports `no regressions vs baseline`. A fresh CI runner's first leg fails for this reason.

## Root cause

`configure-test-prefix` writes `Mac Driver\RetinaMode` and `X11 Driver\EmulateModeset` with the same `reg add` run that creates the prefix. Creating the prefix boots a wineserver session, and a session enumerates the display once, when its desktop starts, then serves that geometry to every process in it. That enumeration happens while the prefix is being created, which is before the third `reg add` writes `RetinaMode`, so the session caches monitor geometry in the point space (1728x1117) instead of the physical-pixel space the key pins. `wineserver -p` on the next recipe line makes that session persistent, so the whole first leg runs against the stale geometry: window-rect assertions fail, and the mode changes the desktop-mode `ceiling` sites expect to be rejected are accepted instead, so those sites read 0.

The second leg reads the baseline because the first leg's tests drive `ChangeDisplaySettingsW` and force a re-enumeration, with the keys in place by then.

## Changes

`configure-test-prefix` ends the prefix-creating session after the `reg add` lines and before the persistent server is started: `wineserver -k` shuts it down cleanly (the registry is flushed on the way out) and `wineserver -w` covers the case where the server had to be killed outright. The next session, the persistent one the tests attach to, enumerates the display with the keys already written. Ordering is load-bearing: `-w` waits for the current server to terminate, and the persistent server started below it never does.

`unix/conformance/CONFORMANCE.md` records why the harness ends that session, next to the existing prose on what the mode-switching pins buy.

The teardown assumes legs sharing one prefix run in sequence, which they already do: the two arches are separate CI jobs, and `conformance-baseline` serialises its legs through recursive make for the same reason.

## Alternatives

`wineboot -u` after the `reg add` lines: re-runs the wine.inf update on every leg for no effect here, since the implicit `wineboot --init` that creates the prefix has already completed by the time the first `reg add` returns; it does not end the session holding the stale enumeration.

Writing the driver keys before the prefix exists: there is no way to populate the registry without booting a session first, so the creating session always predates the keys.

Ending the session only when the recipe created the prefix: needs the prefix path in the Makefile and a shell conditional, and buys nothing over ending it unconditionally, which also gives every leg the same starting display state instead of inheriting whatever the previous leg's tests left behind.

## Verification

The conformance leg is the test. Before the change, with `$WINEPREFIX` deleted, `make conformance-i686` reports `REGRESSIONS detected` with `device.c:4903 0 -> 1`, `device.c:15023 0 -> 1` and thirteen `ceiling` sites at 0; a second leg in the same prefix reports `no regressions vs baseline`. After the change, `make conformance` from a deleted prefix reports no regressions on both i686 and x86_64 on its first leg.

The mechanism was confirmed separately by running `d3d9_test.exe device` directly: three fresh prefixes built the current way each report `device.c:15023` and `device.c:4903` once and `device.c:5509`/`5533` zero times, while a second session on one of those prefixes, started after the keys were written, reports the reverse.

`make check` is clean (audit: 257 files). `make test`, also from a deleted prefix, is green: 957 + 155 unit tests passed, and the e2e suite ran 405 tests per architecture (i686 and x86_64) with 405 passed and 1 leaky on each leg, 0 failures.

Closes #312
