### PR TITLE
Describe debug.expandPacked16 as the GPU upload pass it is

### DIFF
--- a/unix/unix/src/metal/device.rs
+++ b/unix/unix/src/metal/device.rs
@@ -68,7 +68,7 @@ pub fn supports_sampler_border(device: &ProtocolObject<dyn MTLDevice>) -> bool {
 /// in Metal's pixel-format capability table; the Mac2 Bronze driver
 /// (Intel/AMD) raises a validation abort when a texture descriptor names one.
 /// When false, the PE side backs the corresponding D3D formats with
-/// `Bgra8Unorm` and expands texels on the CPU at upload time.
+/// `Bgra8Unorm` and widens their texels in the GPU upload pass.
 pub fn supports_native_packed16(device: &ProtocolObject<dyn MTLDevice>) -> bool {
     device.supportsFamily(MTLGPUFamily::Apple2)
 }

--- a/windows/core/src/config.rs
+++ b/windows/core/src/config.rs
@@ -35,11 +35,14 @@ pub struct Mtld3dConfig {
     /// Force the packed 16-bit expansion path used on non-Apple-family GPUs.
     ///
     /// Treats the device as lacking the native packed 16-bit pixel
-    /// formats: A4R4G4B4 / R5G6B5 / A1R5G5B5 / X1R5G5B5 textures are backed
-    /// by BGRA8 and expanded on the CPU at upload, and the 16-bit render
-    /// target formats stop being advertised. Exists so the Intel/AMD
-    /// path can be exercised on Apple Silicon. Default: `false`. File
-    /// key: `debug.expandPacked16`.
+    /// formats: A4R4G4B4 / R5G6B5 / A1R5G5B5 / X1R5G5B5 textures are
+    /// backed by BGRA8, every upload into one is widened from its 2 bpp staging
+    /// by the GPU upload pass (a render pass whose fragment function
+    /// reads the staging slab as a buffer argument) instead of a blit
+    /// copy, and the 16-bit render target formats stop being
+    /// advertised. Exists so the Intel/AMD path can be exercised on
+    /// Apple Silicon. Default: `false`. File key:
+    /// `debug.expandPacked16`.
     pub expand_packed16: bool,
     /// Whether single-precision float textures may be advertised as filterable.
     ///


### PR DESCRIPTION
## Symptoms

The `expand_packed16` field in `windows/core/src/config.rs` documents the packed 16-bit path as widening texels "on the CPU at upload". A reader following that comment looks for a CPU widening loop in the upload path and does not find one. The same claim appears on `supports_native_packed16` in `unix/unix/src/metal/device.rs`. `mtld3d.conf`, the `native_packed16_supported` log line in `windows/d3d9/src/direct3d9.rs`, `format.rs` and the `texture_expand_uploads` counter in `perf.rs` all describe the mechanism correctly, so the two stale comments are the outliers.

## Root cause

Documentation only. A packed 16-bit staging feeding a `Bgra8Unorm` texture cannot ride `copyFromBuffer:toTexture:` (2 bpp source, 4 bpp destination), so the widening is done by the upload-quad render pass: the fragment function reads the staging slab as a buffer argument and decodes each texel on the way to the destination (`windows/core/src/upload_pass.rs`, `unix/unix/src/metal/upload_quad.rs`). Nothing on the CPU touches the texels.

## Changes

`windows/core/src/config.rs`: the `expand_packed16` doc block now says the uploads are widened from the 2 bpp staging by the GPU upload pass instead of a blit copy, and names the mechanism (a render pass whose fragment function reads the staging slab as a buffer argument). The rest of the block, the BGRA8 backing, the de-advertised 16-bit render targets, the purpose and the default, is unchanged.

`unix/unix/src/metal/device.rs`: the same correction on `supports_native_packed16`, which carried the shorter form of the claim.

No code change, and no other file restates the CPU wording (`.claude/conventions-digest.md` does not mention the key).

## Alternatives

Point the comment at `upload_pass` and say nothing else: rejected, the field doc is the place a reader meets the key and should carry the mechanism in one sentence.

Fix only `config.rs` as the issue asks: rejected, the `device.rs` comment is the same error and both are read by anyone tracing the path end to end.

## Verification

`make check` clean (fmt-check, clippy on both PE targets and native, audit clean over 257 files, rustdoc on both workspaces). No behavioural claim to prove, so no test accompanies the change; the path itself stays pinned by `windows/tests/tests/expand16.rs`.

Closes #321
