### PR TITLE
Stop probing a sampler address mode the device rejects

### DIFF
--- a/unix/conformance/CONFORMANCE.md
+++ b/unix/conformance/CONFORMANCE.md
@@ -55,8 +55,16 @@ looked identical. A `metal-validation:` line therefore means the layer
 committed API misuse, so any of them fails the leg. The expected number is
 zero, kept as a constant in the runner next to the reporting code rather than
 in `baseline.txt`, which records machine-owned per-site counts and nothing
-else. There is no tolerance to keep in step: a leg that logs a line has started
-misusing Metal, and the fix is the misuse, not the number.
+else. There is no tolerance to keep in step: a leg that logs a message has
+started misusing Metal, and the fix is the misuse, not the number.
+
+The layer writes a report as a headline naming the check that fired
+(`Sampler Descriptor Validation`) followed by unadorned detail lines, and the
+detail is the half that names what was rejected. The runner keeps them
+together: a recognised line opens a message and the lines under it are its
+detail, up to the next `NSLog` line, Wine channel line or blank line, so the
+whole report reaches the log indented under its `metal-validation:` line
+instead of only in the raw output. One report counts once.
 
 This is **not** part of `make test`: many checks fail by design (see below), so
 it is a tracked-score tool, not a pass/fail gate on zero. The runner exits

