### PR TITLE
Follow the display for the present throttle and the backing scale

### DIFF
--- a/mtld3d.conf
+++ b/mtld3d.conf
@@ -91,7 +91,9 @@
 # clamps to `[1, 8]` — the cursor matches the panel. Set a positive
 # integer to override (e.g. `2` for a uniform 2× cursor, useful when
 # `backingScaleFactor` reports 1 on a hi-DPI external panel). Values
-# above 8 clamp to 8 at use time.
+# above 8 clamp to 8 at use time. Both are resolved again when the
+# window moves to a display of another scale, so `auto` follows it and
+# an override holds everywhere.
 #
 # Default: auto
 # Supported values: auto, 1, 2, 3, …

--- a/unix/shared/src/params.rs
+++ b/unix/shared/src/params.rs
@@ -44,7 +44,7 @@ const _: () = {
     // identical on all targets.
     assert!(core::mem::align_of::<CreateCommandQueueParams>() == 8);
     assert!(core::mem::size_of::<CreateCommandQueueParams>() == 24);
-    assert!(core::mem::size_of::<AttachMetalLayerParams>() == 64);
+    assert!(core::mem::size_of::<AttachMetalLayerParams>() == 72);
     assert!(core::mem::size_of::<CreateBackbufferParams>() == 64);
     assert!(core::mem::size_of::<DestroyCommandQueueParams>() == 48);
     assert!(core::mem::size_of::<SubmitFrameParams>() == 104);
@@ -175,6 +175,17 @@ pub struct AttachMetalLayerParams {
     /// the layer instead — the pre-`MetalFX` behaviour, and the only correct
     /// fallback since nothing else on the unix side can resize a frame.
     pub metalfx_available: u32, // out
+    /// Address of a PE-side `AtomicU32` that receives a changed `backing_scale`.
+    ///
+    /// `backing_scale` above answers for the display the window is on at
+    /// attach; the window can move to one with another scale afterwards. The
+    /// unix side stores the new value here whenever its display-follow
+    /// reconciliation derives one, so the PE-side cursor upscale picks it up
+    /// without a second thunk. Backed by a static in the PE image rather than
+    /// a device-owned allocation: the reconciliation runs on the `AppKit`
+    /// main thread, outside any thunk, so it cannot be ordered against a
+    /// device teardown. `0` disables the republish.
+    pub backing_scale_ptr: u64, // in: *const AtomicU32 (PE static, process lifetime)
 }
 
 impl Thunk for AttachMetalLayerParams {

--- a/unix/shared/src/params/tests.rs
+++ b/unix/shared/src/params/tests.rs
@@ -33,10 +33,10 @@ fn buffer_param_layouts_match_wow64() {
 fn attach_metal_layer_layout() {
     use super::AttachMetalLayerParams;
     // 2*u64 + 2*u32 + 2*u64 + 2*u32 + 1*u32 + 1*ColorSpacePolicy
-    // + 2*u32 = 16 + 8 + 16 + 8 + 4 + 4 + 8 = 64 (explicit pad0
-    // keeps the size a multiple of the align-8).
+    // + 2*u32 + 1*u64 = 16 + 8 + 16 + 8 + 4 + 4 + 8 + 8 = 72 (the
+    // six 4-byte fields pair up, so the trailing u64 needs no pad).
     assert_eq!(core::mem::align_of::<AttachMetalLayerParams>(), 8);
-    assert_eq!(core::mem::size_of::<AttachMetalLayerParams>(), 64);
+    assert_eq!(core::mem::size_of::<AttachMetalLayerParams>(), 72);
 }
 
 #[test]

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -150,20 +150,19 @@ pub extern "C" fn attach_metal_layer_handler(args: *mut c_void) -> i32 {
         return -1;
     };
 
-    let pacing = metal::PresentPacing {
-        vsync_requested: params.display_sync_enabled != 0,
-        max_fps: params.max_fps,
+    let request = metal::LayerAttachRequest {
+        hwnd: params.hwnd,
+        width: params.width,
+        height: params.height,
+        pacing: metal::PresentPacing {
+            vsync_requested: params.display_sync_enabled != 0,
+            max_fps: params.max_fps,
+        },
+        hdr_enable: params.hdr_enable != 0,
+        color_space: params.color_space,
+        backing_scale_sink_ptr: params.backing_scale_ptr,
     };
-    let hdr_enable = params.hdr_enable != 0;
-    if let Some((view, layer, caps)) = metal::attach_metal_layer(
-        params.device_handle,
-        params.hwnd,
-        params.width,
-        params.height,
-        pacing,
-        hdr_enable,
-        params.color_space,
-    ) {
+    if let Some((view, layer, caps)) = metal::attach_metal_layer(params.device_handle, request) {
         params.view_handle = view;
         params.layer_handle = layer;
         params.backing_scale = caps.backing_scale;

--- a/unix/unix/src/metal.rs
+++ b/unix/unix/src/metal.rs
@@ -22,7 +22,8 @@ pub use clear_quad::ensure_clear_quad_pipeline;
 pub use command::{BlitArgs, blit_texture_to_buffer, submit_frame, wait_for_gpu_retire};
 pub use device::{create_command_queue, default_device_info, destroy_command_queue};
 pub use macdrv::{
-    PresentPacing, attach_metal_layer, declare_latency_critical_activity, set_display_sync_enabled,
+    LayerAttachRequest, PresentPacing, attach_metal_layer, declare_latency_critical_activity,
+    set_display_sync_enabled,
 };
 pub use mtld3d_shared::perf::init_tracking_enabled;
 pub use pipeline::{create_render_pipeline, destroy_render_pipeline};

--- a/unix/unix/src/metal/macdrv.rs
+++ b/unix/unix/src/metal/macdrv.rs
@@ -176,6 +176,12 @@ fn is_bound_window(window: usize) -> bool {
 /// HDR configuration applied, the identity headroom the present pass treats
 /// as a no-op, and a window that never suppresses a present.
 ///
+/// What attach latched *about* the display goes with it. A reconciliation
+/// that survived the clear must not re-derive a present throttle from the
+/// pacing of a guest that is gone, and must not publish a backing scale into
+/// a `d3d9.dll` static the guest may since have unloaded. This is the only
+/// entry point that drops any of it; the next attach latches its own.
+///
 /// Only the bound view's own teardown clears, so a device that never attached
 /// and one whose view a later attach has already replaced leave the record
 /// naming the view that is still live.
@@ -196,6 +202,9 @@ pub fn detach_metal_layer(view_handle: MetalHandle<NSViewKind>) {
     CURRENT_HEADROOM_BITS.store(1.0_f32.to_bits(), Ordering::Relaxed);
     LAST_LOGGED_HEADROOM_BITS.store(0, Ordering::Relaxed);
     WINDOW_OCCLUDED.store(false, Ordering::Relaxed);
+    PRESENT_PACING_BITS.store(0, Ordering::Relaxed);
+    CURRENT_BACKING_SCALE.store(0, Ordering::Relaxed);
+    BACKING_SCALE_SINK_PTR.store(0, Ordering::Relaxed);
 }
 
 /// Whether a headroom refresh is already queued on the main thread.
@@ -578,6 +587,35 @@ fn install_occlusion_observer_once() {
 /// (`set_display_sync_enabled`) re-queries the panel and overwrites.
 static MIN_PRESENT_DURATION_BITS: AtomicU64 = AtomicU64::new(0);
 
+/// Present pacing latched from the PE side, encoded by [`pack_pacing`].
+///
+/// Attach and the D3D9 Reset path both write it, and the display-follow
+/// reconciliation reads it back so a re-derivation on another panel still
+/// honours the guest's vsync request and the user's `present.maxFps`
+/// ceiling. One packed word rather than two atomics, so a Reset landing
+/// between two reads cannot hand the reconciliation half of each.
+static PRESENT_PACING_BITS: AtomicU64 = AtomicU64::new(0);
+
+/// Backing scale of the display the bound layer is on.
+///
+/// Seeded at attach from the same reading [`DisplayCaps`] carries to the PE
+/// side, and re-derived by the display-follow reconciliation. Compared
+/// against before publishing, so the PE side only hears about real changes.
+/// `0` before the first attach and again once [`detach_metal_layer`] runs,
+/// which is what [`display_state_is_latched`] reads.
+static CURRENT_BACKING_SCALE: AtomicU32 = AtomicU32::new(0);
+
+/// Address of the PE-side `AtomicU32` a changed backing scale is published into.
+///
+/// Latched at attach from `AttachMetalLayerParams::backing_scale_ptr`. The
+/// PE side backs it with a static in its own image rather than a
+/// device-owned allocation, because the reconciliation runs on the main
+/// thread outside any thunk and so cannot be ordered against a device
+/// teardown. [`detach_metal_layer`] clears it all the same, because a
+/// `d3d9.dll` the guest unloads takes the static with it. `0` before the
+/// first attach.
+static BACKING_SCALE_SINK_PTR: AtomicUsize = AtomicUsize::new(0);
+
 /// Present-throttle request resolved PE-side.
 ///
 /// The guest's vsync ask (`D3DPRESENT_PARAMETERS::PresentationInterval`
@@ -634,6 +672,110 @@ fn min_present_duration(panel_max_hz: f64, pacing: &PresentPacing) -> f64 {
 fn store_min_present_duration(panel_max_hz: f64, pacing: &PresentPacing) {
     let seconds = min_present_duration(panel_max_hz, pacing);
     MIN_PRESENT_DURATION_BITS.store(seconds.to_bits(), Ordering::Relaxed);
+}
+
+/// Fold a [`PresentPacing`] into the one word [`PRESENT_PACING_BITS`] holds.
+///
+/// The vsync request is the low bit and the frame cap rides above it, so the
+/// pair is written and read as a unit.
+fn pack_pacing(pacing: &PresentPacing) -> u64 {
+    (u64::from(pacing.max_fps) << 1) | u64::from(pacing.vsync_requested)
+}
+
+/// Read back what [`pack_pacing`] wrote.
+fn unpack_pacing(bits: u64) -> PresentPacing {
+    let max_fps = u32::try_from((bits >> 1) & u64::from(u32::MAX))
+        .expect("masked to u32::MAX on the line above");
+    PresentPacing {
+        vsync_requested: bits & 1 != 0,
+        max_fps,
+    }
+}
+
+/// The present-throttle duration to apply when the panel under the window changed.
+///
+/// `Some(seconds)` when what [`min_present_duration`] derives differs from
+/// the duration the present site is using, `None` while the two agree, which
+/// is every poll of a session that stays on one display. The comparison is
+/// bit-exact because both sides come out of the same derivation, so equal
+/// inputs give an identical pattern and only a real change moves it.
+fn min_present_duration_change(
+    applied_seconds: f64,
+    panel_max_hz: f64,
+    pacing: &PresentPacing,
+) -> Option<f64> {
+    let target = min_present_duration(panel_max_hz, pacing);
+    (target.to_bits() != applied_seconds.to_bits()).then_some(target)
+}
+
+/// Round and clamp an `NSScreen.backingScaleFactor` into the range the PE side takes.
+///
+/// macOS reports the factor as an integer already; the clamp bounds the
+/// HCURSOR upscaler downstream, which asserts `[1, 8]`.
+fn backing_scale_from(screen_scale: f64) -> u32 {
+    bounded_cast::f64_to_u32_saturating(screen_scale.round()).clamp(1, 8)
+}
+
+/// The backing scale to publish when the window's display no longer matches it.
+///
+/// `Some(scale)` when the screen asks for a different factor than the one
+/// last published, `None` while they agree.
+fn backing_scale_change(applied: u32, screen_scale: f64) -> Option<u32> {
+    let target = backing_scale_from(screen_scale);
+    (target != applied).then_some(target)
+}
+
+/// A screen's refresh ceiling in Hz, from `NSScreen.maximumFramesPerSecond`.
+///
+/// 60 on most external displays, 120 on a `ProMotion` panel. `0.0` when the
+/// screen reports nothing usable (older macOS, a virtualised display), which
+/// [`min_present_duration`] reads as "no vsync throttle".
+fn screen_max_hz(screen: &objc2_app_kit::NSScreen) -> f64 {
+    let clamped = screen.maximumFramesPerSecond().clamp(0, 1000);
+    let as_u32 = u32::try_from(clamped).expect("clamped above to [0, 1000]");
+    f64::from(as_u32)
+}
+
+/// Publish a backing scale into the PE-side sink, when one has been handed over.
+///
+/// The store is `Relaxed`: the value stands alone, the PE side reads it once
+/// per present, and there is nothing for it to order against.
+fn publish_backing_scale(scale: u32) {
+    let sink = BACKING_SCALE_SINK_PTR.load(Ordering::Relaxed);
+    if sink == 0 {
+        return;
+    }
+    // SAFETY: the PE side backs this address with a static `AtomicU32` in its
+    // own image, so it stays readable for every write from here, including
+    // ones landing after the device it was attached for is gone. `AtomicU32`
+    // has the same size and alignment in both images.
+    let sink = unsafe { &*(sink as *const AtomicU32) };
+    sink.store(scale, Ordering::Relaxed);
+}
+
+/// Everything the PE side's `AttachMetalLayer` request carries in.
+///
+/// Bundled so the entry point stays inside clippy's `too_many_arguments`
+/// threshold, the same reason [`PresentPacing`] exists.
+pub struct LayerAttachRequest {
+    /// The guest window the layer is attached to.
+    pub hwnd: u64,
+    /// Back-buffer width, for the geometry log line.
+    pub width: u32,
+    /// Back-buffer height, for the geometry log line.
+    pub height: u32,
+    /// The guest's vsync ask plus the user's frame-rate ceiling.
+    pub pacing: PresentPacing,
+    /// `color.hdr.enable` from `mtld3d.conf`.
+    pub hdr_enable: bool,
+    /// `color.space` from `mtld3d.conf`.
+    pub color_space: ColorSpacePolicy,
+    /// Address of the PE-side `AtomicU32` that receives a changed backing scale.
+    ///
+    /// See [`BACKING_SCALE_SINK_PTR`]. `0` leaves the display-follow path
+    /// with nothing to publish into, which is what a headless smoke test
+    /// that never built one looks like.
+    pub backing_scale_sink_ptr: u64,
 }
 
 /// Resolved `CAMetalLayer`-relevant capabilities of the `NSScreen` the bound view lives on.
@@ -822,22 +964,27 @@ fn run_on_main_thread_sync<F: FnOnce()>(f: F) {
 ///
 /// Side effect: latches the unix-side `HDR_ACTIVE` global to `true`
 /// when the display has EDR potential and `hdr_enable` is set (resolved
-/// PE-side from `color.hdr.enable` in `mtld3d.conf`), and records the layer
-/// plus both user settings so the per-present poll can follow the window
-/// onto a display of the other class.
+/// PE-side from `color.hdr.enable` in `mtld3d.conf`), and records the layer,
+/// the pacing, the backing scale and both user settings so the per-present
+/// poll can follow the window onto another display and re-derive everything
+/// that display decides.
 pub fn attach_metal_layer(
     device_handle: MetalHandle<MTLDeviceKind>,
-    hwnd: u64,
-    width: u32,
-    height: u32,
-    pacing: PresentPacing,
-    hdr_enable: bool,
-    color_space: mtld3d_shared::mtl::ColorSpacePolicy,
+    request: LayerAttachRequest,
 ) -> Option<(
     MetalHandle<NSViewKind>,
     MetalHandle<CAMetalLayerKind>,
     DisplayCaps,
 )> {
+    let LayerAttachRequest {
+        hwnd,
+        width,
+        height,
+        pacing,
+        hdr_enable,
+        color_space,
+        backing_scale_sink_ptr,
+    } = request;
     if hwnd == 0 || device_handle.is_null() {
         return None;
     }
@@ -880,6 +1027,18 @@ pub fn attach_metal_layer(
             with_bound_display(|bound| bound.layer = layer as usize);
             HDR_ENABLE_REQUESTED.store(hdr_enable, Ordering::Relaxed);
             COLOR_SPACE_POLICY.store(color_space as u32, Ordering::Relaxed);
+            // Same for the pacing and the backing scale: the display-follow
+            // path re-derives the present throttle and the scale for a screen
+            // that was not attached yet, and needs the guest's vsync ask, the
+            // user's frame cap and the value the PE side is already using.
+            PRESENT_PACING_BITS.store(pack_pacing(&pacing), Ordering::Relaxed);
+            CURRENT_BACKING_SCALE.store(hint.caps.backing_scale, Ordering::Relaxed);
+            BACKING_SCALE_SINK_PTR.store(
+                usize::try_from(backing_scale_sink_ptr)
+                    .expect("PE wire pointer fits host address space (unix is 64-bit)"),
+                Ordering::Relaxed,
+            );
+            publish_backing_scale(hint.caps.backing_scale);
             // Decide HDR vs SDR layer configuration from the panel's
             // static potential + the user's `color.hdr.enable` setting. Latch
             // the result as the configuration the layer now carries — the
@@ -938,9 +1097,12 @@ pub fn attach_metal_layer(
 /// recomputed from `NSScreen.mainScreen` here (the PE side re-sends the
 /// `present.maxFps` cap so it survives Resets). `layer_handle` is unused
 /// (kept for wire-format stability). The mainScreen lookup may pick the
-/// wrong panel in multi-monitor setups — accepted simplification, the Reset
-/// path is rare; the right fix (traverse `layer → delegate → window →
-/// screen`) is more code than the multi-monitor edge case warrants today.
+/// wrong panel in a multi-monitor setup; the display-follow reconciliation
+/// walks to the window's own screen and corrects it within one poll
+/// interval, which is why this path stays a one-line read.
+///
+/// The new pacing is latched for that reconciliation too, so a throttle it
+/// re-derives on another panel keeps the interval the guest just asked for.
 pub fn set_display_sync_enabled(
     _layer_handle: MetalHandle<CAMetalLayerKind>,
     pacing: &PresentPacing,
@@ -954,11 +1116,8 @@ pub fn set_display_sync_enabled(
     // can be retrieved from any thread"). This is the canonical statement
     // of that posture; the other NSScreen readers in this file cite it.
     let mtm = unsafe { MainThreadMarker::new_unchecked() };
-    let panel_max_hz = NSScreen::mainScreen(mtm).map_or(0.0_f64, |s| {
-        let clamped = s.maximumFramesPerSecond().clamp(0, 1000);
-        let as_u32 = u32::try_from(clamped).expect("clamped above to [0, 1000]");
-        f64::from(as_u32)
-    });
+    PRESENT_PACING_BITS.store(pack_pacing(pacing), Ordering::Relaxed);
+    let panel_max_hz = NSScreen::mainScreen(mtm).map_or(0.0_f64, |s| screen_max_hz(&s));
     store_min_present_duration(panel_max_hz, pacing);
 }
 
@@ -1238,20 +1397,10 @@ fn view_display_caps(view: *mut c_void) -> DisplayHint {
             )
         });
 
-    // f64 → u32 via the saturating helper, then clamped to a reasonable
-    // backing-scale range (1×–8× — clippy can't see the prior clamp).
-    let backing_scale = bounded_cast::f64_to_u32_saturating(screen_scale.round()).clamp(1, 8);
-    // `maximumFramesPerSecond` is the panel ceiling (e.g. 60 on most
-    // external displays, 120 on `ProMotion`). Drives the present-throttle
-    // cap computed at attach. Returns `NSInteger`; clamp + widening cast
-    // mirrors `set_display_sync_enabled`'s posture. Sub-zero / huge
-    // pathological values fall through to `0.0`, which
-    // `compute_min_present_duration` then treats as "no throttle".
-    let panel_max_hz = screen.as_deref().map_or(0.0_f64, |s| {
-        let clamped = s.maximumFramesPerSecond().clamp(0, 1000);
-        let as_u32 = u32::try_from(clamped).expect("clamped above to [0, 1000]");
-        f64::from(as_u32)
-    });
+    let backing_scale = backing_scale_from(screen_scale);
+    // The panel ceiling drives the present-throttle duration computed at
+    // attach; a display move re-derives it from the same helper.
+    let panel_max_hz = screen.as_deref().map_or(0.0_f64, screen_max_hz);
     let mut colorspace_flags = ColorspaceFlags::empty();
     colorspace_flags.set(ColorspaceFlags::IS_HDR, colorspace_is_hdr);
     colorspace_flags.set(ColorspaceFlags::IS_WIDE_GAMUT, colorspace_is_wide_gamut);
@@ -1397,8 +1546,10 @@ fn queue_headroom_refresh() {
 /// reason, since naming the screen means walking to it again.
 ///
 /// The walk ends on whichever screen the window is on *now*, so it is also
-/// where the layer's own configuration is reconciled against that screen; see
-/// [`follow_screen_layer_mode`].
+/// where everything the display decides is reconciled against that screen:
+/// the layer's own configuration ([`follow_screen_layer_mode`]), the present
+/// throttle ([`follow_screen_present_throttle`]) and the backing scale the PE
+/// side consumes ([`follow_screen_backing_scale`]).
 fn refresh_headroom_on_main() {
     use objc2::MainThreadMarker;
     use objc2_app_kit::NSScreen;
@@ -1435,6 +1586,8 @@ fn refresh_headroom_on_main() {
     // than reconfigured twice against a screen the window is leaving.
     if let Some(screen) = screen.as_deref() {
         follow_screen_layer_mode(screen);
+        follow_screen_present_throttle(screen);
+        follow_screen_backing_scale(screen);
     }
     log_headroom_change_if_any(headroom, &view_obj);
 }
@@ -1874,6 +2027,77 @@ fn follow_screen_layer_mode(screen: &objc2_app_kit::NSScreen) {
         target: LOG_TARGET,
         "hdr: window moved onto '{screen_name}' (potential={potential:.2}×), layer reconfigured: \
          pixelFormat={pf:?} wantsEDR={wants} colorspace={cs_label}",
+    );
+}
+
+/// Whether a bound display's own state is latched for the follow path to use.
+///
+/// Attach seeds [`CURRENT_BACKING_SCALE`] with a factor of at least 1 and
+/// [`detach_metal_layer`] clears it back to `0`, so it doubles as the flag
+/// for "there is a display whose state these two can re-derive". The retained
+/// view the reconciliation walks answers whether an `AppKit` object is safe
+/// to touch; this answers whether the values to compare against are still
+/// this session's, which a teardown landing between the two would otherwise
+/// leave stale.
+fn display_state_is_latched() -> bool {
+    CURRENT_BACKING_SCALE.load(Ordering::Relaxed) != 0
+}
+
+/// Re-derive the present throttle for the screen the window is on. **Main thread only.**
+///
+/// The throttle is a function of the panel's refresh ceiling, so a window
+/// dragged from a 120 Hz panel onto a 60 Hz one keeps presenting at an 8.3 ms
+/// floor until this runs, and the reverse leaves a 16.6 ms floor on a panel
+/// that could show twice as many frames. The guest's vsync request and the
+/// user's frame cap are not what moved, so they come from the pacing latched
+/// at attach and at every Reset.
+///
+/// A session that stays on one display derives the duration it already has,
+/// and nothing is stored or logged.
+fn follow_screen_present_throttle(screen: &objc2_app_kit::NSScreen) {
+    if !display_state_is_latched() {
+        return;
+    }
+    let pacing = unpack_pacing(PRESENT_PACING_BITS.load(Ordering::Relaxed));
+    let panel_max_hz = screen_max_hz(screen);
+    let applied = min_present_duration_sec();
+    let Some(seconds) = min_present_duration_change(applied, panel_max_hz, &pacing) else {
+        return;
+    };
+    MIN_PRESENT_DURATION_BITS.store(seconds.to_bits(), Ordering::Relaxed);
+    info!(
+        target: LOG_TARGET,
+        "present: '{}' tops out at {panel_max_hz:.0} Hz, minimum present duration \
+         {applied:.5}s -> {seconds:.5}s (vsync={} maxFps={})",
+        screen.localizedName(),
+        pacing.vsync_requested,
+        pacing.max_fps,
+    );
+}
+
+/// Re-derive the backing scale for the screen the window is on. **Main thread only.**
+///
+/// The PE side takes the scale as a property of the display and drives the
+/// hardware-cursor upscale from it, so a move between a retina panel and a
+/// 1x one leaves the pointer at twice or half the size the display asks for
+/// until the new value is published.
+///
+/// A session that stays on one display reads back the scale it already
+/// published, and nothing is stored or logged.
+fn follow_screen_backing_scale(screen: &objc2_app_kit::NSScreen) {
+    if !display_state_is_latched() {
+        return;
+    }
+    let applied = CURRENT_BACKING_SCALE.load(Ordering::Relaxed);
+    let Some(scale) = backing_scale_change(applied, screen.backingScaleFactor()) else {
+        return;
+    };
+    CURRENT_BACKING_SCALE.store(scale, Ordering::Relaxed);
+    publish_backing_scale(scale);
+    info!(
+        target: LOG_TARGET,
+        "present: '{}' has a {scale}x backing scale (was {applied}x), republished to the guest",
+        screen.localizedName(),
     );
 }
 

--- a/unix/unix/src/metal/macdrv/tests.rs
+++ b/unix/unix/src/metal/macdrv/tests.rs
@@ -9,23 +9,28 @@
 //!
 //! `layer_mode_for` and `layer_mode_change` decide which `CAMetalLayer`
 //! configuration a screen asks for and whether the applied one has to be
-//! replaced. They are the whole of the display-follow decision, so the tests
-//! below pin both directions of a display change, the user's off switch, the
-//! degenerate ceilings, and the case that must *not* reconfigure.
+//! replaced. `min_present_duration_change` and `backing_scale_change` are
+//! their two neighbours in the same reconciliation. All four are the whole of
+//! the display-follow decision, so the tests below pin both directions of a
+//! display change, the user's off switch, the degenerate ceilings, and the
+//! case that must *not* reconfigure.
 //!
 //! `detach_metal_layer` is the other half of that path: the reconciliation
 //! runs from process-lifetime observers, so what stops it walking a released
-//! view is that teardown leaves nothing bound. One test covers it, because the
-//! record and the derived state it clears are process-wide.
+//! view, or re-deriving against a display nothing is bound to, is that
+//! teardown leaves nothing bound. One test covers it, because the record and
+//! the derived state it clears are process-wide.
 
 use core::sync::atomic::Ordering;
 
 use mtld3d_shared::{MetalHandle, mtl_handle::NSViewKind};
 
 use super::{
-    CURRENT_HEADROOM_BITS, HDR_ACTIVE, LAST_LOGGED_HEADROOM_BITS, LayerMode, PresentPacing,
-    WINDOW_OCCLUDED, detach_metal_layer, is_bound_window, layer_mode_change, layer_mode_for,
-    min_present_duration, with_bound_display,
+    BACKING_SCALE_SINK_PTR, CURRENT_BACKING_SCALE, CURRENT_HEADROOM_BITS, HDR_ACTIVE,
+    LAST_LOGGED_HEADROOM_BITS, LayerMode, PRESENT_PACING_BITS, PresentPacing, WINDOW_OCCLUDED,
+    backing_scale_change, backing_scale_from, detach_metal_layer, display_state_is_latched,
+    is_bound_window, layer_mode_change, layer_mode_for, min_present_duration,
+    min_present_duration_change, pack_pacing, unpack_pacing, with_bound_display,
 };
 
 #[test]
@@ -158,6 +163,19 @@ fn teardown_unbinds_the_display_and_resets_what_it_derived() {
     CURRENT_HEADROOM_BITS.store(4.0_f32.to_bits(), Ordering::Relaxed);
     LAST_LOGGED_HEADROOM_BITS.store(4.0_f32.to_bits(), Ordering::Relaxed);
     WINDOW_OCCLUDED.store(true, Ordering::Relaxed);
+    PRESENT_PACING_BITS.store(
+        pack_pacing(&PresentPacing {
+            vsync_requested: true,
+            max_fps: 60,
+        }),
+        Ordering::Relaxed,
+    );
+    CURRENT_BACKING_SCALE.store(2, Ordering::Relaxed);
+    BACKING_SCALE_SINK_PTR.store(0x4000, Ordering::Relaxed);
+    assert!(
+        display_state_is_latched(),
+        "the reconciliation has a display to re-derive against"
+    );
     assert!(
         is_bound_window(WINDOW),
         "the bound window matches while attached"
@@ -213,4 +231,128 @@ fn teardown_unbinds_the_display_and_resets_what_it_derived() {
         !WINDOW_OCCLUDED.load(Ordering::Relaxed),
         "no window suppresses a present"
     );
+    assert_eq!(
+        PRESENT_PACING_BITS.load(Ordering::Relaxed),
+        0,
+        "the next attach latches the pacing its own guest asked for",
+    );
+    assert_eq!(
+        CURRENT_BACKING_SCALE.load(Ordering::Relaxed),
+        0,
+        "no display's backing scale is published",
+    );
+    assert_eq!(
+        BACKING_SCALE_SINK_PTR.load(Ordering::Relaxed),
+        0,
+        "nothing is written into a guest that may have unloaded d3d9.dll",
+    );
+    assert!(
+        !display_state_is_latched(),
+        "the reconciliation has nothing to re-derive against"
+    );
+}
+
+#[test]
+fn pacing_survives_the_round_trip_through_one_word() {
+    for (vsync_requested, max_fps) in [(true, 0), (false, 0), (true, 60), (false, 240)] {
+        let packed = pack_pacing(&PresentPacing {
+            vsync_requested,
+            max_fps,
+        });
+        let back = unpack_pacing(packed);
+        assert_eq!(back.vsync_requested, vsync_requested);
+        assert_eq!(back.max_fps, max_fps);
+    }
+}
+
+#[test]
+fn the_widest_cap_survives_the_round_trip() {
+    let packed = pack_pacing(&PresentPacing {
+        vsync_requested: true,
+        max_fps: u32::MAX,
+    });
+    let back = unpack_pacing(packed);
+    assert!(back.vsync_requested);
+    assert_eq!(back.max_fps, u32::MAX);
+}
+
+#[test]
+fn staying_on_one_panel_never_rederives_the_throttle() {
+    let pacing = PresentPacing {
+        vsync_requested: true,
+        max_fps: 0,
+    };
+    let applied = min_present_duration(120.0, &pacing);
+    assert_eq!(min_present_duration_change(applied, 120.0, &pacing), None);
+}
+
+#[test]
+fn moving_onto_a_slower_panel_lengthens_the_throttle() {
+    let pacing = PresentPacing {
+        vsync_requested: true,
+        max_fps: 0,
+    };
+    let applied = min_present_duration(120.0, &pacing);
+    let changed = min_present_duration_change(applied, 60.0, &pacing).expect("panel rate moved");
+    assert_eq!(changed.to_bits(), (1.0_f64 / 60.0).to_bits());
+}
+
+#[test]
+fn moving_onto_a_faster_panel_shortens_the_throttle() {
+    let pacing = PresentPacing {
+        vsync_requested: true,
+        max_fps: 0,
+    };
+    let applied = min_present_duration(60.0, &pacing);
+    let changed = min_present_duration_change(applied, 120.0, &pacing).expect("panel rate moved");
+    assert_eq!(changed.to_bits(), (1.0_f64 / 120.0).to_bits());
+}
+
+#[test]
+fn a_user_cap_below_both_panels_holds_the_throttle_still() {
+    // The cap is the lower rate on either display, so the duration the
+    // present site uses does not move and nothing is rewritten or logged.
+    let pacing = PresentPacing {
+        vsync_requested: true,
+        max_fps: 30,
+    };
+    let applied = min_present_duration(120.0, &pacing);
+    assert_eq!(min_present_duration_change(applied, 60.0, &pacing), None);
+}
+
+#[test]
+fn a_free_running_session_stays_unthrottled_on_any_panel() {
+    let pacing = PresentPacing {
+        vsync_requested: false,
+        max_fps: 0,
+    };
+    let applied = min_present_duration(120.0, &pacing);
+    assert_eq!(applied.to_bits(), 0.0_f64.to_bits());
+    assert_eq!(min_present_duration_change(applied, 60.0, &pacing), None);
+}
+
+#[test]
+fn backing_scale_rounds_and_clamps_into_the_hcursor_range() {
+    assert_eq!(backing_scale_from(1.0), 1);
+    assert_eq!(backing_scale_from(2.0), 2);
+    assert_eq!(backing_scale_from(1.4), 1);
+    assert_eq!(backing_scale_from(1.5), 2);
+    // No screen at all, and a pathological reading, both land on identity
+    // rather than a factor the HCURSOR builder would reject.
+    assert_eq!(backing_scale_from(0.0), 1);
+    assert_eq!(backing_scale_from(-4.0), 1);
+    assert_eq!(backing_scale_from(f64::NAN), 1);
+    assert_eq!(backing_scale_from(99.0), 8);
+}
+
+#[test]
+fn staying_on_one_display_never_republishes_the_scale() {
+    assert_eq!(backing_scale_change(2, 2.0), None);
+    assert_eq!(backing_scale_change(1, 1.0), None);
+}
+
+#[test]
+fn moving_between_displays_of_different_scale_republishes() {
+    assert_eq!(backing_scale_change(2, 1.0), Some(1));
+    assert_eq!(backing_scale_change(1, 2.0), Some(2));
 }

--- a/windows/core/src/config.rs
+++ b/windows/core/src/config.rs
@@ -235,6 +235,30 @@ pub enum CursorScale {
     Fixed(u32),
 }
 
+impl CursorScale {
+    /// Resolve the HCURSOR upscale factor for a display's backing scale.
+    ///
+    /// Called again whenever the window lands on a display of another
+    /// backing scale, so `Fixed` has to keep answering with the user's
+    /// number: a setting that pins the cursor size means pinned, on every
+    /// display. The clamp is the range the HCURSOR builder accepts.
+    #[must_use]
+    pub const fn resolve(self, backing_scale: u32) -> u32 {
+        let requested = match self {
+            Self::Auto => backing_scale,
+            Self::Fixed(n) => n,
+        };
+        // `u32::clamp` is not const.
+        if requested < 1 {
+            1
+        } else if requested > 8 {
+            8
+        } else {
+            requested
+        }
+    }
+}
+
 impl Default for Mtld3dConfig {
     fn default() -> Self {
         Self {

--- a/windows/core/src/config/tests.rs
+++ b/windows/core/src/config/tests.rs
@@ -214,6 +214,28 @@ fn cursor_scale_garbage_keeps_default() {
 }
 
 #[test]
+fn cursor_scale_auto_follows_the_display() {
+    // Resolved again on every display move, so both readings of the same
+    // policy have to answer for the display they were handed.
+    assert_eq!(CursorScale::Auto.resolve(1), 1);
+    assert_eq!(CursorScale::Auto.resolve(2), 2);
+}
+
+#[test]
+fn cursor_scale_override_ignores_the_display() {
+    assert_eq!(CursorScale::Fixed(3).resolve(1), 3);
+    assert_eq!(CursorScale::Fixed(3).resolve(2), 3);
+}
+
+#[test]
+fn cursor_scale_resolves_into_the_hcursor_range() {
+    assert_eq!(CursorScale::Auto.resolve(0), 1);
+    assert_eq!(CursorScale::Auto.resolve(99), 8);
+    assert_eq!(CursorScale::Fixed(0).resolve(2), 1);
+    assert_eq!(CursorScale::Fixed(99).resolve(2), 8);
+}
+
+#[test]
 fn color_space_accepts_both_policies_case_insensitive() {
     let cfg = parse(None, "color.space = accurate\n", None);
     assert_eq!(cfg.color_space, ColorSpacePolicy::Accurate);

--- a/windows/d3d9/src/cursor.rs
+++ b/windows/d3d9/src/cursor.rs
@@ -17,7 +17,7 @@ use std::{
     time::Instant,
 };
 
-use log::{Level, debug, error, log_enabled, trace, warn};
+use log::{Level, debug, error, info, log_enabled, trace, warn};
 use mtld3d_core::perf::DeviceSubCategory;
 use mtld3d_shared::InPtr;
 use mtld3d_types::{
@@ -319,11 +319,31 @@ pub struct CursorState {
     probe: HitchProbe,
     /// Nearest-neighbor upscale factor applied to the cursor bitmap.
     ///
-    /// Sourced from the display's `backingScaleFactor` at `CreateDevice` so
-    /// a retina Mac gets a proportionally-sized Win32 cursor (Wine's
-    /// HCURSOR path does not participate in the OS's retina upscale).
-    /// `1` is the identity fast path.
+    /// Sourced from the display's `backingScaleFactor` at `CreateDevice`, and
+    /// re-sourced whenever the window lands on a display of another one, so a
+    /// retina Mac gets a proportionally-sized Win32 cursor (Wine's HCURSOR
+    /// path does not participate in the OS's retina upscale). `1` is the
+    /// identity fast path.
     scale: u32,
+    /// The bitmap the game last handed `SetCursorProperties`.
+    ///
+    /// Kept so a backing-scale change can rebuild the pointer the game is
+    /// already showing. Without it the new factor would only reach the
+    /// display on the game's next cursor change, which for a title that sets
+    /// its pointer once is never. `None` until the first accepted call.
+    source: Option<CursorSource>,
+}
+
+/// A cursor bitmap in the shape `build_hcursor` consumes.
+///
+/// `pixels` is a tight BGRA copy of the locked surface, so the row pitch is
+/// `width * 4` and the buffer outlives the lock it came from.
+struct CursorSource {
+    width: u32,
+    height: u32,
+    x_hotspot: u32,
+    y_hotspot: u32,
+    pixels: Vec<u8>,
 }
 
 impl CursorState {
@@ -339,6 +359,81 @@ impl CursorState {
             cache: FxHashMap::default(),
             probe: HitchProbe::new(),
             scale: scale.clamp(1, 8),
+            source: None,
+        }
+    }
+
+    /// Re-scale the pointer after the window moved to a display of another backing scale.
+    ///
+    /// A no-op while the factor is unchanged, which is every frame of a
+    /// session that stays on one display. On a real change the bitmap the
+    /// game is currently showing is rebuilt at the new factor and re-realised
+    /// straight away, so the pointer resizes with the window rather than at
+    /// the game's next `SetCursorProperties`.
+    pub fn follow_scale(&mut self, scale: u32) {
+        let scale = scale.clamp(1, 8);
+        let previous = self.scale;
+        if scale == previous {
+            return;
+        }
+        self.scale = scale;
+        info!(
+            target: LOG_TARGET,
+            "hardware cursor scale: {previous}x -> {scale}x (display backing scale changed)",
+        );
+        self.rebuild_current();
+    }
+
+    /// Rebuild and re-realise the current pointer at the current scale.
+    ///
+    /// Keyed through the same cache as `SetCursorProperties`, whose key folds
+    /// the scale in, so moving back to the first display reuses the bitmap
+    /// built for it instead of building a third.
+    fn rebuild_current(&mut self) {
+        let Some(source) = self.source.take() else {
+            return;
+        };
+        let pitch = source.width as usize * 4;
+        let hash = hash_cursor(
+            source.x_hotspot,
+            source.y_hotspot,
+            source.width,
+            source.height,
+            source.pixels.as_ptr(),
+            pitch,
+            self.scale,
+        );
+        let handle = if let Some(&h) = self.cache.get(&hash) {
+            Some(h)
+        } else {
+            let built = build_hcursor(
+                source.width,
+                source.height,
+                pitch,
+                source.pixels.as_ptr(),
+                source.x_hotspot,
+                source.y_hotspot,
+                self.scale,
+            );
+            if let Some(h) = built {
+                self.cache.insert(hash, h);
+            }
+            built
+        };
+        self.source = Some(source);
+        let Some(handle) = handle else {
+            mtld3d_shared::log_once_warn!(
+                target: LOG_TARGET,
+                "cursor: build_hcursor failed while following a backing-scale change; \
+                 the pointer stays at its previous size",
+            );
+            return;
+        };
+        self.hash = hash;
+        self.handle = handle;
+        if self.effective_visible() {
+            let us = timed_set_cursor(handle);
+            self.charge_call_us(us);
         }
     }
 
@@ -602,9 +697,8 @@ pub extern "system" fn device_set_cursor_properties(
 
     let pitch = usize::try_from(locked.pitch).expect("D3D9 LOCKED_RECT.pitch is non-negative");
     let src = locked.bits as *const u8;
-    let hash = hash_cursor(x_hotspot, y_hotspot, width, height, src, pitch);
-
     let cur = dev.cursor_mut();
+    let hash = hash_cursor(x_hotspot, y_hotspot, width, height, src, pitch, cur.scale);
     let prev_hash = cur.hash;
     let (handle, outcome) = if hash == prev_hash {
         (cur.handle, "unchanged")
@@ -626,6 +720,21 @@ pub extern "system" fn device_set_cursor_properties(
         cur.cache.insert(hash, h);
         (h, "built-fresh")
     };
+
+    // Keep the pixels: the backing scale can change under a running session
+    // when the window moves to another display, and rebuilding the pointer at
+    // the new factor needs the bitmap the unlock below hands back to the
+    // guest. Only on a new bitmap, so a game re-setting the same cursor every
+    // frame pays nothing.
+    if hash != prev_hash {
+        cur.source = Some(CursorSource {
+            width,
+            height,
+            x_hotspot,
+            y_hotspot,
+            pixels: tight_copy(width, height, pitch, src),
+        });
+    }
 
     // SAFETY: calling the just-loaded `unlock_rect` thunk through
     // `surf_vtbl`; paired with the `lock_rect` call above.
@@ -941,6 +1050,10 @@ extern "system" fn cursor_wnd_proc(hwnd: *mut c_void, msg: u32, wp: usize, lp: i
 /// content hash for byte buffers throughout the tree (see `ProgramId`); the
 /// value is the whole identity of the cursor, so it needs real avalanche, not
 /// a map hasher.
+///
+/// The upscale factor is part of that identity: the same bitmap on displays
+/// of different backing scale produces different HCURSORs, and one key for
+/// both would serve the wrong-sized one out of the cache.
 fn hash_cursor(
     x_hotspot: u32,
     y_hotspot: u32,
@@ -948,12 +1061,14 @@ fn hash_cursor(
     height: u32,
     src: *const u8,
     pitch: usize,
+    scale: u32,
 ) -> u64 {
     let mut h = Xxh3::new();
     h.write_u32(x_hotspot);
     h.write_u32(y_hotspot);
     h.write_u32(width);
     h.write_u32(height);
+    h.write_u32(scale);
     let row_bytes = (width as usize) * 4;
     for y in 0..height as usize {
         // SAFETY: caller-validated `src + y*pitch` stays within the bitmap.
@@ -963,6 +1078,24 @@ fn hash_cursor(
         h.write(row);
     }
     h.finish()
+}
+
+/// Copy a locked BGRA cursor surface into a tight `width * 4`-pitch buffer.
+///
+/// The caller validates that `src` covers `height` rows of at least
+/// `width * 4` readable bytes, `pitch` apart, which is what
+/// `D3DLOCKED_RECT` describes for the locked region.
+fn tight_copy(width: u32, height: u32, pitch: usize, src: *const u8) -> Vec<u8> {
+    let row_bytes = width as usize * 4;
+    let mut out = vec![0u8; row_bytes * height as usize];
+    for y in 0..height as usize {
+        // SAFETY: caller-validated `src + y*pitch` stays within the bitmap.
+        let row_ptr = unsafe { src.add(y * pitch) };
+        // SAFETY: `row_ptr..row_ptr + row_bytes` lies in the same allocation.
+        let row = unsafe { core::slice::from_raw_parts(row_ptr, row_bytes) };
+        out[y * row_bytes..(y + 1) * row_bytes].copy_from_slice(row);
+    }
+    out
 }
 
 /// Build a Win32 HCURSOR from a BGRA bitmap.

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -4089,6 +4089,14 @@ extern "system" fn device_present(
     let dev = obj.inner();
 
     mtld3d_shared::crumb!("d3d9:present");
+    // The unix side republishes the backing scale whenever the window's
+    // display changes it, so the cursor upscale follows the window between
+    // displays. One relaxed load and a compare on an unchanged value, which
+    // is every frame that stays put.
+    if let Some(backing_scale) = crate::direct3d9::display_backing_scale() {
+        let (scale, _origin) = crate::direct3d9::resolve_cursor_scale(backing_scale);
+        dev.cursor_mut().follow_scale(scale);
+    }
     dev.cursor_mut().note_present();
     let fresh = dev.fresh_frame();
     dev.present(fresh);

--- a/windows/d3d9/src/direct3d9.rs
+++ b/windows/d3d9/src/direct3d9.rs
@@ -1,4 +1,7 @@
-use core::ffi::c_void;
+use core::{
+    ffi::c_void,
+    sync::atomic::{AtomicU32, Ordering},
+};
 use std::sync::LazyLock;
 
 use log::{error, info, trace, warn};
@@ -41,6 +44,18 @@ use super::{
 // so the list shapes the game's UI dropdown, not actual rendering behaviour.
 // The first entry doubles as the current adapter display mode.
 static ADAPTER_MODES: LazyLock<Vec<D3DDISPLAYMODE>> = LazyLock::new(build_adapter_modes);
+
+/// Backing scale of the display the Metal layer's window is on.
+///
+/// `AttachMetalLayer` hands the unix side this address and it publishes the
+/// scale here, at attach and again whenever its display-follow reconciliation
+/// derives a different one, so a window dragged between a retina panel and a
+/// 1x one moves every consumer with it. A static rather than device-owned
+/// state because the writer is `AppKit`'s main thread running outside any
+/// thunk, which cannot be ordered against a device teardown; one bound layer
+/// exists per process, so one slot answers for it. `0` until the first
+/// attach publishes.
+static DISPLAY_BACKING_SCALE: AtomicU32 = AtomicU32::new(0);
 
 // Common gaming resolutions filtered down to those <= host display. Host
 // native is prepended separately so GetAdapterDisplayMode returns it.
@@ -1354,7 +1369,7 @@ extern "system" fn d3d9_create_device(
         restore_from_fullscreen(fullscreen.as_ref());
         return D3DERR_INVALIDCALL;
     }
-    let (cursor_scale, scale_origin) = resolve_initial_cursor_scale(layer_params.backing_scale);
+    let (cursor_scale, scale_origin) = resolve_cursor_scale(layer_params.backing_scale);
     info!(
         target: LOG_TARGET,
         "hardware cursor scale: {cursor_scale}x ({scale_origin})"
@@ -1569,6 +1584,7 @@ fn attach_metal_layer(
         color_space: crate::config::CONFIG.color_space,
         max_fps: crate::config::CONFIG.present_max_fps,
         metalfx_available: 0,
+        backing_scale_ptr: (&raw const DISPLAY_BACKING_SCALE) as u64,
     };
     if hwnd != 0 {
         unix_call(&mut layer_params);
@@ -1651,21 +1667,32 @@ fn warn_unsupported_backbuffer_format(format: u32) {
     }
 }
 
+/// The backing scale of the display the layer is on, or `None` before attach.
+///
+/// See [`DISPLAY_BACKING_SCALE`]. `Present` reads it once per frame so a
+/// display move reaches the cursor upscale without a thunk of its own.
+pub fn display_backing_scale() -> Option<u32> {
+    match DISPLAY_BACKING_SCALE.load(Ordering::Relaxed) {
+        0 => None,
+        scale => Some(scale),
+    }
+}
+
 /// Match the hardware cursor bitmap to the display's retina factor by default.
 ///
 /// Wine's HCURSOR path then produces a proportionally-sized pointer on a
 /// retina Mac. `cursor.scale` in `mtld3d.conf` overrides: `auto` (the default)
 /// follows `backingScaleFactor`; a positive integer forces a fixed multiplier.
 /// Both paths clamp to `[1, 8]` — the downstream HCURSOR builder asserts that
-/// range.
-fn resolve_initial_cursor_scale(backing_scale: u32) -> (u32, &'static str) {
-    match crate::config::CONFIG.cursor_scale {
-        mtld3d_core::config::CursorScale::Auto => (
-            backing_scale.clamp(1, 8),
-            "auto from display backingScaleFactor",
-        ),
-        mtld3d_core::config::CursorScale::Fixed(n) => (n.clamp(1, 8), "cursor.scale override"),
-    }
+/// range. Resolved again on every display move, so the override keeps
+/// overriding on the display the window arrived at.
+pub fn resolve_cursor_scale(backing_scale: u32) -> (u32, &'static str) {
+    let scale = crate::config::CONFIG.cursor_scale.resolve(backing_scale);
+    let origin = match crate::config::CONFIG.cursor_scale {
+        mtld3d_core::config::CursorScale::Auto => "auto from display backingScaleFactor",
+        mtld3d_core::config::CursorScale::Fixed(_) => "cursor.scale override",
+    };
+    (scale, origin)
 }
 
 /// Resolve `render.scale` against what the GPU can actually do.


### PR DESCRIPTION
## Symptoms

A session that starts on a 120 Hz ProMotion panel and moves to a 60 Hz external display keeps presenting against a 1/120 s minimum duration, so vsync no longer caps at the panel's rate; the reverse leaves a 1/60 s floor on a panel that could show twice as many frames, and the log still reads the rate the session started on. The same move between displays of different `backingScaleFactor` leaves the hardware cursor at the size the first display asked for: dragging a window from a 2x panel to a 1x one keeps a double-sized pointer, and the other direction keeps a half-sized one.

## Root cause

`store_min_present_duration` in `unix/unix/src/metal/macdrv.rs` had two callers, `configure_metal_layer_inner` (attach) and `set_display_sync_enabled` (the D3D9 Reset path). Neither is a display change, so the duration derived from `NSScreen.maximumFramesPerSecond` was fixed at the panel the layer was attached to. `DisplayCaps.backing_scale` was returned once from `attach_metal_layer` and consumed once, by `resolve_initial_cursor_scale` at `CreateDevice`, so nothing could move it afterwards either.

The reconciliation that does follow the window, `refresh_headroom_on_main`, already walks `NSView -> NSWindow -> NSScreen` on every headroom poll and on every real screen-parameters change, and already reconciles the layer's colour configuration against the screen it lands on. Both neighbours were simply not part of it.

## Changes

`unix/unix/src/metal/macdrv.rs` re-derives all three in that one reconciliation. `follow_screen_present_throttle` recomputes the minimum present duration from the screen's refresh ceiling and the pacing latched at attach and at every Reset, and `follow_screen_backing_scale` re-derives the scale and publishes it when it moved. Each writes and logs only on a real change, so a session that stays on one display costs two reads per poll. The pacing rides one packed word rather than two atomics so a Reset landing between two reads cannot hand the reconciliation half of each, and the panel-rate and backing-scale derivations are now single helpers shared with the attach path instead of being restated per call site.

The new backing scale reaches the PE side over `AttachMetalLayerParams::backing_scale_ptr`: the address of a `d3d9.dll` static that the unix side stores into at attach and on every later change. The reconciliation runs on `AppKit`'s main thread, outside any thunk, so it has no thunk return to write into and nothing to order it against a device teardown; a static in the PE image is addressable for the life of the module, where a device-owned allocation would not be. The three latches attach records are dropped by `detach_metal_layer`, alongside the bound-display record and the rest of what a reconciliation derives, so teardown keeps one entry point; both follow paths also early-out while nothing is latched, which covers a teardown landing between the retained view and the re-derivation.

`Present` reads that static once per frame, resolves it through `CursorScale::resolve` (new in `mtld3d-core`, so a `cursor.scale` override keeps overriding on the display the window arrived at) and hands the result to `CursorState::follow_scale`. A changed factor rebuilds the pointer the game is currently showing, from a tight copy of the last bitmap `SetCursorProperties` accepted, and re-realises it. Without that copy the new factor would only reach the screen at the game's next cursor change, which for a title that sets its pointer once is never. The HCURSOR cache key now folds the scale in, so the two displays' bitmaps coexist and a move back reuses the one already built.

## Alternatives

Return the scale as an out field on `SubmitFrameParams`: the value would arrive on the submit thread, one hop away from the `CursorState` on the API thread, needing a second shared atomic to finish the trip that the PE static already is.

Hand over a device-owned `Arc<AtomicU32>` instead of a static, mirroring `coherent_seq_ptr`: those pointers are only dereferenced inside the thunk that carries them, where the PE side holds the allocation alive. This writer outlives every thunk, so the same shape would be a use-after-free waiting on a teardown.

Re-derive the throttle from the layer's own screen inside `set_display_sync_enabled` rather than at the poll: it runs on the encoder thread, and the `NSView -> NSWindow -> NSScreen` walk is main-thread-only. The poll corrects a Reset's `mainScreen` guess within one interval instead.

Rebuild nothing and let the new cursor factor apply from the game's next `SetCursorProperties`: no retained bitmap, but a title that sets its pointer once never picks the change up.

## Verification

`make check` clean. `make test` green on both architectures: 415 end-to-end tests per architecture, identical test sets, 414 PASS and 1 benign LEAK on each, 0 FAIL, 0 SIGABRT, 0 TIMEOUT, plus 970 host-native and 174 unix-side unit tests.

New unit tests, all failing before the change because the helpers they cover did not exist. In `unix/unix/src/metal/macdrv/tests.rs`: `staying_on_one_panel_never_rederives_the_throttle`, `moving_onto_a_slower_panel_lengthens_the_throttle`, `moving_onto_a_faster_panel_shortens_the_throttle`, `a_user_cap_below_both_panels_holds_the_throttle_still`, `a_free_running_session_stays_unthrottled_on_any_panel`, `backing_scale_rounds_and_clamps_into_the_hcursor_range`, `staying_on_one_display_never_republishes_the_scale`, `moving_between_displays_of_different_scale_republishes`, `pacing_survives_the_round_trip_through_one_word`, `the_widest_cap_survives_the_round_trip`. In `windows/core/src/config/tests.rs`: `cursor_scale_auto_follows_the_display`, `cursor_scale_override_ignores_the_display`, `cursor_scale_resolves_into_the_hcursor_range`. `teardown_unbinds_the_display_and_resets_what_it_derived` grows the three latches this change adds, so the one test that owns teardown asserts the whole of what it clears.

`make conformance` reports no regression on either architecture: i686 `device` 767 against a pinned 770, `visual` 221, `stateblock` 0, `d3d9ex` 1; x86_64 `device` 765 against 768, `visual` 219, `stateblock` 0, `d3d9ex` 1. The three that moved on each `device` leg are the flaky pins 4475 and 4480 and the 15088 ceiling, all tolerated, so the baseline is not re-recorded.

The physical move cannot be exercised here, so what a reviewer checks on a two-display setup with panels of different refresh rate and backing scale:

- Drag the window from the ProMotion panel to the 60 Hz one with vsync on. The log gets one `present: '<name>' tops out at 60 Hz, minimum present duration 0.00833s -> 0.01667s` line, and the frame rate settles at the new panel's ceiling. Dragging back gives the mirrored line and the rate returns.
- Set `present.maxFps` below both panels' rates and drag either way. No throttle line at all, because the cap is the lower rate on both displays.
- Drag between a retina panel and a 1x one. The log gets one `present: '<name>' has a 1x backing scale (was 2x), republished to the guest` line followed by `hardware cursor scale: 2x -> 1x`, and the pointer resizes with the window rather than at the game's next cursor change.
- Set `cursor.scale = 3` and repeat. The backing-scale line still appears, the cursor-scale line does not, and the pointer stays at 3x on both displays.
- Stay on one display through a brightness change and a sleep or wake. No throttle, scale or cursor line at all: all three reconcile against a value that did not move.

Closes #319
