### PR TITLE
Flush a same-size Reset and key the VB/IB wrapper cache on the allocation

### DIFF
--- a/windows/core/src/buffer_backing.rs
+++ b/windows/core/src/buffer_backing.rs
@@ -206,6 +206,16 @@ impl BufferBacking {
         self.page_box.as_ref().map_or(0, |b| b.as_ptr() as u64)
     }
 
+    /// The current backing allocation's identity; `0` once released.
+    ///
+    /// Pairs with [`Self::ptr`] in the draw snapshot so the encoder's
+    /// `bytesNoCopy` wrapper cache can tell a re-used address from the
+    /// allocation it wrapped (see `PageBox::generation`).
+    #[must_use]
+    pub fn generation(&self) -> u64 {
+        self.page_box.as_ref().map_or(0, PageBox::generation)
+    }
+
     /// The backing's padded length, which outlives the bytes themselves.
     #[must_use]
     pub const fn padded_len(&self) -> u64 {

--- a/windows/core/src/page_box.rs
+++ b/windows/core/src/page_box.rs
@@ -230,6 +230,17 @@ pub const fn bypasses_local_cache(padded: usize) -> bool {
 /// Sized to the next page multiple of `logical_len`; both the raw pointer
 /// and the reported length are safe to hand to Metal via
 /// `newBufferWithBytesNoCopy:`.
+/// Monotonic identity for every fresh [`PageBox`] allocation.
+///
+/// The global allocator can hand a freed allocation's address back to a
+/// later one, and a `bytesNoCopy` `MTLBuffer` cached against the address
+/// alone would then pair GPU-pinned pages of the dead allocation with CPU
+/// writes into the new one. The generation names the allocation, not the
+/// address, so identity checks survive address reuse. A pool re-acquire
+/// keeps the parked allocation's value: parked pages were never freed, so
+/// they stay resident and coherent.
+static PAGE_BOX_GENERATION: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
 pub struct PageBox {
     ptr: NonNull<u8>,
     /// Rounded-up page multiple.
@@ -240,6 +251,8 @@ pub struct PageBox {
     logical_len: usize,
     /// Layout used for `alloc` — stored so `Drop` can match `dealloc`.
     layout: Layout,
+    /// This allocation's [`PAGE_BOX_GENERATION`] stamp.
+    generation: u64,
 }
 
 // SAFETY: PageBox owns a heap allocation with no interior sharing. Transferring
@@ -279,6 +292,7 @@ impl PageBox {
             len,
             logical_len,
             layout,
+            generation: PAGE_BOX_GENERATION.fetch_add(1, core::sync::atomic::Ordering::Relaxed) + 1,
         }
     }
 
@@ -304,6 +318,7 @@ impl PageBox {
             len,
             logical_len,
             layout,
+            generation: PAGE_BOX_GENERATION.fetch_add(1, core::sync::atomic::Ordering::Relaxed) + 1,
         }
     }
 
@@ -314,6 +329,12 @@ impl PageBox {
 
     pub const fn as_mut_ptr(&mut self) -> *mut u8 {
         self.ptr.as_ptr()
+    }
+
+    /// The allocation's identity stamp (see `PAGE_BOX_GENERATION`).
+    #[must_use]
+    pub const fn generation(&self) -> u64 {
+        self.generation
     }
 
     /// Borrow the full padded region as a slice.

--- a/windows/core/src/passes.rs
+++ b/windows/core/src/passes.rs
@@ -4967,6 +4967,20 @@ impl Default for PassState {
     }
 }
 
+/// What `LastBoundCache::vertex_buffer_changed` decided for a stream slot.
+#[derive(Debug, PartialEq, Eq)]
+pub enum VertexBufferBind {
+    /// The same wrapper at the same offset is bound: no command.
+    Same,
+    /// A different binding: emit `setVertexBuffer`.
+    Changed,
+    /// Same handle and offset over another backing generation: emit.
+    ///
+    /// The handle is a reused object address, so the wrapper it named
+    /// before was destroyed inside this pass; the caller reports it.
+    ReusedHandle,
+}
+
 /// Per-render-pass last-bound state cache.
 ///
 /// Skips redundant `setFragmentSamplerState` / `setFragmentTexture` /
@@ -5020,11 +5034,14 @@ pub struct LastBoundCache {
     ///
     /// Set only while a bound stage carries a non-zero bias.
     ps_lod_bias: Vec<u8>,
-    /// Vertex stream slots 0..16 — bound `MTLBuffer` handle + byte offset each.
+    /// Vertex stream slots 0..16 — bound `MTLBuffer` handle, byte offset, backing generation.
     ///
-    /// Indexed by D3D9 stream, which is the Metal vertex buffer slot. `(0, _)`
-    /// is the unset sentinel (Metal buffer handles are never zero).
-    vertex_buffers: [(u64, u32); VERTEX_STREAM_SLOTS as usize],
+    /// Indexed by D3D9 stream, which is the Metal vertex buffer slot.
+    /// `(0, _, _)` is the unset sentinel (Metal buffer handles are never
+    /// zero). The generation is the backing allocation's identity behind the
+    /// handle: a handle is a raw object address, and an address reused by a
+    /// later wrapper must not read as the same binding.
+    vertex_buffers: [(u64, u32, u64); VERTEX_STREAM_SLOTS as usize],
     /// Resolved `(x, y, w, h)` scissor rect.
     ///
     /// `None` is the unset sentinel — a brand-new render encoder has no
@@ -5068,7 +5085,7 @@ impl LastBoundCache {
             ps_fog_color: Vec::new(),
             ps_bump_env: Vec::new(),
             ps_lod_bias: Vec::new(),
-            vertex_buffers: [(0, 0); VERTEX_STREAM_SLOTS as usize],
+            vertex_buffers: [(0, 0, 0); VERTEX_STREAM_SLOTS as usize],
             scissor_rect: None,
             blend_color: 0xFFFF_FFFF,
             depth_bias_bits: (0, 0),
@@ -5098,7 +5115,7 @@ impl LastBoundCache {
         self.ps_fog_color.clear();
         self.ps_bump_env.clear();
         self.ps_lod_bias.clear();
-        self.vertex_buffers = [(0, 0); VERTEX_STREAM_SLOTS as usize];
+        self.vertex_buffers = [(0, 0, 0); VERTEX_STREAM_SLOTS as usize];
         self.scissor_rect = None;
         self.blend_color = 0xFFFF_FFFF;
         self.depth_bias_bits = (0, 0);
@@ -5184,16 +5201,28 @@ impl LastBoundCache {
     /// Whether vertex stream `slot` needs a `setVertexBuffer` for `(handle, offset)`.
     ///
     /// Records the binding when it does. `slot` is the D3D9 stream index,
-    /// below [`VERTEX_STREAM_SLOTS`].
+    /// below [`VERTEX_STREAM_SLOTS`]. `generation` is the backing allocation
+    /// behind `handle`: the same handle and offset over a different
+    /// generation is a reused object address, and the bind is re-emitted
+    /// rather than deduplicated onto the wrapper the address used to name.
     #[inline]
-    pub const fn vertex_buffer_changed(&mut self, slot: u32, handle: u64, offset: u32) -> bool {
+    pub const fn vertex_buffer_changed(
+        &mut self,
+        slot: u32,
+        handle: u64,
+        offset: u32,
+        generation: u64,
+    ) -> VertexBufferBind {
         let cur = &mut self.vertex_buffers[slot as usize];
         if cur.0 == handle && cur.1 == offset {
-            false
-        } else {
-            *cur = (handle, offset);
-            true
+            if cur.2 == generation {
+                return VertexBufferBind::Same;
+            }
+            *cur = (handle, offset, generation);
+            return VertexBufferBind::ReusedHandle;
         }
+        *cur = (handle, offset, generation);
+        VertexBufferBind::Changed
     }
 
     /// Forget the vertex buffer bound at stream slot 0.
@@ -5217,7 +5246,7 @@ impl LastBoundCache {
     /// the draw path fed inline zero bytes because nothing was bound to it.
     #[inline]
     pub const fn invalidate_vertex_buffer_slot(&mut self, slot: u32) {
-        self.vertex_buffers[slot as usize] = (0, 0);
+        self.vertex_buffers[slot as usize] = (0, 0, 0);
     }
 
     #[inline]
@@ -5456,7 +5485,9 @@ impl LastBoundCache {
             shadow.cull_mode,
             "cull-mode cache desync (cache vs encoder-emitted)"
         );
-        for (slot, (&(cache_h, cache_off), &emitted)) in self
+        // The generation behind the handle is a cache-side key only; the
+        // emitted command carries handle and offset.
+        for (slot, (&(cache_h, cache_off, _), &emitted)) in self
             .vertex_buffers
             .iter()
             .zip(&shadow.vertex_buffers)

--- a/windows/core/src/passes/tests.rs
+++ b/windows/core/src/passes/tests.rs
@@ -213,32 +213,84 @@ fn frame_sampled_textures_ignores_null_bind() {
 fn inline_slot0_bind_forces_next_bound_vertex_buffer_reemit() {
     let mut cache = LastBoundCache::new();
     // First bind of a real VB handle reports a change and caches it.
-    assert!(cache.vertex_buffer_changed(0, 0xDEAD, 0));
-    // A redundant rebind of the same (handle, offset) would be skipped.
-    assert!(!cache.vertex_buffer_changed(0, 0xDEAD, 0));
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xDEAD, 0, 1),
+        VertexBufferBind::Changed
+    );
+    // A redundant rebind of the same (handle, offset, generation) is skipped.
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xDEAD, 0, 1),
+        VertexBufferBind::Same
+    );
     // An inline slot-0 bind (setVertexBytes) clobbers the Metal binding;
     // invalidating the cache must force the next bound draw to re-emit
     // even though it targets the same (handle, offset).
     cache.invalidate_vertex_buffer();
-    assert!(cache.vertex_buffer_changed(0, 0xDEAD, 0));
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xDEAD, 0, 1),
+        VertexBufferBind::Changed
+    );
+}
+
+#[test]
+fn reused_handle_over_another_generation_is_rebound() {
+    let mut cache = LastBoundCache::new();
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xDEAD, 0, 1),
+        VertexBufferBind::Changed
+    );
+    // Same object address and offset, but a wrapper over a different
+    // allocation: the bind goes out again and the cache moves on.
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xDEAD, 0, 2),
+        VertexBufferBind::ReusedHandle
+    );
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xDEAD, 0, 2),
+        VertexBufferBind::Same
+    );
 }
 
 #[test]
 fn vertex_buffer_slots_are_tracked_independently() {
     let mut cache = LastBoundCache::new();
-    assert!(cache.vertex_buffer_changed(0, 0xDEAD, 0));
-    assert!(cache.vertex_buffer_changed(1, 0xBEEF, 16));
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xDEAD, 0, 1),
+        VertexBufferBind::Changed
+    );
+    assert_eq!(
+        cache.vertex_buffer_changed(1, 0xBEEF, 16, 1),
+        VertexBufferBind::Changed
+    );
     // Slot 1's bind leaves slot 0's cache intact, and vice versa.
