### PR TITLE
Capture three frames per F12 press, log the frame dump for the same frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,19 @@ fallback paths, `error!` for unexpected internal failures, `trace!` for
 per-call breadcrumbs, `debug!` for routine per-call noise useful in deep
 debugging.
 
+Pressing F12 in a game records the next three frames twice over. The log
+gets one `[dump]` line at info level for every D3D9 event of those frames
+that a GPU trace cannot show: render-target, depth-stencil, viewport and
+scissor changes, clears, surface copies, occlusion query traffic, and every
+draw with the states that decide its pass shape, its shaders and its
+textures. At the same time a Metal GPU trace of the same frames lands at
+`/tmp/mtld3d_capture.gputrace`, overwritten by the next press; the process
+needs `MTL_CAPTURE_ENABLED=1` in its environment for that half (the launcher
+passes it through), otherwise the log says so and the dump still runs. The
+two sides name each other: each `frame end` line carries the label of the
+frame's command buffer, and every dumped draw sits in a `draw N` debug group
+in the trace, so `gpudebug`'s `find` or Xcode's search lands on it directly.
+
 Each cdylib initializes the logger independently and idempotently; `mtld3d.so`
 has no owning entry point, so `d3d9.dll` dispatches a one-shot `InitLogger`
 thunk from its init path.

--- a/unix/shared/src/commands.rs
+++ b/unix/shared/src/commands.rs
@@ -110,6 +110,15 @@ pub enum CommandType {
     /// it as a shader argument is what lets the upload ignore the linear
     /// texture row alignment a blit copy would have to satisfy.
     SetFragmentBuffer = 24,
+    /// `encoder.pushDebugGroup("draw N")`
+    ///
+    /// Emitted only while the F12 frame dump runs, around the Metal draw
+    /// of dumped draw `param_a`, so the `[dump] draw N` log line and the
+    /// draw's node in a GPU trace name each other. Costs nothing when no
+    /// dump is armed.
+    PushDebugGroup = 25,
+    /// `encoder.popDebugGroup()`, closing a [`CommandType::PushDebugGroup`].
+    PopDebugGroup = 26,
 }
 
 /// Dimensionality of the opaque-black texture a null-texture bind selects.
@@ -479,6 +488,30 @@ impl Command {
         Self {
             cmd: CommandType::SetStencilReference as u32,
             param_a: value,
+            param_b: 0,
+            param_c: 0,
+            param_d: 0,
+        }
+    }
+
+    /// `encoder.pushDebugGroup("draw {draw_index}")`, a frame-dump marker.
+    #[must_use]
+    pub const fn push_debug_group(draw_index: u32) -> Self {
+        Self {
+            cmd: CommandType::PushDebugGroup as u32,
+            param_a: draw_index,
+            param_b: 0,
+            param_c: 0,
+            param_d: 0,
+        }
+    }
+
+    /// `encoder.popDebugGroup()`, closing the frame-dump marker.
+    #[must_use]
+    pub const fn pop_debug_group() -> Self {
+        Self {
+            cmd: CommandType::PopDebugGroup as u32,
+            param_a: 0,
             param_b: 0,
             param_c: 0,
             param_d: 0,

--- a/unix/shared/src/commands/tests.rs
+++ b/unix/shared/src/commands/tests.rs
@@ -229,6 +229,20 @@ fn set_stencil_reference_roundtrip() {
 }
 
 #[test]
+fn debug_group_roundtrip() {
+    let push = Command::push_debug_group(345);
+    assert_eq!(push.cmd, CommandType::PushDebugGroup as u32);
+    assert_eq!(push.param_a, 345);
+    let pop = Command::pop_debug_group();
+    assert_eq!(pop.cmd, CommandType::PopDebugGroup as u32);
+    assert_eq!(
+        CommandType::from_repr(25),
+        Some(CommandType::PushDebugGroup)
+    );
+    assert_eq!(CommandType::from_repr(26), Some(CommandType::PopDebugGroup));
+}
+
+#[test]
 fn set_blend_color_roundtrip() {
     let cmd = Command::set_blend_color(0.25, 0.5, 0.75, 1.0);
     assert_eq!(cmd.cmd, CommandType::SetBlendColor as u32);

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -2127,9 +2127,25 @@ fn encode_pass(
             )
         };
 
+        // Frame-dump debug groups open around a draw. A push whose draw the
+        // PE side then dropped never gets its pop, so the depth is tracked
+        // here and any group still open is closed before `endEncoding`.
+        let mut debug_group_depth: u32 = 0;
         for (i, cmd) in commands.iter().enumerate() {
             mtld3d_shared::crumb!("pass:cmd", u64::from(cmd.cmd), i as u64);
             match CommandType::from_repr(cmd.cmd) {
+                Some(CommandType::PushDebugGroup) => {
+                    let label =
+                        objc2_foundation::NSString::from_str(&format!("draw {}", cmd.param_a));
+                    encoder.pushDebugGroup(&label);
+                    debug_group_depth += 1;
+                }
+                Some(CommandType::PopDebugGroup) => {
+                    if debug_group_depth > 0 {
+                        encoder.popDebugGroup();
+                        debug_group_depth -= 1;
+                    }
+                }
                 Some(CommandType::SetRenderPipelineState) => {
                     // SAFETY: cmd.param_b is a previously-retained MTLRenderPipelineState address.
                     let Some(pipeline) =
@@ -2599,6 +2615,9 @@ fn encode_pass(
                     mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET, "unknown command type {t}", t = cmd.cmd);
                 }
             }
+        }
+        for _ in 0..debug_group_depth {
+            encoder.popDebugGroup();
         }
     }
 

--- a/windows/core/src/present.rs
+++ b/windows/core/src/present.rs
@@ -40,5 +40,18 @@ pub const fn display_sync_for(interval: u32) -> DisplaySync {
     }
 }
 
+/// Which capture marks frame `index` of a `total`-frame diagnostic run carries.
+///
+/// Returns `(start, stop)`: the first frame of the run starts the GPU
+/// capture, the last one stops it, and a one-frame run does both. Frames
+/// are numbered from 1; an index outside the run carries nothing.
+#[must_use]
+pub const fn capture_marks(index: u32, total: u32) -> (bool, bool) {
+    if index == 0 || index > total {
+        return (false, false);
+    }
+    (index == 1, index == total)
+}
+
 #[cfg(test)]
 mod tests;

--- a/windows/core/src/present/tests.rs
+++ b/windows/core/src/present/tests.rs
@@ -41,3 +41,24 @@ fn enabled_polarity() {
     assert!(!DisplaySync::Off.enabled());
     assert!(DisplaySync::Fallthrough.enabled());
 }