--- a/unix/conformance/src/main.rs
+++ b/unix/conformance/src/main.rs
@@ -138,15 +138,15 @@ fn real_main() -> Result<ExitCode, String> {
 ///
 /// Three independent verdicts, each fatal on its own: a regression vs the
 /// baseline, a baseline that overstates reality, and any Metal API-validation
-/// error line the leg logged. The validation gate is orthogonal to the per-site
-/// counts: a leg that starts misusing Metal while every count holds still has
-/// to fail.
+/// error message the leg logged. The validation gate is orthogonal to the
+/// per-site counts: a leg that starts misusing Metal while every count holds
+/// still has to fail.
 fn verdict(report: &diff::Report, validation_errors: usize) -> ExitCode {
     let validation_failed = run::validation_gate_failed(validation_errors);
     if validation_failed {
         println!(
-            "conformance: METAL VALIDATION - {validation_errors} error line(s) logged; every \
-             metal-validation: line above is API misuse to fix"
+            "conformance: METAL VALIDATION - {validation_errors} error message(s) logged; every \
+             metal-validation: line above, with the detail indented under it, is API misuse to fix"
         );
     }
     if report.regressed {

--- a/unix/conformance/src/run.rs
+++ b/unix/conformance/src/run.rs
@@ -31,19 +31,26 @@ use crate::{
 const DEFAULT_TIMEOUT_SECS: u64 = 180;
 const HEADLESS_DLL_OVERRIDES: &str = "mscoree,mshtml=";
 
-/// How many Metal API-validation error lines a leg may log and still pass.
+/// How many Metal API-validation error messages a leg may log and still pass.
 ///
 /// Zero. The layer's warnings are filtered out (see [`run_subtest`]), so every
-/// line that survives is real API misuse and has to read as a regression
+/// message that survives is real API misuse and has to read as a regression
 /// rather than as noise. The expectation lives beside the reporting code
 /// because `baseline.txt` is machine-owned per-site counts whose parser
 /// rejects anything else.
 const MAX_VALIDATION_ERRORS: usize = 0;
 
+/// How many detail lines one validation message keeps.
+///
+/// Metal's reports run to a handful of them; the cap keeps a stderr that
+/// stopped looking like one from pasting a whole subtest into a single
+/// message. A message that hits it ends in an ellipsis.
+const MAX_DETAIL_LINES: usize = 8;
+
 /// One subtest's outcome.
 ///
 /// The parsed per-site result, plus how many distinct Metal API-validation
-/// error lines the run logged for the caller to gate on.
+/// error messages the run logged for the caller to gate on.
 pub struct SubtestRun {
     /// Failing sites, the crash bit and the marked-failure tallies.
     pub result: SubtestResult,
@@ -51,7 +58,7 @@ pub struct SubtestRun {
     pub validation_errors: usize,
 }
 
-/// Whether the Metal-validation error lines a run logged fail its leg.
+/// Whether the Metal-validation error messages a run logged fail its leg.
 #[must_use]
 pub const fn validation_gate_failed(errors: usize) -> bool {
     errors > MAX_VALIDATION_ERRORS
@@ -254,37 +261,105 @@ fn save_raw_output(arch: Arch, subtest: Subtest, combined: &str) {
 /// Print a deduplicated, number-normalised summary of any Metal API-validation messages.
 ///
 /// The subtest logged them rather than aborting — the layer runs in `nslog`
-/// mode. Returns how many distinct messages were printed, which is what the
-/// leg gates on.
+/// mode. A message prints as its opening line plus its detail lines, indented
+/// under it: the opening line names the check that fired (`Sampler Descriptor
+/// Validation`) and the detail names what failed it. Returns how many distinct
+/// messages were printed, which is what the leg gates on.
 fn report_validation_errors(arch: Arch, subtest: Subtest, stderr: &str) -> usize {
     let seen = validation_errors(stderr);
     for msg in &seen {
-        eprintln!("  [{arch}/{subtest}] metal-validation: {msg}");
+        let mut lines = msg.lines();
+        if let Some(header) = lines.next() {
+            eprintln!("  [{arch}/{subtest}] metal-validation: {header}");
+        }
+        for detail in lines {
+            eprintln!("      {detail}");
+        }
     }
     seen.len()
 }
 
 /// The distinct Metal API-validation error messages in a subtest's stderr.
 ///
-/// Volatile addresses and counts collapse to `N` so a repeated error reports
-/// once. The layer's warnings never reach here (the run switches them off), so
-/// every match is misuse.
+/// A recognised line opens a message and the lines under it are its detail,
+/// which is where the layer names the property it rejected. Volatile addresses
+/// and counts collapse to `N` so a repeated message reports once. The layer's
+/// warnings never reach here (the run switches them off), so every match is
+/// misuse.
 fn validation_errors(stderr: &str) -> BTreeSet<String> {
+    let lines: Vec<&str> = stderr.lines().collect();
     let mut seen: BTreeSet<String> = BTreeSet::new();
-    for line in stderr.lines() {
-        let l = line.trim();
-        let is_validation = l.contains("does not match")
-            || l.contains("is missing from")
-            || l.contains("must be <=")
-            || l.contains("incorrect type of texture")
-            || l.contains("Insufficient")
-            || l.contains("exceeds the limit")
-            || (l.contains(" Validation") && !l.contains("Validation Enabled"));
-        if is_validation {
-            seen.insert(normalize_numbers(l));
+    let mut i = 0;
+    while i < lines.len() {
+        if !opens_validation_message(lines[i].trim()) {
+            i += 1;
+            continue;
         }
+        let mut msg = normalize_numbers(lines[i].trim());
+        i += 1;
+        let mut detail = 0;
+        while i < lines.len() && continues_validation_message(lines[i]) {
+            if detail < MAX_DETAIL_LINES {
+                msg.push('\n');
+                msg.push_str(&normalize_numbers(lines[i].trim()));
+            } else if detail == MAX_DETAIL_LINES {
+                msg.push_str("\n…");
+            }
+            detail += 1;
+            i += 1;
+        }
+        seen.insert(msg);
     }
     seen
+}
+
+/// Whether a line opens a Metal API-validation message.
+///
+/// The layer heads a multi-line report with the check that fired
+/// (`… Validation`) and also emits stand-alone error lines carrying no such
+/// header, so both shapes open one. Its start-up notice is not an error.
+fn opens_validation_message(line: &str) -> bool {
+    line.contains("does not match")
+        || line.contains("is missing from")
+        || line.contains("must be <=")
+        || line.contains("incorrect type of texture")
+        || line.contains("Insufficient")
+        || line.contains("exceeds the limit")
+        || (line.contains(" Validation") && !line.contains("Validation Enabled"))
+}
+
+/// Whether a line is detail under the validation message above it.
+///
+/// The layer writes its detail lines unadorned, so a message runs until
+/// something the run can attribute to another writer: the next `NSLog` line,
+/// a Wine channel line, or a blank line.
+fn continues_validation_message(line: &str) -> bool {
+    let line = line.trim();
+    !line.is_empty() && !is_nslog_line(line) && !is_wine_channel_line(line)
+}
+
+/// Whether a line carries an `NSLog` timestamp (`YYYY-MM-DD HH:MM:SS.mmm …`).
+fn is_nslog_line(line: &str) -> bool {
+    let b = line.as_bytes();
+    b.len() > 10
+        && b[..4].iter().all(u8::is_ascii_digit)
+        && b[4] == b'-'
+        && b[5..7].iter().all(u8::is_ascii_digit)
+        && b[7] == b'-'
+        && b[8..10].iter().all(u8::is_ascii_digit)
+}
+
+/// Whether a line is Wine's own channel output (`0000:err:d3d9:…`).
+fn is_wine_channel_line(line: &str) -> bool {
+    let Some((id, rest)) = line.split_once(':') else {
+        return false;
+    };
+    id.len() >= 4
+        && id.bytes().all(|b| b.is_ascii_hexdigit())
+        && matches!(
+            rest.split(':').next(),
+            Some("err" | "warn" | "fixme" | "trace")
+        )
 }
 
 /// Collapse hex literals (`0x…`) and decimal runs to `N`.

--- a/unix/conformance/src/run/tests.rs
+++ b/unix/conformance/src/run/tests.rs
@@ -1,29 +1,67 @@
 //! Unit tests for the Metal-validation reporting and its gate.
 //!
-//! The recogniser picks the layer's error lines out of a subtest's stderr,
-//! collapses volatile numbers so a repeated error reports once, and leaves
-//! ordinary Wine and Metal chatter alone. The gate then fails a leg for any
-//! line that survives: after the warning filter there is no benign one left.
+//! The recogniser picks the layer's error messages out of a subtest's stderr,
+//! keeps the detail lines under each one, collapses volatile numbers so a
+//! repeated message reports once, and leaves ordinary Wine and Metal chatter
+//! alone. The gate then fails a leg for any message that survives: after the
+//! warning filter there is no benign one left.
 
 use super::{normalize_numbers, validation_errors, validation_gate_failed};
 
-/// Two draw-error lines the mismatched-sampler-type case used to log, verbatim.
+/// The two draw errors the mismatched-sampler-type case logged, verbatim.
 const MISMATCHED_SAMPLER: &str = "\
 0000:err:d3d9: something unrelated\n\
-Draw Errors Validation\n\
+2026-08-28 11:59:31.778 wine[27403:71732] Draw Errors Validation\n\
 Fragment Function(mtld3d_ps_sm3_29b0ab41fc8da9b1): incorrect type of texture (MTLTextureType2D) bound at Texture binding at index 0 (expect MTLTextureType3D) for s0[0].\n\
 Fragment Function(mtld3d_ps_sm3_fab23e4e59af0b3b): incorrect type of texture (MTLTextureType3D) bound at Texture binding at index 0 (expect MTLTextureType2D) for s0[0].\n";
 
+/// The rejected sampler descriptor a paravirtual GPU logged, verbatim.
+const REJECTED_SAMPLER_DESCRIPTOR: &str = "\
+2026-08-28 11:59:28.959 wine[27403:71131] Metal API Validation Enabled\n\
+2026-08-28 11:59:31.778 wine[27403:71732] Sampler Descriptor Validation\n\
+MTLSamplerAddressModeMirrorClampToEdge is not supported on this device\n";
+
 #[test]
-fn draw_error_lines_are_collected() {
+fn draw_errors_are_detail_of_one_message() {
     let seen = validation_errors(MISMATCHED_SAMPLER);
-    assert_eq!(seen.len(), 3, "the banner and both draw errors: {seen:?}");
+    assert_eq!(seen.len(), 1, "one report, not one per line: {seen:?}");
+    let msg = seen.iter().next().unwrap();
+    assert_eq!(msg.lines().count(), 3, "banner and both draw errors: {msg}");
     assert!(validation_gate_failed(seen.len()));
 }
 
 #[test]
+fn the_rejected_property_is_kept() {
+    let seen = validation_errors(REJECTED_SAMPLER_DESCRIPTOR);
+    assert_eq!(seen.len(), 1, "{seen:?}");
+    let msg = seen.iter().next().unwrap();
+    assert!(
+        msg.contains("Sampler Descriptor Validation")
+            && msg.contains("MTLSamplerAddressModeMirrorClampToEdge is not supported"),
+        "the header alone does not say which property was rejected: {msg}"
+    );
+}
+
+#[test]
+fn a_message_ends_at_the_next_writer() {
+    let stderr = "\
+2026-08-28 11:59:31.778 wine[27403:71732] Sampler Descriptor Validation\n\
+MTLSamplerAddressModeMirrorClampToEdge is not supported on this device\n\
+0000:err:d3d9: unrelated, and not this message's detail\n\
+2026-08-28 11:59:32.001 wine[27403:71732] Buffer Validation\n\
+Insufficient buffer size at buffer binding at index 2\n";
+    let seen = validation_errors(stderr);
+    assert_eq!(seen.len(), 2, "{seen:?}");
+    assert!(
+        seen.iter().all(|msg| !msg.contains("unrelated")),
+        "a Wine channel line was swallowed as detail: {seen:?}"
+    );
+}
+
+#[test]
 fn one_error_repeated_per_draw_reports_once() {
-    let line = "Buffer Validation: Insufficient buffer size at buffer binding at index 2";
+    let line = "2026-08-28 11:59:31.778 wine[27403:71732] Buffer Validation: \
+                Insufficient buffer size at buffer binding at index 2";
     let stderr = format!("{line} 0x600002a1c000\n{line} 0x600002b40480\n");
     assert_eq!(validation_errors(&stderr).len(), 1);
 }

--- a/unix/unix/src/metal/device.rs
+++ b/unix/unix/src/metal/device.rs
@@ -57,9 +57,30 @@ pub fn default_device_info() -> Option<(String, u64, DeviceCapsFlags)> {
 ///
 /// On paper a Mac2-family feature, but the paravirtualized device on CI
 /// runners claims Mac2 and still aborts sampler creation on a border
-/// colour, so the device name is checked as well.
+/// colour, so the device is checked for that as well.
 pub fn supports_sampler_border(device: &ProtocolObject<dyn MTLDevice>) -> bool {
-    device.supportsFamily(MTLGPUFamily::Mac2) && !device.name().to_string().contains("Paravirtual")
+    device.supportsFamily(MTLGPUFamily::Mac2) && !is_paravirtual(device)
+}
+
+/// True when the device implements the `MirrorClampToEdge` address mode.
+///
+/// Every GPU family macOS runs on implements it and Metal offers no query for
+/// it, so the paravirtualized device is the whole predicate: it rejects the
+/// descriptor with `MTLSamplerAddressModeMirrorClampToEdge is not supported on
+/// this device`. The sampler path substitutes `MirrorRepeat` when this is
+/// false, up front, because the rejected creation is API misuse the validation
+/// layer logs whether or not a retry succeeds.
+pub fn supports_sampler_mirror_clamp(device: &ProtocolObject<dyn MTLDevice>) -> bool {
+    !is_paravirtual(device)
+}
+
+/// True when the Metal device is the paravirtualized one a CI runner exposes.
+///
+/// It answers `supportsFamily:` like the Mac2 device it stands in for while
+/// implementing less than one, so a feature it is known to reject is gated on
+/// its name instead.
+fn is_paravirtual(device: &ProtocolObject<dyn MTLDevice>) -> bool {
+    device.name().to_string().contains("Paravirtual")
 }
 
 /// True when the packed 16-bit pixel formats exist natively on this device.

--- a/unix/unix/src/metal/sampler.rs
+++ b/unix/unix/src/metal/sampler.rs
@@ -10,7 +10,7 @@ use objc2_metal::{
 };
 
 use crate::metal::{
-    device::supports_sampler_border,
+    device::{supports_sampler_border, supports_sampler_mirror_clamp},
     handle::{IntoRetained, ReleaseRetain},
 };
 
@@ -35,6 +35,14 @@ pub fn create_sampler_state(
     let uses_border = matches!(params.address_u, AddressMode::ClampToBorderColor)
         || matches!(params.address_v, AddressMode::ClampToBorderColor)
         || matches!(params.address_w, AddressMode::ClampToBorderColor);
+    // A device without `MirrorClampToEdge` (D3DTADDRESS_MIRRORONCE) gets
+    // `MirrorRepeat`, which agrees with MIRRORONCE inside |coord| <= 1, where
+    // content actually samples, and only diverges beyond it — so the D3D9 cap
+    // stays advertised everywhere and no title has to check it. The
+    // substitution happens before the descriptor is built rather than after a
+    // rejected creation, because a creation the device refuses is API misuse
+    // the validation layer logs whether or not a retry then succeeds.
+    let mirror_clamp_ok = supports_sampler_mirror_clamp(&device);
     let address = |wire: AddressMode| {
         if !border_ok && matches!(wire, AddressMode::ClampToBorderColor) {
             mtld3d_shared::log_once_warn!(
@@ -42,6 +50,13 @@ pub fn create_sampler_state(
                 "sampler border addressing unsupported on this device — clamped to edge"
             );
             return MTLSamplerAddressMode::ClampToEdge;
+        }
+        if !mirror_clamp_ok && matches!(wire, AddressMode::MirrorClampToEdge) {
+            mtld3d_shared::log_once_warn!(
+                target: crate::LOG_TARGET,
+                "sampler: MirrorClampToEdge unsupported on this device — falling back to MirrorRepeat"
+            );
+            return MTLSamplerAddressMode::MirrorRepeat;
         }
         mtl_address_mode(wire)
     };
@@ -106,30 +121,7 @@ pub fn create_sampler_state(
         objc2_foundation::NSString::from_str(&format!("mtld3d-{label_kind}-{:#x}", params.id));
     desc.setLabel(Some(&label));
 
-    let mut sampler = device.newSamplerStateWithDescriptor(&desc);
-    if sampler.is_none() && uses_mirror_clamp(params) {
-        // `MirrorClampToEdge` (D3DTADDRESS_MIRRORONCE) is unimplemented on
-        // some Metal devices — a GitHub runner's paravirtual GPU rejects the
-        // descriptor outright. Retry with `MirrorRepeat`, which matches
-        // MIRRORONCE inside |coord| <= 1 (where content actually samples)
-        // and only diverges beyond it.
-        mtld3d_shared::log_once_warn!(
-            target: crate::LOG_TARGET,
-            "sampler: MirrorClampToEdge unsupported on this device — falling back to MirrorRepeat"
-        );
-        let fix = |mode: AddressMode| {
-            if mode == AddressMode::MirrorClampToEdge {
-                MTLSamplerAddressMode::MirrorRepeat
-            } else {
-                mtl_address_mode(mode)
-            }
-        };
-        desc.setSAddressMode(fix(params.address_u));
-        desc.setTAddressMode(fix(params.address_v));
-        desc.setRAddressMode(fix(params.address_w));
-        sampler = device.newSamplerStateWithDescriptor(&desc);
-    }
-    let Some(sampler) = sampler else {
+    let Some(sampler) = device.newSamplerStateWithDescriptor(&desc) else {
         mtld3d_shared::log_once_warn!(
             target: crate::LOG_TARGET,
             "sampler: newSamplerStateWithDescriptor failed (id={:#x}) — draws with this sampler bind nothing",
@@ -139,14 +131,6 @@ pub fn create_sampler_state(
     };
     // SAFETY: Retained::into_raw transfers the retain into the typed handle.
     Some(unsafe { MetalHandle::<MTLSamplerStateKind>::new(Retained::into_raw(sampler) as u64) })
-}
-
-/// Whether any of the three address modes is `MirrorClampToEdge`.
-#[inline]
-fn uses_mirror_clamp(params: &CreateSamplerStateParams) -> bool {
-    params.address_u == AddressMode::MirrorClampToEdge
-        || params.address_v == AddressMode::MirrorClampToEdge
-        || params.address_w == AddressMode::MirrorClampToEdge
 }
 
 /// Release a Metal sampler-state handle.

--- a/windows/core/src/caps.rs
+++ b/windows/core/src/caps.rs
@@ -224,7 +224,12 @@ const FILTER_DEFAULT: FilterCaps = FilterCaps::MINFPOINT
 /// All six, including `MIRRORONCE` (`D3DTADDRESS_MIRRORONCE`), which
 /// `convert::d3d_to_metal_address_mode` maps to
 /// `AddressMode::MirrorClampToEdge` through the same code path as the other
-/// four modes.
+/// four modes. `MIRRORONCE` stays advertised on a device that does not
+/// implement that Metal address mode (the paravirtualized one a CI runner
+/// exposes): the sampler path substitutes `MirrorRepeat`, which agrees with
+/// MIRRORONCE wherever content samples. `BORDER` is the one mode that comes
+/// back out below, because clamping to edge instead is visible in the image a
+/// title that asked for a border colour gets.
 const ADDRESS_DEFAULT: AddressCaps = AddressCaps::WRAP
     .union(AddressCaps::MIRROR)
     .union(AddressCaps::CLAMP)


### PR DESCRIPTION
## Symptoms

Both conformance legs have been red on CI since the Metal-validation gate landed, on exactly one line, while every site held its pin:

```
  [i686/visual] metal-validation: N-N-N N:N:N.N wine[N:N] Sampler Descriptor Validation
conformance: METAL VALIDATION - 1 error line(s) logged
```

The line names no property. Metal writes a report as a headline plus unadorned detail lines, and the runner recognised validation output one line at a time: the detail carried none of the recognised phrases, so it was dropped. Only the `conformance-raw-<arch>` artifact had it:

```
2026-08-28 11:59:31.778 wine[27403:71732] Sampler Descriptor Validation
MTLSamplerAddressModeMirrorClampToEdge is not supported on this device
```

## Root cause

The misuse is ours. `create_sampler_state` built the descriptor with `MirrorClampToEdge` and only retried with `MirrorRepeat` once the device had refused it, so on a GPU without that address mode (the paravirtualized one a CI runner exposes) every sampler creation walked through a rejected descriptor first. The validation layer logs the refusal whether or not the retry succeeds, so a try-then-fall-back can never be quiet under it.

## Changes

The unix side decides up front. `supports_sampler_mirror_clamp` joins `supports_sampler_border` on the device, both gated on the same paravirtual check, and the address-mode closure substitutes `MirrorRepeat` there beside the border-colour substitution that was already handled that way. The retry and its helper are gone.

The D3D9 cap set does not move: `MirrorRepeat` agrees with MIRRORONCE inside `|coord| <= 1`, where content actually samples, so `D3DPTADDRESSCAPS_MIRRORONCE` stays advertised on every device and no title has to check it. Border addressing keeps de-advertising itself, because clamping to edge instead is visible in the image; the `ADDRESS_DEFAULT` doc comment now says why the two are treated differently.

The runner keeps a report together: a recognised line opens a message and the lines under it are its detail, up to the next NSLog line, Wine channel line or blank line, capped so a stderr that stopped looking like one cannot paste a subtest into a single message. The whole report reaches the log, indented under its `metal-validation:` line, and one report counts once instead of once per line that happened to match.

## Alternatives

An allow-list, or a CI-only downgrade of the validation verdict, for a line the runner's GPU alone produces: rejected, it re-hides exactly what the gate exists to surface, and reading CI in the runner would be a new environment variable.

De-advertising MIRRORONCE the way BORDER is de-advertised: rejected, the substitution is not observable where content samples, so the cap would cost titles a mode they can have.

Recognising Metal's detail lines by adding their phrases to the per-line filter: rejected, the phrases are per-check, and the next unknown one would truncate the same way.

## Verification

`make check` clean. `make test` green: 988 windows unit, 176 unix unit, 425 e2e per arch.

Three runner cases fail before this change and pass after: `the_rejected_property_is_kept` (the detail line is dropped, so the message names no property), `draw_errors_are_detail_of_one_message` and `a_message_ends_at_the_next_writer` (one report counted three times).

`make conformance` green on both arches, no `metal-validation:` line and no site moved. That run covers `test_cube_wrap`, which walks all five address modes. Apple Silicon implements `MirrorClampToEdge`, so the substitution itself can only be confirmed by the conformance legs on this PR going green.

Closes #337