-    assert!(!cache.vertex_buffer_changed(0, 0xDEAD, 0));
-    assert!(!cache.vertex_buffer_changed(1, 0xBEEF, 16));
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xDEAD, 0, 1),
+        VertexBufferBind::Same
+    );
+    assert_eq!(
+        cache.vertex_buffer_changed(1, 0xBEEF, 16, 1),
+        VertexBufferBind::Same
+    );
     // Invalidating slot 0 (inline UP bytes) does not touch slot 1.
     cache.invalidate_vertex_buffer();
-    assert!(cache.vertex_buffer_changed(0, 0xDEAD, 0));
-    assert!(!cache.vertex_buffer_changed(1, 0xBEEF, 16));
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xDEAD, 0, 1),
+        VertexBufferBind::Changed
+    );
+    assert_eq!(
+        cache.vertex_buffer_changed(1, 0xBEEF, 16, 1),
+        VertexBufferBind::Same
+    );
     // A null-stream inline bind at slot 1 forgets only slot 1.
     cache.invalidate_vertex_buffer_slot(1);
-    assert!(cache.vertex_buffer_changed(1, 0xBEEF, 16));
-    assert!(!cache.vertex_buffer_changed(0, 0xDEAD, 0));
+    assert_eq!(
+        cache.vertex_buffer_changed(1, 0xBEEF, 16, 1),
+        VertexBufferBind::Changed
+    );
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xDEAD, 0, 1),
+        VertexBufferBind::Same
+    );
 }
 
 #[test]