+
+#[test]
+fn capture_marks_bracket_the_run() {
+    use super::capture_marks;
+    assert_eq!(capture_marks(1, 3), (true, false));
+    assert_eq!(capture_marks(2, 3), (false, false));
+    assert_eq!(capture_marks(3, 3), (false, true));
+}
+
+#[test]
+fn capture_marks_one_frame_run_starts_and_stops() {
+    use super::capture_marks;
+    assert_eq!(capture_marks(1, 1), (true, true));
+}
+
+#[test]
+fn capture_marks_outside_the_run_carry_nothing() {
+    use super::capture_marks;
+    assert_eq!(capture_marks(0, 3), (false, false));
+    assert_eq!(capture_marks(4, 3), (false, false));
+}

--- a/windows/d3d9/src/capture.rs
+++ b/windows/d3d9/src/capture.rs
@@ -1,32 +1,36 @@
-//! F12 hotkey poll for one-shot Metal GPU frame capture.
+//! F12 hotkey poll: one press arms the frame dump and the Metal GPU capture.
 //!
-//! Apple gates capture itself on `MTL_CAPTURE_ENABLED=1` at process
-//! launch — no mtld3d-side env guard needed; without the Apple env, the
-//! unix-side `start_capture` handler logs a warn and returns. Polling
-//! cost is one `GetAsyncKeyState` syscall per `Present()` (~100 ns),
-//! free in practice.
+//! Both diagnostics cover the same [`FrameDump::FRAMES`] consecutive frames
+//! (see `device::frame_dump`): the dump logs the D3D9-level events a GPU
+//! trace cannot know, the trace holds everything Metal saw, and the dump's
+//! draw numbering and frame labels name the trace's nodes.
 //!
-//! Flow: `device_present` → `poll()` → on F12 rising-edge sets
-//! `CAPTURE_REQUESTED`. The encoder thread reads + clears the flag at
-//! the next frame and brackets `run_frame` with `StartGpuCapture` /
-//! `StopGpuCapture` thunks. Output is `/tmp/mtld3d_capture.gputrace`.
+//! Apple gates the capture itself on `MTL_CAPTURE_ENABLED=1` at process
+//! launch, so there is no mtld3d-side env guard; without the Apple env the
+//! unix-side `start_capture` handler logs a warn and returns, and the dump
+//! still runs. Polling cost is one `GetAsyncKeyState` syscall per
+//! `Present()` (~100 ns), free in practice.
+//!
+//! A plain function key is a weak trigger on a Mac (F11 is the system's
+//! "show desktop" key, others double as media keys); F12 is the one Apple
+//! leaves alone and the one Xcode uses for the same purpose.
+//!
+//! Flow: `device_present` → `poll()` → on the F12 rising edge sets
+//! `CAPTURE_REQUESTED`; the same `Present` takes it through
+//! `take_request()` and arms `frame_dump_present`, which marks the first
+//! and last frame of the run with `FrameDataFlags::GPU_CAPTURE_START` /
+//! `GPU_CAPTURE_STOP`. The encoder thread brackets those frames with the
+//! `StartGpuCapture` / `StopGpuCapture` thunks. Output is
+//! `/tmp/mtld3d_capture.gputrace`, overwritten per press.
+//!
+//! [`FrameDump::FRAMES`]: crate::device::frame_dump::FrameDump::FRAMES
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
 const VK_F12: i32 = 0x7B;
-const VK_SHIFT: i32 = 0x10;
-const VK_CONTROL: i32 = 0x11;
-/// The `D` key: Ctrl+Shift+D arms the one-frame draw-state dump.
-///
-/// A plain function key is a bad trigger on a Mac: F11 is the system's
-/// "show desktop" key, and others double as media keys.
-const VK_D: i32 = 0x44;
 
 static CAPTURE_REQUESTED: AtomicBool = AtomicBool::new(false);
 static F12_DOWN_LAST: AtomicBool = AtomicBool::new(false);