@@ -933,7 +985,7 @@ fn last_bound_reset_clears_everything() {
     c.ps_constants_changed(&[5, 6, 7, 8]);
     c.ps_alpha_ref_changed(&[9, 10, 11, 12]);
     c.ps_fog_color_changed(&[13, 14, 15, 16]);
-    c.vertex_buffer_changed(0, 0xEEEE, 32);
+    c.vertex_buffer_changed(0, 0xEEEE, 32, 1);
     c.scissor_rect_changed((1, 2, 3, 4));
     c.blend_color_changed(0xFF11_2233);
     c.reset();
@@ -946,7 +998,10 @@ fn last_bound_reset_clears_everything() {
     assert!(c.ps_constants_changed(&[5, 6, 7, 8]));
     assert!(c.ps_alpha_ref_changed(&[9, 10, 11, 12]));
     assert!(c.ps_fog_color_changed(&[13, 14, 15, 16]));
-    assert!(c.vertex_buffer_changed(0, 0xEEEE, 32));
+    assert_eq!(
+        c.vertex_buffer_changed(0, 0xEEEE, 32, 1),
+        VertexBufferBind::Changed
+    );
     assert!(c.scissor_rect_changed((1, 2, 3, 4)));
     assert!(c.blend_color_changed(0xFF11_2233));
 }
@@ -989,12 +1044,24 @@ fn last_bound_inline_bytes_reset_keeps_capacity() {
 #[test]
 fn last_bound_vertex_buffer_dedup() {
     let mut c = LastBoundCache::new();
-    assert!(c.vertex_buffer_changed(0, 0xAAAA, 0));
-    assert!(!c.vertex_buffer_changed(0, 0xAAAA, 0));
+    assert_eq!(
+        c.vertex_buffer_changed(0, 0xAAAA, 0, 1),
+        VertexBufferBind::Changed
+    );
+    assert_eq!(
+        c.vertex_buffer_changed(0, 0xAAAA, 0, 1),
+        VertexBufferBind::Same
+    );
     // Same handle, different offset → changed.
-    assert!(c.vertex_buffer_changed(0, 0xAAAA, 64));
+    assert_eq!(
+        c.vertex_buffer_changed(0, 0xAAAA, 64, 1),
+        VertexBufferBind::Changed
+    );
     // Same offset, different handle → changed.
-    assert!(c.vertex_buffer_changed(0, 0xBBBB, 64));
+    assert_eq!(
+        c.vertex_buffer_changed(0, 0xBBBB, 64, 1),
+        VertexBufferBind::Changed
+    );
 }
 
 #[test]
@@ -1083,7 +1150,10 @@ fn debug_guard_in_sync_across_every_tracked_slot() {
     shadow.record(&Command::set_fragment_texture(0x7E10, 3));
     assert!(cache.fragment_sampler_changed(3, 0x5A77));
     shadow.record(&Command::set_fragment_sampler_state(0x5A77, 3));
-    assert!(cache.vertex_buffer_changed(0, 0xBEEF, 0x40));
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xBEEF, 0x40, 1),
+        VertexBufferBind::Changed
+    );
     shadow.record(&Command::set_vertex_buffer(0xBEEF, 0x40, 0));
     assert!(cache.scissor_rect_changed((7, 9, 1024, 768)));
     shadow.record(&Command::set_scissor_rect(7, 9, 1024, 768));
@@ -1103,7 +1173,10 @@ fn debug_guard_in_sync_after_inline_slot0_invalidate() {
     let mut cache = LastBoundCache::new();
     let mut shadow = DebugBoundShadow::default();
 
-    assert!(cache.vertex_buffer_changed(0, 0xBEEF, 0x10));
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xBEEF, 0x10, 1),
+        VertexBufferBind::Changed
+    );
     shadow.record(&Command::set_vertex_buffer(0xBEEF, 0x10, 0));
     cache.debug_assert_in_sync(&shadow);
 
@@ -1113,7 +1186,10 @@ fn debug_guard_in_sync_after_inline_slot0_invalidate() {
     cache.debug_assert_in_sync(&shadow);
 
     // The next bound draw re-binds the same buffer and stays in sync.
-    assert!(cache.vertex_buffer_changed(0, 0xBEEF, 0x10));
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xBEEF, 0x10, 1),
+        VertexBufferBind::Changed
+    );
     shadow.record(&Command::set_vertex_buffer(0xBEEF, 0x10, 0));
     cache.debug_assert_in_sync(&shadow);
 }
@@ -1127,9 +1203,15 @@ fn debug_guard_tracks_every_vertex_stream_slot() {
     let mut cache = LastBoundCache::new();
     let mut shadow = DebugBoundShadow::default();
 
-    assert!(cache.vertex_buffer_changed(0, 0xBEEF, 0x10));
+    assert_eq!(
+        cache.vertex_buffer_changed(0, 0xBEEF, 0x10, 1),
+        VertexBufferBind::Changed
+    );
     shadow.record(&Command::set_vertex_buffer(0xBEEF, 0x10, 0));
-    assert!(cache.vertex_buffer_changed(1, 0xCAFE, 0x20));
+    assert_eq!(
+        cache.vertex_buffer_changed(1, 0xCAFE, 0x20, 1),
+        VertexBufferBind::Changed
+    );
     shadow.record(&Command::set_vertex_buffer(0xCAFE, 0x20, 1));
     cache.debug_assert_in_sync(&shadow);
 

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -3846,9 +3846,20 @@ extern "system" fn device_reset(this: *mut c_void, present_params: *mut c_void) 
             dev.flags.insert(DeviceFlags::NOT_RESET);
             return hr;
         }
+        // Deliver every op queued since the last Present before the reseed
+        // below replaces `current_frame`. The queue holds work whose
+        // bookkeeping already advanced (texture and Staged-buffer uploads
+        // scheduled at bind time cleared their dirty bits when they were
+        // queued), so dropping it loses that content on the GPU side for
+        // good: the game believes it uploaded and never rewrites it. HL2's
+        // cached VGUI text meshes rode exactly this queue through its
+        // same-size windowed/fullscreen Reset, which is issue #76's garbled
+        // menu text. The resized path flushes inside
+        // `reset_recreate_resources`.
+        dev.flush_current_frame_blocking();
         debug!(
             target: LOG_TARGET,
-            "Reset: dims unchanged ({}x{}) — skipping flush + texture recreate cycle, applying state defaults only",
+            "Reset: dims unchanged ({}x{}), flushed pending ops, skipping the texture recreate cycle",
             dev.backbuffer_width, dev.backbuffer_height,
         );
     }