-/// Ctrl+Shift+D asked for a one-frame draw-state dump (`device::frame_dump`).
-static FRAME_DUMP_REQUESTED: AtomicBool = AtomicBool::new(false);
-static DUMP_CHORD_DOWN_LAST: AtomicBool = AtomicBool::new(false);
 
 #[link(name = "user32")]
 unsafe extern "system" {
@@ -39,28 +43,18 @@ fn key_down(vkey: i32) -> bool {
     unsafe { GetAsyncKeyState(vkey) }.cast_unsigned() & 0x8000 != 0
 }
 
-/// Poll the trigger keys once per present, firing on the press transition.
+/// Poll the trigger key once per present, firing on the press transition.
 ///
-/// Idempotent across frames where a key is held down.
+/// Idempotent across frames where the key is held down.
 pub fn poll() {
     let down = key_down(VK_F12);
     let was_down = F12_DOWN_LAST.swap(down, Ordering::Relaxed);
     if down && !was_down {
         CAPTURE_REQUESTED.store(true, Ordering::Release);
     }
-    let chord = key_down(VK_CONTROL) && key_down(VK_SHIFT) && key_down(VK_D);
-    let was_chord = DUMP_CHORD_DOWN_LAST.swap(chord, Ordering::Relaxed);
-    if chord && !was_chord {
-        FRAME_DUMP_REQUESTED.store(true, Ordering::Release);
-    }
 }
 
-/// Take the pending Ctrl+Shift+D request, if any; the next frame is then dumped.
-pub fn take_frame_dump_request() -> bool {
-    FRAME_DUMP_REQUESTED.swap(false, Ordering::AcqRel)
-}
-
-/// Encoder-thread side: read-and-clear. Returns true once per F12 press.
+/// Take the pending F12 request, if any; the next frames are then dumped and captured.
 pub fn take_request() -> bool {
     CAPTURE_REQUESTED.swap(false, Ordering::AcqRel)
 }

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -87,8 +87,8 @@ use super::{
         arena_alloc_bytes, build_alpha_ref_bytes, bump_packed_stage_bindings,
     },
     encoder::{
-        BlitSide, ColorFillTarget, EncoderThread, FrameData, FrameEncoder, FrameInit, Op,
-        StagingWarmupEntry, SubmitFence, TextureInfo, VbibWarmupEntry,
+        BlitSide, ColorFillTarget, EncoderThread, FrameData, FrameDataFlags, FrameEncoder,
+        FrameInit, Op, StagingWarmupEntry, SubmitFence, TextureInfo, VbibWarmupEntry,
     },
     index_buffer::{Direct3DIndexBuffer9, IndexBufferCreateInfo},
     null_out,
@@ -664,7 +664,7 @@ pub struct DeviceInner {
     /// every frame starts with `snapshot_dirty == all()` so every field is
     /// freshly populated before the cached state is composed.
     snapshot_cache: CurrentSnapshot,
-    /// The Ctrl+Shift+D one-frame draw-state dump, see `frame_dump`.
+    /// The F12 draw-state dump, see `frame_dump`.
     frame_dump: frame_dump::FrameDump,
     /// Cached `bound_texture_mask` from the most recent `STAGES` rebuild.
     ///
@@ -1398,10 +1398,27 @@ impl DeviceInner {
 
     /// Stamp per-frame counters + `submit_seq` onto `frame`, swap it in for `current_frame`.
     ///
-    /// Returns the stamped outgoing frame ready to hand to the encoder.
-    /// Shared between `Present` and `flush_current_frame_blocking`.
-    fn stamp_and_swap(&mut self, new_frame: FrameData, no_present: bool) -> FrameData {
+    /// Returns the stamped outgoing frame ready to hand to the encoder and
+    /// the `submit_seq` it carries. Shared between `Present` and
+    /// `flush_current_frame_blocking`.
+    fn stamp_and_swap(&mut self, new_frame: FrameData, no_present: bool) -> (FrameData, u64) {
         let mut frame = core::mem::replace(&mut self.current_frame, new_frame);
+        // An F12 run ends with the frame the closing `Present` submits. A
+        // mid-frame flush sends the marked frame out early, so its stop mark
+        // moves onto the continuation; the start mark stays with the first
+        // piece, the encoder keeps capturing until it sees the stop.
+        // `reseed_current_frame` (Reset) replaces the continuation without
+        // passing through here, so a Reset inside a dumped run drops the
+        // migrated stop and the capture ends with the process instead.
+        if no_present
+            && frame
+                .gpu_capture_marks()
+                .contains(FrameDataFlags::GPU_CAPTURE_STOP)
+        {
+            frame.clear_gpu_capture_stop();
+            self.current_frame
+                .mark_gpu_capture(FrameDataFlags::GPU_CAPTURE_STOP);
+        }
         // Pre-reserve the new frame's ops Vec to the running peak so
         // it never reallocs in steady-state — and so that a post-burst
         // dip doesn't shrink capacity (causing the next burst to
@@ -1469,7 +1486,7 @@ impl DeviceInner {
         {
             self.push_depth_binding_op(binding, is_sampleable, has_stencil, sample_count);
         }
-        frame
+        (frame, this_seq)
     }
 
     /// Submit the current frame's accumulated ops synchronously.
@@ -1481,7 +1498,7 @@ impl DeviceInner {
     /// is not consumed.
     pub fn flush_current_frame_blocking(&mut self) {
         let fresh = self.fresh_frame();
-        let frame = self.stamp_and_swap(fresh, true);
+        let (frame, _) = self.stamp_and_swap(fresh, true);
         self.encoder.mid_frame_submit(frame);
     }
 
@@ -1705,7 +1722,7 @@ impl DeviceInner {
     /// release.
     pub fn mid_frame_submit_for_retention(&mut self) {
         let fresh = self.fresh_frame();
-        let frame = self.stamp_and_swap(fresh, true);
+        let (frame, _) = self.stamp_and_swap(fresh, true);
         self.encoder.mid_frame_submit_for_retention(frame);
     }
 
@@ -1766,7 +1783,7 @@ impl DeviceInner {
         // Both `IDirect3DDevice9::Present` and the swap chain's land here, so
         // the diagnostics that run once per frame poll from this point.
         crate::capture::poll();
-        let frame = self.stamp_and_swap(new_frame, false);
+        let (frame, seq) = self.stamp_and_swap(new_frame, false);
 
         // The block we measure belongs to the frame that will next be
         // observed by the encoder — the one we just swapped in. The
@@ -1774,7 +1791,7 @@ impl DeviceInner {
         // when it drops at end of scope.
         let _stall = CycleSetTimer::start(self.current_frame.perf_mut().present_block_cycles_ptr());
         self.encoder.send_frame(frame);
-        self.frame_dump_present(crate::capture::take_frame_dump_request());
+        self.frame_dump_present(crate::capture::take_request(), seq);
         self.mem_watch_present();
     }
 
@@ -7920,22 +7937,6 @@ extern "system" fn device_set_render_target(
             "SetRenderTarget({index}, {})",
             frame_dump::surface_label(surface)
         ));
-        // Extra targets feed later passes (a deferred G-buffer's side
-        // planes), and small offscreen targets hold derived data (visibility
-        // probes, sky maps) consumed out of band; queue both for the
-        // frame-end content readback.
-        if !surface.is_null() {
-            // SAFETY: `surface` is a live IDirect3DSurface9 per the ABI.
-            let parent = unsafe { (*surface.cast::<Direct3DSurface9>()).parent_texture() };
-            if !parent.is_null() {
-                // SAFETY: a surface keeps its parent texture alive.
-                let tex = unsafe { &*parent };
-                let small = tex.inner().mip_width(0) <= 512 && tex.inner().mip_height(0) <= 512;
-                if index > 0 || small {
-                    dev.frame_dump_note_readback(tex);
-                }
-            }
-        }
     }
 
     if surface.is_null() {
@@ -8784,6 +8785,12 @@ extern "system" fn device_set_viewport(this: *mut c_void, viewport: *const c_voi
         rec.record(StateOp::Viewport(v));
         return D3D_OK;
     }
+    if dev.frame_dump.active {
+        dev.frame_dump_event(&format!(
+            "SetViewport {},{}+{}x{} z=[{},{}]",
+            v.x, v.y, v.width, v.height, v.min_z, v.max_z
+        ));
+    }
     dev.set_viewport(v);
     D3D_OK
 }
@@ -9504,6 +9511,11 @@ extern "system" fn device_set_scissor_rect(this: *mut c_void, rect: *const c_voi
     if let Some(rec) = dev.recording_state_block_mut() {
         rec.record(StateOp::ScissorRect([rect_x, rect_y, rect_w, rect_h]));
         return D3D_OK;
+    }
+    if dev.frame_dump.active {
+        dev.frame_dump_event(&format!(
+            "SetScissorRect [{rect_x},{rect_y},{rect_w},{rect_h}]"
+        ));
     }
     dev.set_scissor_rect([rect_x, rect_y, rect_w, rect_h]);
     // scissor_rect is the only piece of RenderStateSnapshot affected.
@@ -10275,6 +10287,11 @@ fn bump_const_delta(
 fn emit_snapshot_deltas(obj: &Direct3DDevice9) {
     let dirty = obj.inner().snapshot_dirty;
     if dirty.is_empty() {
+        // A draw with the same state as its predecessor still gets its dump
+        // line and its trace marker; the cached snapshot is its state.
+        if obj.inner().frame_dump.active {
+            obj.inner().frame_dump_draw();
+        }
         return;
     }
 

--- a/windows/d3d9/src/device/frame_dump.rs
+++ b/windows/d3d9/src/device/frame_dump.rs
@@ -1,18 +1,24 @@
-//! One-frame per-draw state dump, armed by Ctrl+Shift+D (see `crate::capture`).
+//! Per-draw D3D9 state dump for a short run of frames, armed by F12 (see `crate::capture`).
 //!
 //! The silent-write audit reports the states a game sets that we never
 //! read; it cannot tell whether a consumed state produced the pass the game
-//! meant. This dump lists, for exactly one frame, every render-target and
-//! depth-stencil bind, every clear and every draw with the states that
-//! decide pass shape (depth, stencil, blend, cull, colour mask, alpha test,
-//! bias), the bound shaders and the bound textures. It logs at info level,
-//! so a play session needs no environment change: press Ctrl+Shift+D, read the log.
+//! meant. This dump lists, for [`FrameDump::FRAMES`] consecutive frames,
+//! every render-target and depth-stencil bind, viewport and scissor change,
+//! clear, copy, query and draw with the states that decide pass shape
+//! (depth, stencil, blend, cull, colour mask, alpha test, bias), the bound
+//! shaders and the bound textures. It logs at info level, so a play session
+//! needs no environment change: press F12, read the log.
+//!
+//! The same press captures the same frames into a Metal GPU trace, which
+//! holds everything the dump deliberately leaves out (pipeline state,
+//! bindings, buffer and texture bytes, shader source, load/store actions).
+//! The two name each other: the frame end line carries the label of the
+//! frame's command buffer, and every dumped draw sits in a `draw N` debug
+//! group in the trace.
 
 use core::ffi::c_void;
 
 use log::info;
-use mtld3d_core::page_box::PageBox;
-use mtld3d_shared::MetalHandle;
 use mtld3d_types::{
     D3DRS_ALPHABLENDENABLE, D3DRS_ALPHAFUNC, D3DRS_ALPHAREF, D3DRS_ALPHATESTENABLE, D3DRS_BLENDOP,
     D3DRS_BLENDOPALPHA, D3DRS_CCW_STENCILFAIL, D3DRS_CCW_STENCILFUNC, D3DRS_CCW_STENCILPASS,
@@ -29,6 +35,7 @@ use super::{DepthBinding, DeviceInner, RtBinding};
 use crate::{
     LOG_TARGET,
     draw::{PsSource, VsSource},
+    encoder::FrameDataFlags,
 };
 
 /// Label a surface pointer by its backing texture for a dump event.
@@ -64,14 +71,6 @@ pub fn surface_label(surface: *mut c_void) -> String {
     )
 }
 
-/// One texture the dump reads back and summarizes at frame end.
-pub struct DumpReadback {
-    id: mtld3d_core::ids::TextureId,
-    d3d_format: u32,
-    width: u32,
-    height: u32,
-}
-
 /// Whether the dump is running and how many draws it has listed.
 pub struct FrameDump {
     /// The current frame is being dumped.
@@ -80,16 +79,10 @@ pub struct FrameDump {
     pub draws: u32,
     /// Frames still to dump after the current one.
     ///
-    /// The chord captures a short run of consecutive frames rather than a
+    /// A press captures a short run of consecutive frames rather than a
     /// single one, so cross-frame resource flow (a depth texture written in
     /// frame N and consumed in frame N+1) is visible in one capture.
     pub frames_remaining: u32,
-    /// Textures to read back and summarize at frame end.
-    ///
-    /// Every depth texture a draw sampled and every extra render target
-    /// bound above slot 0: their contents decide occlusion-style effects,
-    /// and only a readback can say whether the bytes are sane.
-    pub readback: Vec<DumpReadback>,
 }
 
 impl FrameDump {
@@ -97,15 +90,14 @@ impl FrameDump {
         active: false,
         draws: 0,
         frames_remaining: 0,
-        readback: Vec::new(),
     };
 
-    /// Consecutive frames one Ctrl+Shift+D press captures.
+    /// Consecutive frames one F12 press dumps and captures.
     pub const FRAMES: u32 = 3;
 }
 
 impl DeviceInner {
-    /// Whether a one-frame dump is currently running.
+    /// Whether a dump is currently running.
     ///
     /// For callers outside the device module that want to skip building an
     /// event string when no dump is armed.
@@ -114,16 +106,25 @@ impl DeviceInner {
         self.frame_dump.active
     }
 
-    /// Close the dumped frame at `Present` and arm the next one if the chord asked.
+    /// Close the dumped frame at `Present` and arm the next one if F12 asked.
     ///
-    /// A chord press starts a [`FrameDump::FRAMES`]-frame capture; a capture
-    /// already running continues until its remaining-frame count is spent.
-    pub fn frame_dump_present(&mut self, arm_next: bool) {
+    /// `seq` is the `submit_seq` of the frame just sent; the unix side labels
+    /// its command buffer `mtld3d-frame-{seq:#x}`, so the frame end line
+    /// names the node a GPU trace shows it under. A mid-frame flush inside a
+    /// dumped frame submits its own command buffer with its own seq; only
+    /// the closing one is named here.
+    ///
+    /// A press starts a [`FrameDump::FRAMES`]-frame run; a run already going
+    /// continues until its remaining-frame count is spent. The frame armed
+    /// here is the one about to be built, so it also receives the GPU
+    /// capture marks of its position in the run: the first frame starts the
+    /// capture, the last one stops it, and the trace covers exactly the
+    /// dumped frames.
+    pub fn frame_dump_present(&mut self, arm_next: bool, seq: u64) {
         let carried = if self.frame_dump.active {
-            self.frame_dump_run_readbacks();
             info!(
                 target: LOG_TARGET,
-                "[dump] frame end: {} draws",
+                "[dump] frame end: {} draws, command buffer mtld3d-frame-{seq:#x}",
                 self.frame_dump.draws
             );
             self.frame_dump.frames_remaining
@@ -135,241 +136,24 @@ impl DeviceInner {
             active: remaining > 0,
             draws: 0,
             frames_remaining: remaining.saturating_sub(1),
-            readback: Vec::new(),
         };
         if self.frame_dump.active {
+            let index = FrameDump::FRAMES - remaining + 1;
             info!(
                 target: LOG_TARGET,
-                "[dump] frame start ({} of {})",
-                FrameDump::FRAMES - remaining + 1,
+                "[dump] frame start ({index} of {})",
                 FrameDump::FRAMES
             );
-        }
-    }
-
-    /// Queue a texture for the frame-end readback while a dump is running.
-    ///
-    /// Deduplicates by id; anything past a small cap is dropped so a frame
-    /// binding many depth textures cannot stall the present for long.
-    pub fn frame_dump_note_readback(&mut self, tex: &crate::texture::Direct3DTexture9) {
-        const CAP: usize = 14;
-        if !self.frame_dump.active {
-            return;
-        }
-        let id = tex.texture_id();
-        if self.frame_dump.readback.len() >= CAP
-            || self.frame_dump.readback.iter().any(|r| r.id == id)
-        {
-            return;
-        }
-        let inner = tex.inner();
-        self.frame_dump.readback.push(DumpReadback {
-            id,
-            d3d_format: tex.d3d_format(),
-            width: inner.mip_width(0),
-            height: inner.mip_height(0),
-        });
-    }
-
-    /// Read back and summarize every noted texture; called at frame end.
-    ///
-    /// Each texture is resolved to its Metal handle through a frame op, the
-    /// frame is flushed to the GPU, and the pixels are copied to a host
-    /// buffer. Four-byte formats only: the depth formats and R32F log float
-    /// statistics (garbage shows as absurd ranges or NaN counts), everything
-    /// else logs a few raw pixels.
-    fn frame_dump_run_readbacks(&mut self) {
-        use core::sync::atomic::{AtomicU64, Ordering};
-        use std::sync::Arc;
-
-        let targets = std::mem::take(&mut self.frame_dump.readback);
-        for t in &targets {
-            let label = format!("{:?}/{:#x} {}x{}", t.id, t.d3d_format, t.width, t.height);
-            // The depth fourccs read back as their Depth32Float substrate;
-            // `bytes_per_pixel` calls them 0 because they have no lock pitch.
-            let is_depth = matches!(
-                t.d3d_format,
-                mtld3d_types::D3DFMT_INTZ | mtld3d_types::D3DFMT_DF24 | mtld3d_types::D3DFMT_DF16
-            );
-            let bpp = if is_depth {
-                4
-            } else {
-                mtld3d_core::format::map_d3d_format(t.d3d_format).map_or(0, |m| m.bytes_per_pixel())
-            };
-            if !matches!(bpp, 2 | 4) || t.width == 0 || t.height == 0 {
-                info!(target: LOG_TARGET, "[dump] readback {label}: skipped ({bpp} bytes/px)");
-                continue;
+            let (start, stop) = mtld3d_core::present::capture_marks(index, FrameDump::FRAMES);
+            let mut marks = FrameDataFlags::empty();
+            if start {
+                marks.insert(FrameDataFlags::GPU_CAPTURE_START);
             }
-            let slot = Arc::new(AtomicU64::new(0));
-            let slot_op = Arc::clone(&slot);
-            let snap_slot = Arc::new(AtomicU64::new(0));
-            let snap_slot_op = Arc::clone(&snap_slot);
-            let id = t.id;
-            self.push_op(Box::new(move |enc| {
-                let h = enc.get_texture_handle_by_id(id);
-                if h != 0 {
-                    // SAFETY: `h` is a live retained MTLTexture handle from
-                    // the encoder texture cache.
-                    enc.note_color_read_back(unsafe { MetalHandle::new(h) });
-                    // A depth attachment sampled by draws is read through a
-                    // snapshot copy; its contents are what those draws saw.
-                    snap_slot_op.store(enc.depth_snapshot_handle(h), Ordering::Release);
-                }
-                slot_op.store(h, Ordering::Release);
-            }));
-            self.flush_current_frame_blocking();
-            for (h, what) in [
-                (slot.load(Ordering::Acquire), ""),
-                (snap_slot.load(Ordering::Acquire), " snapshot"),
-            ] {
-                if h == 0 {
-                    if what.is_empty() {
-                        info!(target: LOG_TARGET, "[dump] readback {label}: no Metal texture");
-                    }
-                    continue;
-                }
-                let bytes_per_row = t.width * bpp;
-                let len = bytes_per_row as usize * t.height as usize;
-                // The unix side wraps the destination in `newBufferWithBytesNoCopy`,
-                // which takes a page-aligned base and a page-multiple length, so the
-                // destination is a `PageBox` and the wrapper sees its padded length.
-                let mut buf = PageBox::new_zeroed(len);
-                let hr = super::blit_handle_to_systemmem(
-                    self,
-                    &super::SystemMemReadback {
-                        // SAFETY: `h` is non-zero (checked above) and a live retained
-                        // MTLTexture handle from the encoder texture cache.
-                        tex_handle: unsafe { MetalHandle::new(h) },
-                        dst_ptr: buf.as_mut_ptr() as u64,
-                        dst_len: buf.len() as u64,
-                        level: 0,
-                        slice: 0,
-                        width: t.width,
-                        height: t.height,
-                        bytes_per_row,
-                        full_width: t.width,
-                        full_height: t.height,
-                    },
-                );
-                if hr != 0 {
-                    info!(
-                        target: LOG_TARGET,
-                        "[dump] readback {label}{what}: blit failed {hr:#x}"
-                    );
-                    continue;
-                }
-                let full = format!("{label}{what}");
-                // The blit writes the image rows from the start of the backing; the
-                // page padding past them is not part of the texture.
-                let image = &buf.as_slice()[..len];
-                if bpp == 2 {
-                    frame_dump_log_readback_f16(&full, image);
-                } else {
-                    frame_dump_log_readback(&full, t, image);
-                }
+            if stop {
+                marks.insert(FrameDataFlags::GPU_CAPTURE_STOP);
             }
+            self.current_frame.mark_gpu_capture(marks);
         }
-    }
-}
-
-/// Decode one IEEE half-precision value to `f32`.
-///
-/// The readback path is diagnostics-only, so a plain bit-level expansion
-/// (sign, 5-bit exponent, 10-bit mantissa, subnormals flushed through the
-/// scale) beats pulling in a half-float dependency.
-fn f16_to_f32(bits: u16) -> f32 {
-    let sign = f32::from(u8::from(bits & 0x8000 != 0)).mul_add(-2.0, 1.0);
-    let exp = i32::from((bits >> 10) & 0x1F);
-    let mant = f32::from(bits & 0x3FF);
-    match exp {
-        0 => sign * mant * 2f32.powi(-24),
-        0x1F => {
-            if mant == 0.0 {
-                sign * f32::INFINITY
-            } else {
-                f32::NAN
-            }
-        }
-        _ => sign * (1024.0 + mant) * 2f32.powi(exp - 25),
-    }
-}
-
-/// Log the statistics line for one read-back 2-byte (`R16F`) texture.
-fn frame_dump_log_readback_f16(label: &str, buf: &[u8]) {
-    let mut min = f32::INFINITY;
-    let mut max = f32::NEG_INFINITY;
-    let mut sum = 0.0f64;
-    let mut nan = 0u32;
-    let mut finite = 0u32;
-    for c in buf.chunks_exact(2) {
-        let v = f16_to_f32(u16::from_le_bytes([c[0], c[1]]));
-        if v.is_nan() {
-            nan += 1;
-            continue;
-        }
-        finite += 1;
-        min = min.min(v);
-        max = max.max(v);
-        sum += f64::from(v);
-    }
-    let mean = sum / f64::from(finite.max(1));
-    info!(
-        target: LOG_TARGET,
-        "[dump] readback {label}: f16 min={min:.6} max={max:.6} mean={mean:.6} nan={nan}"
-    );
-}
-
-/// Log the statistics line for one read-back texture.
-fn frame_dump_log_readback(label: &str, t: &DumpReadback, buf: &[u8]) {
-    let is_float = matches!(
-        t.d3d_format,
-        mtld3d_types::D3DFMT_R32F
-            | mtld3d_types::D3DFMT_INTZ
-            | mtld3d_types::D3DFMT_DF24
-            | mtld3d_types::D3DFMT_DF16
-    );
-    let px = |x: u32, y: u32| {
-        let idx = (y * t.width + x) as usize * 4;
-        u32::from_le_bytes([buf[idx], buf[idx + 1], buf[idx + 2], buf[idx + 3]])
-    };
-    let (cx, cy) = (t.width / 2, t.height / 2);
-    if is_float {
-        let mut min = f32::INFINITY;
-        let mut max = f32::NEG_INFINITY;
-        let mut sum = 0.0f64;
-        let mut nan = 0u32;
-        let mut finite = 0u32;
-        for c in buf.chunks_exact(4) {
-            let v = f32::from_le_bytes([c[0], c[1], c[2], c[3]]);
-            if v.is_nan() {
-                nan += 1;
-                continue;
-            }
-            finite += 1;
-            min = min.min(v);
-            max = max.max(v);
-            sum += f64::from(v);
-        }
-        let mean = sum / f64::from(finite.max(1));
-        info!(
-            target: LOG_TARGET,
-            "[dump] readback {label}: f32 min={min:.6} max={max:.6} mean={mean:.6} nan={nan} \
-             center={:.6} q1={:.6} q3={:.6}",
-            f32::from_bits(px(cx, cy)),
-            f32::from_bits(px(t.width / 4, t.height / 4)),
-            f32::from_bits(px(3 * t.width / 4, 3 * t.height / 4))
-        );
-    } else {
-        info!(
-            target: LOG_TARGET,
-            "[dump] readback {label}: raw center={:#010x} tl={:#010x} tr={:#010x} \
-             bl={:#010x} br={:#010x}",
-            px(cx, cy),
-            px(t.width / 4, t.height / 4),
-            px(3 * t.width / 4, t.height / 4),
-            px(t.width / 4, 3 * t.height / 4),
-            px(3 * t.width / 4, 3 * t.height / 4)
-        );
     }
 }
 
@@ -424,9 +208,15 @@ impl DeviceInner {
     }
 
     /// Log the assembled draw state; called once per draw while a dump runs.
+    ///
+    /// Also tags the draw for the encoder, which wraps its Metal draw in a
+    /// `draw {seq}` debug group; the closure op lands ahead of the draw op
+    /// in the same op stream, so the tag reaches `emit_draw` with the draw.
     pub fn frame_dump_draw(&mut self) {
         let seq = self.frame_dump.draws;
         self.frame_dump.draws += 1;
+        self.push_op(Box::new(move |enc| enc.set_dump_draw(seq)));
+        let vp = self.viewport();
         let rs = |i: u32| self.render_state(i as usize);
 
         let (rt, ds) = self.frame_dump_target_labels();
@@ -450,7 +240,6 @@ impl DeviceInner {
         let depth = bindings.depth_sampler_mask();
         let fetch = bindings.depth_fetch_mask();
         let mut textures = String::new();
-        let mut note: Vec<*const crate::texture::Direct3DTexture9> = Vec::new();
         for stage in 0..16usize {
             if bound & (1u16 << stage) == 0 {
                 continue;
@@ -469,9 +258,6 @@ impl DeviceInner {
             } else {
                 ""
             };
-            if !kind.is_empty() {
-                note.push(std::ptr::from_ref(tex));
-            }
             let inner = tex.inner();
             let _ = std::fmt::Write::write_fmt(
                 &mut textures,
@@ -513,7 +299,7 @@ impl DeviceInner {
             "[dump] draw {seq}: rt={rt} ds={ds}/{:#x} vs={vs} ps={ps} \
              z=[{},{},{}] blend=[{},{},{},{} sep={} {},{},{}] cull={} cw=[{:#x},{:#x},{:#x},{:#x}] \
              alpha=[{},{},{}] stencil=[{},{},{:#x},{:#x},{:#x} {},{},{} two={} ccw={},{},{},{}] \
-             bias=[{:#x},{:#x}] scissor={} tex=[{}]",
+             bias=[{:#x},{:#x}] vp={},{}+{}x{} scissor={} tex=[{}]",
             self.snapshot_cache.depth_stencil.bits(),
             rs(D3DRS_ZENABLE),
             rs(D3DRS_ZWRITEENABLE),
@@ -549,14 +335,13 @@ impl DeviceInner {
             rs(D3DRS_CCW_STENCILPASS),
             rs(D3DRS_DEPTHBIAS),
             rs(D3DRS_SLOPESCALEDEPTHBIAS),
+            vp.x,
+            vp.y,
+            vp.width,
+            vp.height,
             rs(D3DRS_SCISSORTESTENABLE),
             textures.trim_start(),
         );
-        for tex in note {
-            // SAFETY: collected above from live bound stages on this thread;
-            // nothing between there and here can release them.
-            self.frame_dump_note_readback(unsafe { &*tex });
-        }
         // Draws that fetch raw depth reconstruct positions from shared PS
         // constants (screen scale, linearization); print the window those
         // shaders read so wrong uploads are visible next to the draw.

--- a/windows/d3d9/src/draw.rs
+++ b/windows/d3d9/src/draw.rs
@@ -1249,6 +1249,13 @@ fn skip_shader_hashes() -> &'static [u64] {
     &crate::config::CONFIG.skip_shaders
 }
 
+/// Close the `draw N` debug group `emit_draw` opened for a dumped draw.
+fn close_dump_group(enc: &mut FrameEncoder, dump_draw: Option<u32>) {
+    if dump_draw.is_some() {
+        enc.emit_command(Command::pop_debug_group());
+    }
+}
+
 /// Encoder-thread draw dispatch.
 ///
 /// Pulls the cumulative state from `enc.current_snapshot` (updated by
@@ -1262,6 +1269,9 @@ pub fn emit_draw(enc: &mut FrameEncoder, draw: DrawOp) {
         vertex_source,
         index_source,
     } = draw;
+    // Taken up front: a draw dropped below must not leave its frame-dump
+    // index for the next draw to wear.
+    let dump_draw = enc.take_dump_draw();
     // Per-draw cost breakdown: six `CycleAddTimer` scopes tile `emit_draw`
     // end to end so the perf summary's "Closures (op)" row decomposes into
     // resolve / pipeline / state / probe / samplers / binds. Each guard holds
@@ -2351,6 +2361,11 @@ pub fn emit_draw(enc: &mut FrameEncoder, draw: DrawOp) {
     if matches!(index_source, IndexSource::Generated { .. }) {
         enc.bump_fan_generated();
     }
+    // While the F12 dump runs, the Metal draw sits in a `draw N` debug group
+    // so the trace node and the `[dump] draw N` line name each other.
+    if let Some(index) = dump_draw {
+        enc.emit_command(Command::push_debug_group(index));
+    }
     let verts = match index_source {
         IndexSource::None {
             start_vertex,
@@ -2381,6 +2396,7 @@ pub fn emit_draw(enc: &mut FrameEncoder, draw: DrawOp) {
                     "drop: IB buffer {:#x} wrap failed",
                     buffer_id.raw(),
                 );
+                close_dump_group(enc, dump_draw);
                 return;
             }
             // Record this draw's IB read range so a later overlapping
@@ -2416,12 +2432,14 @@ pub fn emit_draw(enc: &mut FrameEncoder, draw: DrawOp) {
             let Ok(base_vertex) = i32::try_from(start_vertex) else {
                 mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
                     "draw dropped: triangle fan start vertex {start_vertex} exceeds the base vertex range");
+                close_dump_group(enc, dump_draw);
                 return;
             };
             let buffer_handle = enc.fan_index_buffer(primitive_count);
             if buffer_handle == 0 {
                 mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
                     "draw dropped: the shared triangle fan index buffer could not be created");
+                close_dump_group(enc, dump_draw);
                 return;
             }
             let index_count = primitive_count * 3;
@@ -2479,6 +2497,7 @@ pub fn emit_draw(enc: &mut FrameEncoder, draw: DrawOp) {
             index_count
         }
     };
+    close_dump_group(enc, dump_draw);
     drop(t_draw);
     drop(t_binds);
 

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -714,6 +714,13 @@ bitflags::bitflags! {
         /// Also latched when any open/write failure makes further attempts
         /// pointless.
         const CACHE_DISABLED = 1 << 2;
+        /// A Metal GPU capture is open: every frame runs `SubmitMode::Sync`.
+        ///
+        /// Set on `FrameDataFlags::GPU_CAPTURE_START`, cleared after the frame
+        /// carrying `GPU_CAPTURE_STOP`, so the `SubmitFrame` thunks of the
+        /// whole run execute inline on the encoder thread between the
+        /// `StartGpuCapture` and `StopGpuCapture` thunks.
+        const GPU_CAPTURING = 1 << 3;
     }
 }
 
@@ -846,6 +853,13 @@ pub struct FrameEncoder {
     /// `begin_frame` so `PassState::reset_frame` keeps the seen-rt sets when
     /// the D3D9 frame did not actually end at the flush. Encoder-thread only.
     prev_submit_no_present: bool,
+    /// Frame-dump index of the draw about to be emitted, while a dump runs.
+    ///
+    /// Set by the closure op `frame_dump_draw` pushes ahead of the draw op,
+    /// taken by `emit_draw`, which wraps the Metal draw in a `draw N` debug
+    /// group so the trace node and the `[dump] draw N` line name each other.
+    /// `None` outside a dump; cleared in `begin_frame`.
+    dump_draw: Option<u32>,
     /// Arc clones of staging `PageBoxes` referenced by blits emitted this frame.
     ///
     /// Moved into `pending_blit_retention` at submit time with the frame's
@@ -1458,6 +1472,7 @@ impl FrameEncoder {
             submit_payloads_total: 0,
             last_submit_status: 0,
             prev_submit_no_present: false,
+            dump_draw: None,
             current_blit_retention: Vec::new(),
             pending_blit_retention: VecDeque::new(),
             coherent_seq_ptr: 0,
@@ -2217,6 +2232,7 @@ impl FrameEncoder {
         self.frame_blit_commands.clear();
         self.upload_pass_textures.clear();
         self.flags.remove(FrameEncoderFlags::BLIT_CMDS_NEED_ENCODER);
+        self.dump_draw = None;
         mtld3d_shared::crumb!("phase:BfRecl");
         self.reclaim_retired_blit_retention();
         if frame.coherent_seq_ptr != 0 {
@@ -2746,15 +2762,14 @@ impl FrameEncoder {
         self.depth_write_epoch += 1;
     }
 
-    /// Metal handle of the snapshot copy kept for a depth attachment, or 0.
-    ///
-    /// Diagnostics only: the frame dump reads the copy back, since that is
-    /// what depth-sampling draws actually saw.
-    #[must_use]
-    pub fn depth_snapshot_handle(&self, src_raw: u64) -> u64 {
-        self.depth_snapshots
-            .get(&src_raw)
-            .map_or(0, |s| s.handle.raw())
+    /// Tag the next draw with its frame-dump index; see `dump_draw`.
+    pub const fn set_dump_draw(&mut self, index: u32) {
+        self.dump_draw = Some(index);
+    }
+
+    /// Take the frame-dump index tagged for the draw being emitted, if any.
+    pub const fn take_dump_draw(&mut self) -> Option<u32> {
+        self.dump_draw.take()
     }
 
     /// Resolve the bound depth attachment into `dst` (the RESZ hack).
@@ -7993,6 +8008,19 @@ bitflags::bitflags! {
         /// texture safe to read from the subsequent readback-blit command
         /// buffer.
         const NO_PRESENT = 1 << 1;
+        /// First frame of an F12 run: start the Metal GPU capture before it.
+        ///
+        /// Set by `frame_dump_present` on the frame it arms. The encoder
+        /// drains the submit thread, starts the capture and runs every frame
+        /// synchronously until `GPU_CAPTURE_STOP` so each `SubmitFrame`
+        /// thunk falls inside the bracket.
+        const GPU_CAPTURE_START = 1 << 2;
+        /// Last frame of an F12 run: stop the Metal GPU capture after it.
+        ///
+        /// When a mid-frame flush sends the flagged frame out early,
+        /// `stamp_and_swap` moves this bit onto the fresh continuation so the
+        /// capture ends with the piece the closing `Present` submits.
+        const GPU_CAPTURE_STOP = 1 << 3;
     }
 }
 
@@ -8284,6 +8312,23 @@ impl FrameData {
         } else {
             self.flags.difference(FrameDataFlags::NO_PRESENT)
         };
+    }
+
+    /// Add GPU-capture marks (`GPU_CAPTURE_START` / `GPU_CAPTURE_STOP`) to the frame.
+    pub const fn mark_gpu_capture(&mut self, marks: FrameDataFlags) {
+        self.flags = self.flags.union(marks);
+    }
+
+    /// The GPU-capture marks the frame carries, if any.
+    #[must_use]
+    pub const fn gpu_capture_marks(&self) -> FrameDataFlags {
+        self.flags
+            .intersection(FrameDataFlags::GPU_CAPTURE_START.union(FrameDataFlags::GPU_CAPTURE_STOP))
+    }
+
+    /// Drop the `GPU_CAPTURE_STOP` mark, for moving it onto a continuation frame.
+    pub const fn clear_gpu_capture_stop(&mut self) {
+        self.flags = self.flags.difference(FrameDataFlags::GPU_CAPTURE_STOP);
     }
 
     pub const fn set_submit_fence(&mut self, fence: &SubmitFence) {
@@ -8726,24 +8771,7 @@ fn encoder_thread_main(
             Ok(EncoderMessage::Frame(frame)) => {
                 frame_counter += 1;
                 mtld3d_shared::crumb!("phase:RecvFrame");
-                let capture = crate::capture::take_request();
-                if capture {
-                    // Capture must bracket the actual `SubmitFrame` thunk,
-                    // which `Async` runs on the submit thread. Drain the
-                    // submit thread so prior frames are committed, then run
-                    // this frame synchronously so Start/Stop wrap its
-                    // inline execute on the encoder thread.
-                    enc.drain_submit_thread();
-                    let mut p = mtld3d_shared::StartGpuCaptureParams {
-                        device_handle: enc.device_handle,
-                    };
-                    let _ = unix_call(&mut p);
-                    run_frame(&mut enc, frame, frame_counter, SubmitMode::Sync);
-                    let mut p = mtld3d_shared::StopGpuCaptureParams { pad0: 0 };
-                    let _ = unix_call(&mut p);
-                } else {
-                    run_frame(&mut enc, frame, frame_counter, SubmitMode::Async);
-                }
+                run_frame_bracketed(&mut enc, frame, frame_counter, SubmitMode::Async);
             }
             Ok(EncoderMessage::MidFrameSubmit { frame, done }) => {
                 frame_counter += 1;
@@ -8752,14 +8780,14 @@ fn encoder_thread_main(
                 // on Metal's in-order queue, so every prior async frame must
                 // be committed first.
                 enc.drain_submit_thread();
-                run_frame(&mut enc, frame, frame_counter, SubmitMode::Sync);
+                run_frame_bracketed(&mut enc, frame, frame_counter, SubmitMode::Sync);
                 let _ = done.send(());
             }
             Ok(EncoderMessage::MidFrameSubmitForRetention { frame, done }) => {
                 frame_counter += 1;
                 mtld3d_shared::crumb!("phase:RecvMidRet");
                 enc.drain_submit_thread();
-                run_frame(&mut enc, frame, frame_counter, SubmitMode::Sync);
+                run_frame_bracketed(&mut enc, frame, frame_counter, SubmitMode::Sync);
                 // Wait for our just-submitted seq to retire on the GPU
                 // so `coherent_seq` covers it; then drain so the freed
                 // bytes are back in the global allocator before the
@@ -8827,6 +8855,38 @@ fn encoder_thread_main(
                 break;
             }
         }
+    }
+}
+
+/// Run one frame inside the F12 GPU-capture bracket when it carries the marks.
+///
+/// The capture must wrap the actual `SubmitFrame` thunk, which `Async`
+/// runs on the submit thread. On `GPU_CAPTURE_START` the submit thread is
+/// drained so prior frames are committed, the capture starts, and every
+/// frame until `GPU_CAPTURE_STOP` runs `Sync` so its inline execute on this
+/// thread sits between the two capture thunks. A mid-frame flush of a
+/// marked frame arrives through the `MidFrameSubmit*` arms, which is why
+/// all three frame arms go through here.
+fn run_frame_bracketed(enc: &mut FrameEncoder, frame: Box<FrameData>, fc: u64, mode: SubmitMode) {
+    let marks = frame.gpu_capture_marks();
+    if marks.contains(FrameDataFlags::GPU_CAPTURE_START) {
+        enc.drain_submit_thread();
+        let mut p = mtld3d_shared::StartGpuCaptureParams {
+            device_handle: enc.device_handle,
+        };
+        let _ = unix_call(&mut p);
+        enc.flags.insert(FrameEncoderFlags::GPU_CAPTURING);
+    }
+    let mode = if enc.flags.contains(FrameEncoderFlags::GPU_CAPTURING) {
+        SubmitMode::Sync
+    } else {
+        mode
+    };
+    run_frame(enc, frame, fc, mode);
+    if marks.contains(FrameDataFlags::GPU_CAPTURE_STOP) {
+        let mut p = mtld3d_shared::StopGpuCaptureParams { pad0: 0 };
+        let _ = unix_call(&mut p);
+        enc.flags.remove(FrameEncoderFlags::GPU_CAPTURING);
     }
 }
 


### PR DESCRIPTION
## Symptoms

Two hotkeys served one job. F12 captured exactly one Metal frame, and Ctrl+Shift+D logged a three-frame `[dump]` of D3D9 state; they were polled at the same Present but never covered the same frames, because the encoder consumed the F12 flag for the frame already in flight while the dump armed the next one. The dump also blocked the Present with up to fourteen readback flushes for float statistics that a GPU trace shows better, and it never listed a draw whose state equalled its predecessor's, because the clean-snapshot early return skipped the hook, so its draw numbering had gaps.

## Changes

F12 is the only hotkey. One press arms the next three frames for both tools. The request rides the frame itself: `frame_dump_present` marks the first frame of the run with `GPU_CAPTURE_START` and the last with `GPU_CAPTURE_STOP`, and the encoder's `run_frame_bracketed` starts the capture, keeps every frame synchronous while `GPU_CAPTURING`, and stops after the marked frame. All three frame-message arms go through it, so a mid-frame flush that sends a marked frame out early stays inside the bracket; `stamp_and_swap` moves the stop mark onto the continuation so the capture ends with the closing Present. The marks for frame i of N come from `mtld3d_core::present::capture_marks`.

The dump keeps what a trace cannot know and gains a bridge onto it. Each frame end line names the frame's command buffer label (`mtld3d-frame-0x<seq>`), every dumped draw is wrapped in a `draw N` debug group through two new encoder commands (`PushDebugGroup`, `PopDebugGroup`; the unix side pops anything left open before `endEncoding`), `SetViewport` and `SetScissorRect` are logged, and the draw line carries the viewport. The texture readbacks and their float statistics are removed together with the encoder helper only they used. The README documents the hotkey.

## Alternatives

Keeping the readbacks would have put their blits inside the captured frames; `gpudebug fetch` reads any texture at any draw from the trace instead. Numbering draws on the encoder side would have drifted from the dump's numbering whenever a draw is dropped, so the index travels with the draw through a closure op and is taken at the top of `emit_draw`. A configurable frame count was not added; three is a constant.

## Verification

`make check` and `make test` are green on both architectures (1009 + 180 unit tests including the new `capture_marks` and `debug_group_roundtrip`, 431 + 431 end-to-end). An HL2 run with the change installed produced a trace with exactly three command buffers labelled `mtld3d-frame-0x118` to `0x11a`, and `gpudebug find "draw 3"` lands on the group of dumped draw 3 in each frame.