@@ -3864,17 +3875,20 @@ extern "system" fn device_reset(this: *mut c_void, present_params: *mut c_void) 
     }
     dev.set_present_params(stored);
 
-    // 7. Reset device state to D3D9 defaults. Cursor + silent-write
-    //    warn latches survive (per-spec / process-lifetime telemetry).
-    dev.reset_to_defaults();
-    dev.flags.remove(DeviceFlags::NOT_RESET);
-
-    // 8. Reseed `current_frame` so it carries the new backbuffer/depth
+    // 7. Reseed `current_frame` so it carries the new backbuffer/depth
     //    handles. The post-flush frame still referenced the destroyed
     //    pre-Reset textures; without this, the next Present would
     //    submit a freed MTLTexture pointer (status=0xc0000005 on the
-    //    unix side).
+    //    unix side). Runs before the state defaults: `reset_to_defaults`
+    //    pushes ops (default viewport, unbinds), and pushing them first
+    //    would hand them to the reseed to throw away, so this keeps the
+    //    order `apply_auto_resize` already uses.
     dev.reseed_current_frame();
+
+    // 8. Reset device state to D3D9 defaults. Cursor + silent-write
+    //    warn latches survive (per-spec / process-lifetime telemetry).
+    dev.reset_to_defaults();
+    dev.flags.remove(DeviceFlags::NOT_RESET);
 
     // 9. Defer the PresentationInterval change to the next frame's first
     //    `nextDrawable`. Mutating `displaySyncEnabled` synchronously here

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -5162,6 +5162,7 @@ extern "system" fn device_create_vertex_buffer(
         buffer_id: inner.buffer_id(),
         backing_ptr: inner.current_backing_ptr(),
         backing_len: inner.current_backing_len(),
+        backing_generation: inner.current_backing_generation(),
         map_mode: inner.map_mode(),
     });
     // SAFETY: vtable out-param; `vb` is *mut *mut c_void per IDirect3DDevice9 ABI.
@@ -5239,6 +5240,7 @@ extern "system" fn device_create_index_buffer(
         buffer_id: inner.buffer_id(),
         backing_ptr: inner.current_backing_ptr(),
         backing_len: inner.current_backing_len(),
+        backing_generation: inner.current_backing_generation(),
         map_mode: inner.map_mode(),
     });
     // SAFETY: vtable out-param; `ib` is *mut *mut c_void per IDirect3DDevice9 ABI.
@@ -10022,6 +10024,7 @@ fn snapshot_stream_binding(bound: &BoundBuffers, stream: u32, seq: u64) -> Strea
         buffer_id: inner.buffer_id(),
         backing_ptr: inner.current_backing_ptr(),
         backing_len: inner.current_backing_len(),
+        backing_generation: inner.current_backing_generation(),
         offset: bound.stream_offset(s),
         stride: bound.stream_stride(s),
         freq: bound.stream_freq(s),
@@ -10065,6 +10068,7 @@ fn snapshot_bound_index_source(
         buffer_id: inner.buffer_id(),
         backing_ptr: inner.current_backing_ptr(),
         backing_len: inner.current_backing_len(),
+        backing_generation: inner.current_backing_generation(),
         offset: start_index * index_stride,
         index_count,
         index_type,

--- a/windows/d3d9/src/draw.rs
+++ b/windows/d3d9/src/draw.rs
@@ -19,7 +19,7 @@ use mtld3d_core::{
         FfPsKey, FfVsKey, TextureType, VariantFlags, VariantKey, VsSamplerKinds, bound_sampler_type,
     },
     ids::{BufferId, ProgramId},
-    passes::{NULL_TEXTURE_SAMPLER_SENTINEL, null_texture_tex_sentinel},
+    passes::{NULL_TEXTURE_SAMPLER_SENTINEL, VertexBufferBind, null_texture_tex_sentinel},
     perf::{CycleAddTimer, OpSub, OpSubDetail, PairShaderId},
     pipeline_state::{PipelineSnapshot, StreamLayout},
     scratch::ScratchArena,
@@ -2227,10 +2227,26 @@ pub fn emit_draw(enc: &mut FrameEncoder, draw: DrawOp) {
                     );
                     return;
                 }
-                if enc
-                    .last_bound()
-                    .vertex_buffer_changed(slot, buffer_handle, b.offset)
-                {
+                let bind = enc.last_bound().vertex_buffer_changed(
+                    slot,
+                    buffer_handle,
+                    b.offset,
+                    b.backing_generation,
+                );
+                if bind == VertexBufferBind::ReusedHandle {
+                    // The dedup would have kept the wrapper this address used
+                    // to name bound; that wrapper was destroyed inside this
+                    // pass, which the retention schedule is meant to rule out.
+                    mtld3d_shared::log_once_warn!(
+                        target: crate::LOG_TARGET,
+                        "vertex buffer handle {buffer_handle:#x} reused within a pass for \
+                         buffer {:#x} generation {}: rebinding instead of deduplicating",
+                        b.buffer_id.raw(),
+                        b.backing_generation
+                    );
+                }
+                let vb_emitted = bind != VertexBufferBind::Same;
+                if vb_emitted {
                     enc.emit_command(Command::set_vertex_buffer(buffer_handle, b.offset, slot));
                 }
                 // Record this draw's VB read range so a later overlapping

--- a/windows/d3d9/src/draw.rs
+++ b/windows/d3d9/src/draw.rs
@@ -120,6 +120,8 @@ pub struct StreamBinding {
     pub buffer_id: BufferId,
     pub backing_ptr: u64,
     pub backing_len: u64,
+    /// The backing allocation's identity (see `PageBox::generation`).
+    pub backing_generation: u64,
     pub offset: u32,
     pub stride: u32,
     /// Raw `SetStreamSourceFreq` word of this stream (flags + count).
@@ -249,6 +251,8 @@ pub enum IndexSource {
         buffer_id: BufferId,
         backing_ptr: u64,
         backing_len: u64,
+        /// The backing allocation's identity (see `PageBox::generation`).
+        backing_generation: u64,
         offset: u32,
         index_count: u32,
         index_type: IndexType,
@@ -2207,8 +2211,12 @@ pub fn emit_draw(enc: &mut FrameEncoder, draw: DrawOp) {
                     // attributes: nothing to bind.
                     continue;
                 }
-                let buffer_handle =
-                    enc.ensure_vbib_mtl_buffer(b.buffer_id, b.backing_ptr, b.backing_len);
+                let buffer_handle = enc.ensure_vbib_mtl_buffer(
+                    b.buffer_id,
+                    b.backing_ptr,
+                    b.backing_len,
+                    b.backing_generation,
+                );
                 if buffer_handle == 0 {
                     mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET, "draw dropped: ensure_vbib_mtl_buffer returned 0 for VB");
                     mtld3d_shared::log_once_trace_by!(
@@ -2367,12 +2375,14 @@ pub fn emit_draw(enc: &mut FrameEncoder, draw: DrawOp) {
             buffer_id,
             backing_ptr,
             backing_len,
+            backing_generation,
             offset,
             index_count,
             index_type,
             base_vertex,
         } => {
-            let buffer_handle = enc.ensure_vbib_mtl_buffer(buffer_id, backing_ptr, backing_len);
+            let buffer_handle =
+                enc.ensure_vbib_mtl_buffer(buffer_id, backing_ptr, backing_len, backing_generation);
             if buffer_handle == 0 {
                 mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET, "draw dropped: ensure_vbib_mtl_buffer returned 0 for IB");
                 mtld3d_shared::log_once_trace_by!(

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -1259,6 +1259,14 @@ struct BufferGpuState {
     is_staged: bool,
     backing_ptr: u64,
     length: u64,
+    /// Identity of the backing allocation the wrapper was created over.
+    ///
+    /// A cache hit needs it to match alongside the address: the allocator
+    /// can hand a freed backing's address to a later allocation, and the
+    /// `bytesNoCopy` wrapper pins the dead allocation's pages, so an
+    /// address-only match pairs GPU reads with pages the CPU no longer
+    /// writes (issue #76's garbled text). Meaningless for `Staged` (0).
+    backing_generation: u64,
     /// Max submit seq this wrapper has been bound into a Draw for.
     ///
     /// Used when the cache entry is evicted to retention.
@@ -1788,6 +1796,7 @@ impl FrameEncoder {
                             is_staged: true,
                             backing_ptr: 0,
                             length: warmup.backing_len,
+                            backing_generation: 0,
                             last_submit_seq: current_seq,
                         });
                     }
@@ -1802,6 +1811,7 @@ impl FrameEncoder {
                         is_staged: staged,
                         backing_ptr: if staged { 0 } else { warmup.backing_ptr },
                         length: warmup.backing_len,
+                        backing_generation: if staged { 0 } else { warmup.backing_generation },
                         last_submit_seq: current_seq,
                     });
                     // `Direct`: fresh `bytesNoCopy` wrapper — notify the
@@ -5697,6 +5707,7 @@ impl FrameEncoder {
         buffer_id: BufferId,
         backing_ptr: u64,
         backing_len: u64,
+        backing_generation: u64,
     ) -> u64 {
         let current_seq = self.current_submit_seq;
         if let Some(state) = self.buffer_cache.get_mut(&buffer_id) {
@@ -5737,7 +5748,10 @@ impl FrameEncoder {
                 );
                 return fresh.raw();
             }
-            if state.backing_ptr == backing_ptr && state.length == backing_len {
+            if state.backing_ptr == backing_ptr
+                && state.length == backing_len
+                && state.backing_generation == backing_generation
+            {
                 let mtl_buffer = state.mtl_buffer;
                 if current_seq > state.last_submit_seq {
                     // First bind of this buffer this frame — assume the
@@ -5802,6 +5816,7 @@ impl FrameEncoder {
                 is_staged: false,
                 backing_ptr,
                 length: backing_len,
+                backing_generation,
                 last_submit_seq: current_seq,
             },
         );
@@ -7939,6 +7954,8 @@ pub struct VbibWarmupEntry {
     pub buffer_id: BufferId,
     pub backing_ptr: u64,
     pub backing_len: u64,
+    /// The backing allocation's identity (see `PageBox::generation`).
+    pub backing_generation: u64,
     /// Decides the create path.
     ///
     /// `Direct` → one `bytesNoCopy` wrapper (today's zero-copy bind);

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -5994,12 +5994,33 @@ impl FrameEncoder {
                     removed.last_submit_seq.max(last_submit_seq),
                 )
             }
-            Some(state) if state.backing_ptr == backing_ptr => {
+            Some(state)
+                if state.backing_ptr == backing_ptr
+                    && state.backing_generation == page_box.generation() =>
+            {
                 let removed = self.buffer_cache.remove(&buffer_id).expect("just checked");
                 (
                     removed.mtl_buffer,
                     removed.last_submit_seq.max(last_submit_seq),
                 )
+            }
+            // The address matches but the allocation does not: the entry
+            // wraps a later backing at the retained one's address, and
+            // taking it would destroy a wrapper draws still bind. The
+            // ownership rules make this unreachable (a retained box is alive
+            // and so cannot share an address with a live one); the check
+            // keeps that a local fact rather than a lifetime argument.
+            Some(state) if state.backing_ptr == backing_ptr => {
+                mtld3d_shared::log_once_warn!(
+                    target: LOG_TARGET,
+                    "intake_vbib_retention: buffer {:#x} retired backing {backing_ptr:#x} \
+                     generation {} while the cache wraps generation {} at that address; \
+                     the cache entry stays",
+                    buffer_id.raw(),
+                    page_box.generation(),
+                    state.backing_generation
+                );
+                (MetalHandle::NULL, last_submit_seq)
             }
             _ => (MetalHandle::NULL, last_submit_seq),
         };

--- a/windows/d3d9/src/index_buffer.rs
+++ b/windows/d3d9/src/index_buffer.rs
@@ -177,6 +177,11 @@ impl IndexBufferInner {
         self.backing.ptr()
     }
 
+    /// The current backing allocation's identity (see `BufferBacking::generation`).
+    pub fn current_backing_generation(&self) -> u64 {
+        self.backing.generation()
+    }
+
     pub const fn current_backing_len(&self) -> u64 {
         self.backing.padded_len()
     }

--- a/windows/d3d9/src/vertex_buffer.rs
+++ b/windows/d3d9/src/vertex_buffer.rs
@@ -242,6 +242,11 @@ impl VertexBufferInner {
         self.backing.ptr()
     }
 
+    /// The current backing allocation's identity (see `BufferBacking::generation`).
+    pub fn current_backing_generation(&self) -> u64 {
+        self.backing.generation()
+    }
+
     pub const fn current_backing_len(&self) -> u64 {
         self.backing.padded_len()
     }

--- a/windows/tests/tests/device.rs
+++ b/windows/tests/tests/device.rs
@@ -854,6 +854,74 @@ const fn cube_quad_vertex(x: f32, y: f32) -> CubeQuadVertex {
     }
 }
 
+/// An upload queued before a same-size `Reset` still reaches the GPU.
+///
+/// A draw's bind-time flush queues the texture upload onto the pending frame
+/// and clears the mip's dirty bit; with no `Present` in between, that op is
+/// still queued when `Reset` replaces the frame. Dropping it with the
+/// bookkeeping already advanced loses the level's content on the GPU for
+/// good: the game believes it uploaded and never rewrites it. HL2's cached
+/// VGUI text meshes ride exactly this queue through the same-size Reset its
+/// windowed toggle issues, which is issue #76's garbled menu text.
+#[test]
+fn reset_same_size_keeps_uploads_queued_before_it() {
+    const RED: u32 = 0xFFFF_0000;
+    const BLACK: u32 = 0xFF00_0000;
+
+    let h = Harness::new();
+    let tex = h.create_texture(4, 4, 1, 0, D3DFMT_A8R8G8B8, D3DPOOL_MANAGED);
+    {
+        let mut level = tex.lock_rect(0, 0);
+        level.write_u32(&[RED; 16]);
+    }
+    // Bind and draw without presenting: the draw schedules the upload onto
+    // the pending frame and spends the dirty bit.
+    assert_eq!(h.set_texture(0, &tex), 0, "SetTexture before Reset");
+    h.select_texture_stage(0);
+    assert_eq!(h.set_render_state(D3DRS_LIGHTING, 0), 0, "LIGHTING off");
+    assert_eq!(
+        h.set_fvf(D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1),
+        0,
+        "SetFVF for the pre-Reset draw"
+    );
+    assert_eq!(h.begin_scene(), 0, "BeginScene before Reset");
+    assert_eq!(
+        h.draw_primitive_up(D3DPT_TRIANGLELIST, 2, &flat_quad(0xFFFF_FFFF)),
+        0,
+        "pre-Reset draw"
+    );
+    assert_eq!(h.end_scene(), 0, "EndScene before Reset");
+
+    assert_eq!(h.reset(640, 480), 0, "same-size Reset must succeed");
+
+    // The dirty bit is spent, so only the pre-Reset upload can have put the
+    // texels on the GPU; a Reset that dropped the queued op samples nothing.
+    assert_eq!(h.set_texture(0, &tex), 0, "SetTexture after Reset");
+    h.select_texture_stage(0);
+    assert_eq!(
+        h.set_render_state(D3DRS_LIGHTING, 0),
+        0,
+        "LIGHTING off again"
+    );
+    assert_eq!(
+        h.set_fvf(D3DFVF_XYZ | D3DFVF_DIFFUSE | D3DFVF_TEX1),
+        0,
+        "SetFVF for the post-Reset draw"
+    );
+    h.render_once(BLACK, |d| {
+        assert_eq!(
+            d.draw_primitive_up(D3DPT_TRIANGLELIST, 2, &flat_quad(0xFFFF_FFFF)),
+            0,
+            "post-Reset draw"
+        );
+    });
+    assert_pixel_eq(
+        h.read_pixel(320, 240),
+        RED,
+        "the upload queued before the Reset must survive it",
+    );
+}
+
 #[test]
 fn reset_clears_the_stage_cube_binding_mask() {
     const RED: u32 = 0xFFFF_0000;


### PR DESCRIPTION
Three fixes found while chasing #76 (HL2 menu text garbled after a resolution change or a windowed/fullscreen toggle). They cured the two frozen variants of the garble, verified in HL2; the transient variant remains under investigation on #76.

## Symptoms

After a same-size `Reset` (Source resets on a windowed/fullscreen toggle), cached VGUI text meshes rendered with missing or stale glyph quads until the game rebuilt them. Independently, after enough mode churn the GPU rendered index and vertex data the CPU no longer held: reconstruction from the CPU bytes was perfect while the back buffer tore, and the tear was stable for as long as the buffer kept its address.

## Changes

`Reset` with unchanged dimensions never flushed and reseeded the frame, dropping every op queued since the last Present, including staged VB/IB upload blits whose dirty bits were already cleared and the `reset_to_defaults` ops on both paths. The dims-unchanged arm now flushes the current frame before the shared tail, and the tail reseeds before `reset_to_defaults` so those ops survive. An end-to-end test queues uploads, resets same-size and checks they landed; it fails on the previous code.

The Direct VB/IB wrapper cache keyed a `bytesNoCopy` MTLBuffer on (backing pointer, length). `PageBox` allocations in the large band bypass the allocator's local cache: a rename whose old box misses the pool decommits its pages, and a later same-address allocation gets fresh pages while the cached wrapper keeps the old pinned ones. `PageBox` gains a monotonically increasing generation that survives pool parking; the backing, the stream and index bindings, the warm-up entries and the GPU state carry it, and a cache hit requires the generation to match, so a same-address different-allocation bind recreates the wrapper. This one has no deterministic test; it needs the kernel to replace pages under a reused address, which the run-S reconstruction proof documented.

The slot-0 vertex bind dedup and the retention intake compared Metal handles (object addresses) alone; both now carry the backing generation, re-emit or leave alone on a mismatch and warn once, so the guarantee the retention schedule gives is a local check.

## Verification

`make check` and `make test` green on both architectures. Conformance ran on the branch these were developed on with no regressions and 23 device sites improved on both architectures (i686 757 to 734, x86_64 755 to 732).
