### PR TITLE
Log every line to a per-process file beside the executable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,9 @@ and still shows as passing means that hook is not in place.
 So capture with a plain redirect, in this order, `make test > out.log 2>&1`, and
 judge the run by grepping per-test results on both architectures rather than by
 the summary or by `$?`. Every test name appears once per architecture, and the
-occasional `LEAK` line is benign.
+occasional `LEAK` line is benign. The runner's output carries the harness's own
+lines only; mtld3d's log of each test process is a file, `<test>-<pid>.log` under
+`mtld3d-logs` next to the test executable in `windows/target`.
 
 ## Which suite is right when they disagree
 

--- a/README.md
+++ b/README.md
@@ -443,10 +443,10 @@ gets one `[dump]` line at info level for every D3D9 event of those frames
 that a GPU trace cannot show: render-target, depth-stencil, viewport and
 scissor changes, clears, surface copies, occlusion query traffic, and every
 draw with the states that decide its pass shape, its shaders and its
-textures. At the same time a Metal GPU trace of the same frames lands at
-`/tmp/mtld3d_capture.gputrace`, overwritten by the next press; the process
-needs `MTL_CAPTURE_ENABLED=1` in its environment for that half (the launcher
-passes it through), otherwise the log says so and the dump still runs. The
+textures. At the same time a Metal GPU trace of the same frames lands beside
+the process's log file as `<exe>-<pid>-<n>.gputrace`, numbered per press; the
+process needs `MTL_CAPTURE_ENABLED=1` in its environment for that half (the
+launcher passes it through), otherwise the log says so and the dump still runs. The
 two sides name each other: each `frame end` line carries the label of the
 frame's command buffer, and every dumped draw sits in a `draw N` debug group
 in the trace, so `gpudebug`'s `find` or Xcode's search lands on it directly.
@@ -454,6 +454,14 @@ in the trace, so `gpudebug`'s `find` or Xcode's search lands on it directly.
 Each cdylib initializes the logger independently and idempotently; `mtld3d.so`
 has no owning entry point, so `d3d9.dll` dispatches a one-shot `InitLogger`
 thunk from its init path.
+
+Every line goes to a file, never to the process's standard streams: a game a
+launcher spawned has no usable ones, and a launcher's own log dies with its
+pipe. Each process writes `<exe>-<pid>.log` into `mtld3d-logs` beside the
+executable, so a launch never overwrites the log of the one before it, and
+the GPU traces F12 captures land next to it as `<exe>-<pid>-<n>.gputrace`.
+`log.dir` in `mtld3d.conf` moves the directory; the file appears with the
+first line written, so a process that logs nothing leaves nothing behind.
 
 ## Contributing
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,7 +27,7 @@ A dedicated **encoder thread** (one per device, `sync_channel(1)` backpressure) 
 
 A dedicated **submit thread** (one per device) executes the `SubmitFrame` thunk — the cross-boundary command replay, the `nextDrawable` wait, present, and commit — overlapping the encoder's build of the next frame. The frame crosses as an owned `FramePayload` holding every buffer the thunk aliases by raw pointer; two payloads ping-pong over a cap-1 work channel, so render-ahead is bounded at one frame. Rare synchronous submits (`Reset`, mid-frame flushes, GPU capture) first drain the submit thread to idle, then run the thunk inline on the encoder thread — the two paths never call `SubmitFrame` concurrently and present order is preserved.
 
-A **log thread** (one per process) is the only thread that thunks for logging. d3d9.dll's `env_logger` sink pushes each formatted line onto an unbounded channel and returns, so a log line costs the API and encoder threads an allocation and a queue push; the log thread drains the queue and forwards every line through the `WriteLog` thunk to the process's unix stderr, the stream wine's own debug output and the unix side's logger use, whatever Windows standard handles the process was started with. The thread starts from the first `Direct3DCreate9`, never from `DllMain` (loader lock); lines logged before that wait in the queue.
+A **log thread** (one per process) is the only thread that thunks for logging. d3d9.dll's `env_logger` sink pushes each formatted line onto an unbounded channel and returns, so a log line costs the API and encoder threads an allocation and a queue push; the log thread drains the queue and forwards every line through the `WriteLog` thunk into the process's log file, which the unix side owns and its own logger and crash handler write too. The thread starts from the first `Direct3DCreate9`, never from `DllMain` (loader lock), after the resolved `mtld3d.conf` has named the file's location through the `OpenLog` thunk; lines logged before that wait in the queue on the PE side and in the file sink's backlog on the unix side, so the file starts with the identity lines.
 
 ```
 API thread                     Encoder thread              Submit thread
@@ -120,7 +120,7 @@ Counter aggregation — mixing these up misreads the log:
 - **Cache-size snapshots**: point-in-time at window emit, neither averaged nor summed.
 - **Peak counters** (`peak …` cells): max value on any single frame in the window.
 
-ANSI colour by default. Override with `NO_COLOR=1` (no escapes when redirecting to a file) or `CLICOLOR_FORCE=1`. Auto-detection via `is_terminal()` is not used: under Wine the Windows console check returns false even when macOS fd 2 is a real TTY.
+No ANSI colour anywhere: every line goes to the process's log file, and `env_logger` is told so (`WriteStyle::Never`) rather than left to auto-detect a terminal, which under Wine would be wrong in both directions.
 
 ### Don't hand-roll `rdtsc()` brackets — use `perf::ApiTimer` / `CycleSetTimer` / `CycleAddTimer`
 

--- a/mtld3d.conf
+++ b/mtld3d.conf
@@ -35,6 +35,28 @@
 # the profiles that ship and what each one is for.
 
 
+###########
+# Logging #
+###########
+
+# Directory the process's log file and GPU traces go into.
+#
+# Every line of both halves of mtld3d goes to a file, never to the process's
+# standard streams: a game a launcher spawned has no usable ones, and a
+# launcher's own log dies with its pipe. Each process writes
+# `<exe>-<pid>.log` here, so a launch never overwrites the log of the one
+# before it, and the GPU traces F12 captures land next to it as
+# `<exe>-<pid>-<n>.gputrace`. The file appears with the first line written,
+# so a process that logs nothing (`RUST_LOG=off`) leaves nothing behind. A
+# directory that cannot be created falls back to stderr with one line
+# saying so.
+#
+# Default: "" (`mtld3d-logs` next to the executable)
+# Supported values: a directory path, relative to the executable's
+# directory or absolute; empty means the default
+
+# log.dir = ""
+
 ##########
 # Color  #
 ##########

--- a/unix/shared/src/crumb.rs
+++ b/unix/shared/src/crumb.rs
@@ -189,17 +189,18 @@ mod enabled {
         unsafe { core::ptr::write(entry_ptr, new_entry) };
     }
 
-    /// Dump the last `n` entries to the side's stderr sink.
+    /// Dump the last `n` entries to the side's write sink.
     ///
-    /// Async-signal-safe: only `write` (unix) / `WriteFile` (PE), no
-    /// allocator, no locks. Tolerates torn writes on the most recent slot
-    /// (skipped if `seq` doesn't match the expected position).
+    /// Async-signal-safe: only a raw `write` on the unix side and the
+    /// synchronous log thunk on the PE side, no allocator, no locks.
+    /// Tolerates torn writes on the most recent slot (skipped if `seq`
+    /// doesn't match the expected position).
     #[inline]
-    /// Route every dump line through `sink` as well as stderr.
+    /// Route every dump line through `sink`.
     ///
-    /// The PE side installs its unix log thunk here: a launcher-spawned
-    /// game has no stderr handle, so a dump written only there is lost.
-    /// No-op on unix, where stderr is the log already.
+    /// The PE side installs its synchronous unix log thunk here, the unix
+    /// side the raw-descriptor writer of its log file; until a sink is set
+    /// the unix side falls back to fd 2 and the PE side drops the line.
     pub fn set_write_sink(sink: fn(&[u8])) {
         platform::set_write_sink(sink);
     }
@@ -300,7 +301,12 @@ mod enabled {
 
         use super::{Entry, FILE_SIZE, Header};
 
-        pub fn set_write_sink(_sink: fn(&[u8])) {}
+        /// Where dump lines go, see `enabled::set_write_sink`.
+        static WRITE_SINK: std::sync::OnceLock<fn(&[u8])> = std::sync::OnceLock::new();
+
+        pub fn set_write_sink(sink: fn(&[u8])) {
+            let _ = WRITE_SINK.set(sink);
+        }
 
         pub fn current_tid() -> u32 {
             // SAFETY: pthread_self is async-signal-safe.
@@ -313,6 +319,12 @@ mod enabled {
         }
 
         pub fn write_str(bytes: &[u8]) {
+            // The sink writes the process's log file on its raw descriptor
+            // (async-signal-safe); until one is set, fd 2 is all there is.
+            if let Some(sink) = WRITE_SINK.get() {
+                sink(bytes);
+                return;
+            }
             // SAFETY: write(2) on fd 2 is async-signal-safe.
             unsafe {
                 let _ = libc::write(2, bytes.as_ptr().cast::<c_void>(), bytes.len());
@@ -386,9 +398,8 @@ mod enabled {
         const PAGE_READWRITE: u32 = 0x04;
         const FILE_MAP_WRITE: u32 = 0x02;
         const INVALID_HANDLE_VALUE: *mut c_void = !0usize as *mut c_void;
-        const STD_ERROR_HANDLE: u32 = 0xFFFF_FFF4;
 
-        /// Extra destination for dump lines, see `enabled::set_write_sink`.
+        /// Where dump lines go, see `enabled::set_write_sink`.
         static WRITE_SINK: std::sync::OnceLock<fn(&[u8])> = std::sync::OnceLock::new();
 
         pub fn set_write_sink(sink: fn(&[u8])) {
@@ -421,14 +432,6 @@ mod enabled {
                 dw_number_of_bytes_to_map: u32,
             ) -> *mut c_void;
             fn GetCurrentThreadId() -> u32;
-            fn GetStdHandle(n_std_handle: u32) -> *mut c_void;
-            fn WriteFile(
-                h_file: *mut c_void,
-                lp_buffer: *const u8,
-                n_number_of_bytes_to_write: u32,
-                lp_number_of_bytes_written: *mut u32,
-                lp_overlapped: *mut c_void,
-            ) -> i32;
         }
 
         pub fn current_tid() -> u32 {
@@ -437,24 +440,11 @@ mod enabled {
         }
 
         pub fn write_str(bytes: &[u8]) {
+            // The sink is the synchronous `WriteLog` thunk, which lands in
+            // the process's log file; a PE side without one has nowhere a
+            // dump line could go.
             if let Some(sink) = WRITE_SINK.get() {
                 sink(bytes);
-            }
-            // SAFETY: kernel32 WriteFile on the std error handle. Wine
-            // routes fd 2 and STD_ERROR_HANDLE to the same terminal.
-            unsafe {
-                let h = GetStdHandle(STD_ERROR_HANDLE);
-                if h.is_null() || h == INVALID_HANDLE_VALUE {
-                    return;
-                }
-                let mut written = 0u32;
-                let _ = WriteFile(
-                    h,
-                    bytes.as_ptr(),
-                    u32::try_from(bytes.len()).unwrap_or(u32::MAX),
-                    &raw mut written,
-                    core::ptr::null_mut(),
-                );
             }
         }
 

--- a/unix/shared/src/lib.rs
+++ b/unix/shared/src/lib.rs
@@ -8,6 +8,7 @@ pub mod ftol;
 pub mod identity;
 mod log_filter;
 mod log_helpers;
+pub mod log_paths;
 pub mod mtl;
 pub mod mtl_handle;
 mod params;
@@ -30,9 +31,10 @@ pub use params::{
     CreateTextureSliceViewParams, CreateTexturesBatchParams, DestroyCommandQueueParams,
     DestroyResourcesBulkParams, EnsureBlitPipelineParams, EnsureClearQuadPipelineParams,
     ExtraColorAttachmentParams, ExtraColorDesc, GetDeviceInfoParams, GetTaskFaultsParams,
-    InitLoggerParams, PassDescriptor, SetDisplaySyncEnabledParams, StartGpuCaptureParams,
-    StencilFaceParams, StopGpuCaptureParams, SubmitFrameParams, TextureCreateDesc, VertexAttrDesc,
-    VertexBufferLayoutDesc, WaitForGpuRetireParams, WriteLogParams,
+    InitLoggerParams, OpenLogParams, PassDescriptor, SetDisplaySyncEnabledParams,
+    StartGpuCaptureParams, StencilFaceParams, StopGpuCaptureParams, SubmitFrameParams,
+    TextureCreateDesc, VertexAttrDesc, VertexBufferLayoutDesc, WaitForGpuRetireParams,
+    WriteLogParams,
 };
 
 #[repr(u32)]
@@ -64,6 +66,7 @@ pub enum Thunks {
     CreateTextureSliceView,
     GetTaskFaults,
     WriteLog,
+    OpenLog,
 }
 
 pub trait Thunk {

--- a/unix/shared/src/log_filter.rs
+++ b/unix/shared/src/log_filter.rs
@@ -5,22 +5,18 @@
 /// thunk on the unix side). `try_init` is idempotent so repeat calls silently
 /// no-op.
 ///
-/// Forces `WriteStyle::Always` on every target: the PE side runs inside
-/// Wine where stderr-is-a-TTY auto-detection returns false even when
-/// macOS fd 2 is a real terminal, and we want consistent colour across
-/// all three linkage units. `NO_COLOR=1` opts out — `env_logger` only reads
-/// it under `WriteStyle::Auto`, so we have to pre-resolve the choice here.
+/// Every line goes to the process's log file (see the `OpenLog` thunk), so
+/// no target ever colours: `WriteStyle::Never` on all three linkage units
+/// keeps escape sequences out of the file.
 pub fn init_logger() {
     init(None);
 }
 
 /// Register `env_logger` writing every formatted line into `sink`.
 ///
-/// The PE side uses this with a sink that crosses to the unix side: a game a
-/// launcher spawned often has no usable Windows standard handles, so the
-/// default stderr target would discard every line, while the unix side's
-/// stderr is the launcher's log regardless. Filter and style match
-/// [`init_logger`].
+/// The PE side uses this with a sink that crosses to the unix side, which
+/// owns the process's log file; the unix side uses it with the file itself.
+/// Filter and style match [`init_logger`].
 pub fn init_logger_to(sink: Box<dyn std::io::Write + Send + 'static>) {
     init(Some(sink));
 }
@@ -28,13 +24,10 @@ pub fn init_logger_to(sink: Box<dyn std::io::Write + Send + 'static>) {
 fn init(sink: Option<Box<dyn std::io::Write + Send + 'static>>) {
     let user = std::env::var("RUST_LOG").ok();
     let filter = resolved_log_filter(user.as_deref());
-    let style = if std::env::var_os("NO_COLOR").is_some() {
-        env_logger::WriteStyle::Never
-    } else {
-        env_logger::WriteStyle::Always
-    };
     let mut builder = env_logger::Builder::new();
-    builder.parse_filters(&filter).write_style(style);
+    builder
+        .parse_filters(&filter)
+        .write_style(env_logger::WriteStyle::Never);
     if let Some(sink) = sink {
         builder.target(env_logger::Target::Pipe(sink));
     }

--- a/unix/shared/src/log_paths.rs
+++ b/unix/shared/src/log_paths.rs
@@ -1,0 +1,21 @@
+//! Names of the files one process writes into its log directory.
+//!
+//! Both sides agree on them: the PE side names the directory, the unix side
+//! opens the files. One log per process, so a launch never overwrites the
+//! log of the one before it, and the GPU traces of a process sit next to
+//! its log under the same prefix.
+
+/// The log file of process `pid` running executable `stem`: `<stem>-<pid>.log`.
+#[must_use]
+pub fn log_file_name(stem: &str, pid: u32) -> String {
+    format!("{stem}-{pid}.log")
+}
+
+/// The `index`-th GPU trace of that process: `<stem>-<pid>-<index>.gputrace`.
+#[must_use]
+pub fn trace_file_name(stem: &str, pid: u32, index: u32) -> String {
+    format!("{stem}-{pid}-{index}.gputrace")
+}
+
+#[cfg(test)]
+mod tests;

--- a/unix/shared/src/log_paths/tests.rs
+++ b/unix/shared/src/log_paths/tests.rs
@@ -1,0 +1,13 @@
+//! File names of one process's log and traces.
+//!
+//! They share the `<stem>-<pid>` prefix, so a process's traces sort next to its log; the
+//! trace index is the only difference.
+
+use super::{log_file_name, trace_file_name};
+
+#[test]
+fn log_and_trace_names_share_the_process_prefix() {
+    assert_eq!(log_file_name("hl2", 1234), "hl2-1234.log");
+    assert_eq!(trace_file_name("hl2", 1234, 1), "hl2-1234-1.gputrace");
+    assert!(trace_file_name("hl2", 1234, 7).starts_with("hl2-1234-"));
+}

--- a/unix/shared/src/params.rs
+++ b/unix/shared/src/params.rs
@@ -83,6 +83,29 @@ impl Thunk for WriteLogParams {
     const CODE: u32 = Thunks::WriteLog as u32;
 }
 
+/// Where this process's log file and GPU traces go, sent once per process.
+///
+/// `Direct3DCreate9` resolves `mtld3d.conf` long after `InitLogger` fired
+/// from `DllMain`, so the location travels separately. `dir` is the unix
+/// path of the log directory, `stem` the executable's file name without its
+/// extension, both UTF-8 without a terminator and kept alive by the PE side
+/// for the call; `pid` names the process. The unix side opens
+/// `<dir>/<stem>-<pid>.log` on the first line it writes and numbers the
+/// traces `<dir>/<stem>-<pid>-<n>.gputrace`.
+#[repr(C, align(8))]
+pub struct OpenLogParams {
+    pub dir_ptr: u64,  // in: *const u8
+    pub stem_ptr: u64, // in: *const u8
+    pub dir_len: u32,  // in: byte count
+    pub stem_len: u32, // in: byte count
+    pub pid: u32,
+    pub pad0: u32,
+}
+
+impl Thunk for OpenLogParams {
+    const CODE: u32 = Thunks::OpenLog as u32;
+}
+
 #[repr(C, align(8))]
 pub struct GetDeviceInfoParams {
     pub name_ptr: u64,
@@ -238,7 +261,9 @@ impl Thunk for WaitForGpuRetireParams {
 
 /// Begin a Metal GPU frame capture writing a `.gputrace` document to disk.
 ///
-/// The path is hard-coded to `/tmp/mtld3d_capture.gputrace`.
+/// The trace goes next to the process's log file, numbered per capture
+/// (`<stem>-<pid>-<n>.gputrace`), or to `/tmp/mtld3d_capture.gputrace` when
+/// no log location was named.
 ///
 /// Apple requires the process to have launched with `MTL_CAPTURE_ENABLED=1`;
 /// without it the unix-side handler logs a warn and returns without

--- a/unix/shared/src/params/tests.rs
+++ b/unix/shared/src/params/tests.rs
@@ -40,6 +40,14 @@ fn attach_metal_layer_layout() {
 }
 
 #[test]
+fn open_log_layout() {
+    use super::OpenLogParams;
+    // 2*u64 + 4*u32 = 16 + 16 = 32
+    assert_eq!(core::mem::align_of::<OpenLogParams>(), 8);
+    assert_eq!(core::mem::size_of::<OpenLogParams>(), 32);
+}
+
+#[test]
 fn set_display_sync_enabled_layout() {
     use super::SetDisplaySyncEnabledParams;
     // u64 + u32 + u32 = 8 + 4 + 4 = 16

--- a/unix/unix/src/crash.rs
+++ b/unix/unix/src/crash.rs
@@ -2,7 +2,7 @@
 //!
 //! Installed once from `init_logger_handler`. Catches SIGSEGV, SIGBUS,
 //! SIGABRT. The handler is async-signal-safe — it only calls
-//! `libc::write` on fd 2 and `mtld3d_shared::crumb::dump_recent` (which is
+//! `libc::write` on the log file's descriptor and `mtld3d_shared::crumb::dump_recent` (which is
 //! itself async-signal-safe). On a fatal signal in OUR code the handler:
 //!
 //! 1. Writes a single-line fatal banner identifying the signal and the
@@ -224,9 +224,13 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
     }
     push(&mut buf, &mut pos, b"\n");
 
-    // SAFETY: write(2) on fd 2 is async-signal-safe.
+    // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
     unsafe {
-        let _ = libc::write(2, buf.as_ptr().cast::<c_void>(), pos);
+        let _ = libc::write(
+            crate::log_file::raw_fd(),
+            buf.as_ptr().cast::<c_void>(),
+            pos,
+        );
     }
 
     // Faulting thread name. For a teardown race the *which thread* (API vs
@@ -251,9 +255,9 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
         push(&mut b, &mut p, b"[mtld3d::unix] thread=");
         push(&mut b, &mut p, &name[..nlen.min(96)]);
         push(&mut b, &mut p, b"\n");
-        // SAFETY: write(2) on fd 2 is async-signal-safe.
+        // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
         unsafe {
-            let _ = libc::write(2, b.as_ptr().cast::<c_void>(), p);
+            let _ = libc::write(crate::log_file::raw_fd(), b.as_ptr().cast::<c_void>(), p);
         }
     }
 
@@ -270,14 +274,14 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
         push(&mut b, &mut p, b"[mtld3d::unix] fault_pc=");
         push_hex(&mut b, &mut p, rip);
         push(&mut b, &mut p, b"\n");
-        // SAFETY: write(2) on fd 2 is async-signal-safe.
+        // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
         unsafe {
-            let _ = libc::write(2, b.as_ptr().cast::<c_void>(), p);
+            let _ = libc::write(crate::log_file::raw_fd(), b.as_ptr().cast::<c_void>(), p);
         }
         let mut frame = [rip as *mut c_void; 1];
         // SAFETY: single in-bounds frame pointer; `backtrace_symbols_fd` is
-        // async-signal-safe (resolves via `dladdr`, no malloc) and writes to fd 2.
-        unsafe { backtrace_symbols_fd(frame.as_mut_ptr(), 1, 2) };
+        // async-signal-safe (resolves via `dladdr`, no malloc) and writes to the log descriptor.
+        unsafe { backtrace_symbols_fd(frame.as_mut_ptr(), 1, crate::log_file::raw_fd()) };
     }
 
     // For a jump-through-garbage fault (`fault_pc` is a tiny/invalid value), the
@@ -304,9 +308,9 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
         push(&mut b, &mut p, b" sp=");
         push_hex(&mut b, &mut p, sp);
         push(&mut b, &mut p, b"\n");
-        // SAFETY: write(2) on fd 2 is async-signal-safe.
+        // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
         unsafe {
-            let _ = libc::write(2, b.as_ptr().cast::<c_void>(), p);
+            let _ = libc::write(crate::log_file::raw_fd(), b.as_ptr().cast::<c_void>(), p);
         }
         let ret = caller_pc(ctx, sp);
         if ret != 0 {
@@ -316,14 +320,14 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
             push(&mut rb, &mut rp, CALLER_LABEL);
             push_hex(&mut rb, &mut rp, ret);
             push(&mut rb, &mut rp, b"\n");
-            // SAFETY: write(2) on fd 2 is async-signal-safe.
+            // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
             unsafe {
-                let _ = libc::write(2, rb.as_ptr().cast::<c_void>(), rp);
+                let _ = libc::write(crate::log_file::raw_fd(), rb.as_ptr().cast::<c_void>(), rp);
             }
             let mut frame = [ret as *mut c_void; 1];
             // SAFETY: single in-bounds frame pointer; `backtrace_symbols_fd` is
-            // async-signal-safe (resolves via `dladdr`) and writes to fd 2.
-            unsafe { backtrace_symbols_fd(frame.as_mut_ptr(), 1, 2) };
+            // async-signal-safe (resolves via `dladdr`) and writes to the log descriptor.
+            unsafe { backtrace_symbols_fd(frame.as_mut_ptr(), 1, crate::log_file::raw_fd()) };
         }
     }
 
@@ -331,7 +335,7 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
 
     // Native backtrace of the faulting thread. `backtrace` only walks frame
     // pointers (no allocation) and `backtrace_symbols_fd` resolves each via
-    // `dladdr` straight to fd 2 — both async-signal-safe (unlike
+    // `dladdr` straight to the log descriptor — both async-signal-safe (unlike
     // `backtrace_symbols`, which mallocs). Symbolises our `.so`, Wine, and
     // system frames (Metal/CoreAnimation), turning a bare fault address into a
     // call chain.
@@ -341,13 +345,17 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
     let n = unsafe { backtrace(frames.as_mut_ptr(), FRAME_CAP) };
     if n > 0 {
         const HDR: &[u8] = b"[mtld3d::unix] native backtrace:\n";
-        // SAFETY: write(2) on fd 2 is async-signal-safe.
+        // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
         unsafe {
-            let _ = libc::write(2, HDR.as_ptr().cast::<c_void>(), HDR.len());
+            let _ = libc::write(
+                crate::log_file::raw_fd(),
+                HDR.as_ptr().cast::<c_void>(),
+                HDR.len(),
+            );
         }
         // SAFETY: `frames[..n]` were filled by `backtrace`; `backtrace_symbols_fd`
         // is async-signal-safe and writes the resolved frames to fd 2.
-        unsafe { backtrace_symbols_fd(frames.as_ptr(), n, 2) };
+        unsafe { backtrace_symbols_fd(frames.as_ptr(), n, crate::log_file::raw_fd()) };
     }
 
     // Last resort for a jump-to-NULL whose frame chain is broken: scan the raw
@@ -362,9 +370,13 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
         let sp = mcontext_u64(ctx, SP_OFFSET);
         if sp != 0 {
             const HDR: &[u8] = b"[mtld3d::unix] mtld3d.so return addrs on stack:\n";
-            // SAFETY: write(2) on fd 2 is async-signal-safe.
+            // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
             unsafe {
-                let _ = libc::write(2, HDR.as_ptr().cast::<c_void>(), HDR.len());
+                let _ = libc::write(
+                    crate::log_file::raw_fd(),
+                    HDR.as_ptr().cast::<c_void>(),
+                    HDR.len(),
+                );
             }
             scan_stack_for_our_frames(sp);
         }
@@ -406,7 +418,7 @@ fn scan_stack_for_our_frames(sp: u64) {
             let mut frame = [addr as *mut c_void; 1];
             // SAFETY: single in-bounds frame pointer; `backtrace_symbols_fd`
             // resolves via `dladdr` and writes to fd 2.
-            unsafe { backtrace_symbols_fd(frame.as_mut_ptr(), 1, 2) };
+            unsafe { backtrace_symbols_fd(frame.as_mut_ptr(), 1, crate::log_file::raw_fd()) };
             printed += 1;
         }
         slot += 1;
@@ -419,9 +431,13 @@ fn scan_stack_for_our_frames(sp: u64) {
     // real guest call chain (its 0x4xxxxx–0x7xxxxx return addresses) is shown,
     // mapped to modules by their logged load bases.
     //
-    // SAFETY: write(2) on fd 2 is async-signal-safe.
+    // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
     unsafe {
-        let _ = libc::write(2, GUEST_HDR.as_ptr().cast::<c_void>(), GUEST_HDR.len());
+        let _ = libc::write(
+            crate::log_file::raw_fd(),
+            GUEST_HDR.as_ptr().cast::<c_void>(),
+            GUEST_HDR.len(),
+        );
     }
     let mut guest_printed = 0u32;
     let mut slot = 0usize;
@@ -439,9 +455,9 @@ fn scan_stack_for_our_frames(sp: u64) {
             push(&mut b, &mut p, b"  g=");
             push_hex(&mut b, &mut p, u64::from(guest_addr));
             push(&mut b, &mut p, b"\n");
-            // SAFETY: write(2) on fd 2 is async-signal-safe.
+            // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
             unsafe {
-                let _ = libc::write(2, b.as_ptr().cast::<c_void>(), p);
+                let _ = libc::write(crate::log_file::raw_fd(), b.as_ptr().cast::<c_void>(), p);
             }
             guest_printed += 1;
         }

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -8,7 +8,7 @@ use mtld3d_shared::{
     CreateDepthTextureParams, CreateRenderPipelineParams, CreateSamplerStateParams,
     CreateTextureSliceViewParams, CreateTexturesBatchParams, DestroyCommandQueueParams,
     DestroyResourcesBulkParams, EnsureBlitPipelineParams, EnsureClearQuadPipelineParams,
-    GetDeviceInfoParams, GetTaskFaultsParams, InPtr, InPtrMut, MetalHandle,
+    GetDeviceInfoParams, GetTaskFaultsParams, InPtr, InPtrMut, MetalHandle, OpenLogParams,
     SetDisplaySyncEnabledParams, StartGpuCaptureParams, SubmitFrameParams, TextureCreateDesc,
     VertexAttrDesc, VertexBufferLayoutDesc, WaitForGpuRetireParams, WriteLogParams, identity,
     mtl::{DestroyKind, QuadPipelineKind},
@@ -33,7 +33,9 @@ pub extern "C" fn init_logger_handler(_args: *mut c_void) -> i32 {
     // here rather than each callee carrying its own idempotency flag.
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {
-        mtld3d_shared::init_logger();
+        // Every line goes to the process's log file once `OpenLog` names
+        // it; the file sink keeps the lines logged before that.
+        mtld3d_shared::init_logger_to(Box::new(crate::log_file::FileSink));
         log_identity();
         // Latch the unix-side perf-tracking gate (`PERF_TRACKING_ENABLED`)
         // from `RUST_LOG`. Per-cdylib because each cdylib has its own
@@ -42,6 +44,7 @@ pub extern "C" fn init_logger_handler(_args: *mut c_void) -> i32 {
         // Map the shared crash crumb (cfg-gated no-op in production) and
         // install the always-on signal handler.
         mtld3d_shared::crumb::init();
+        mtld3d_shared::crumb::set_write_sink(crate::log_file::write_bytes);
         crate::crash::install();
         // Declare to macOS that we're a latency-critical game, not idle UI, so
         // it keeps the process out of App Nap / display throttling and the
@@ -54,11 +57,9 @@ pub extern "C" fn init_logger_handler(_args: *mut c_void) -> i32 {
 
 /// `WriteLog`: the sink behind the PE-side logger.
 ///
-/// Writes the formatted line to this process's unix stderr, the stream wine's
-/// own debug output uses, so d3d9.dll lines land next to the unix side's
-/// whatever Windows standard handles the process was started with (a game a
-/// launcher spawned often has none, and `std::io::stderr` on the PE side
-/// would discard the line).
+/// Writes the formatted line into this process's log file, next to the unix
+/// side's own lines; the PE side has no usable standard handles of its own
+/// when a launcher spawned the game.
 pub extern "C" fn write_log_handler(args: *mut c_void) -> i32 {
     // SAFETY: unix-call handler params; PE side passes *mut WriteLogParams.
     let Some(params) = (unsafe { InPtrMut::<WriteLogParams>::opt(args) }) else {
@@ -71,10 +72,41 @@ pub extern "C" fn write_log_handler(args: *mut c_void) -> i32 {
     // duration; the pointer is non-zero per the check above.
     let bytes =
         unsafe { core::slice::from_raw_parts(params.ptr as *const u8, params.len as usize) };
-    let mut stderr = std::io::stderr().lock();
-    if std::io::Write::write_all(&mut stderr, bytes).is_err() {
-        return STATUS_UNSUCCESSFUL;
+    crate::log_file::write_all(bytes);
+    STATUS_SUCCESS
+}
+
+/// `OpenLog`: where this process's log file and GPU traces go, once per process.
+///
+/// The lines logged since `InitLogger` wait in the file sink's backlog for
+/// this, so the PE side sends it before it starts its own log thread. The
+/// file itself appears with the first line written after this.
+pub extern "C" fn open_log_handler(args: *mut c_void) -> i32 {
+    // SAFETY: unix-call handler params; PE side passes *mut OpenLogParams.
+    let Some(params) = (unsafe { InPtrMut::<OpenLogParams>::opt(args) }) else {
+        return -1;
+    };
+    if params.dir_ptr == 0 || params.dir_len == 0 || params.stem_ptr == 0 {
+        // The PE side found no usable location; its warn said why.
+        crate::log_file::fall_back_to_stderr();
+        return STATUS_SUCCESS;
     }
+    // SAFETY: PE supplied `dir_ptr`/`dir_len` as a byte slice valid for the
+    // call duration; the pointer is non-zero per the check above.
+    let dir = unsafe {
+        core::slice::from_raw_parts(params.dir_ptr as *const u8, params.dir_len as usize)
+    };
+    // SAFETY: same contract for `stem_ptr`/`stem_len`.
+    let stem = unsafe {
+        core::slice::from_raw_parts(params.stem_ptr as *const u8, params.stem_len as usize)
+    };
+    let (Ok(dir), Ok(stem)) = (core::str::from_utf8(dir), core::str::from_utf8(stem)) else {
+        warn!(target: LOG_TARGET, "OpenLog: the location is not UTF-8, logging to stderr");
+        crate::log_file::fall_back_to_stderr();
+        return STATUS_UNSUCCESSFUL;
+    };
+    let path = crate::log_file::open(dir, stem, params.pid);
+    info!(target: LOG_TARGET, "log file: {}", path.display());
     STATUS_SUCCESS
 }
 

--- a/unix/unix/src/lib.rs
+++ b/unix/unix/src/lib.rs
@@ -5,6 +5,7 @@ use strum::{EnumCount, VariantArray};
 
 mod crash;
 mod handlers;
+mod log_file;
 mod metal;
 
 /// `log` target used by every call inside this crate.
@@ -73,6 +74,7 @@ const fn dispatch(code: Thunks) -> UnixCallFn {
         Thunks::CreateTextureSliceView => arp!(handlers::create_texture_slice_view_handler),
         Thunks::GetTaskFaults => arp!(handlers::get_task_faults_handler),
         Thunks::WriteLog => arp!(handlers::write_log_handler),
+        Thunks::OpenLog => arp!(handlers::open_log_handler),
     }
 }
 

--- a/unix/unix/src/log_file.rs
+++ b/unix/unix/src/log_file.rs
@@ -1,0 +1,256 @@
+//! The process's log file, and the directory its GPU traces share.
+//!
+//! Every line of both sides ends here: the unix `env_logger` target
+//! ([`FileSink`]), the `WriteLog` handler that carries d3d9.dll's lines, and
+//! the crash paths ([`write_raw`], [`write_bytes`], on the raw descriptor
+//! because a signal handler may not take the mutex). The PE side names the
+//! directory through the `OpenLog` thunk once `mtld3d.conf` is resolved at
+//! `Direct3DCreate9`; the unix logger has been running since `DllMain`'s
+//! `InitLogger` by then, so the lines of that gap wait in a backlog and go
+//! out first. The d3d9.dll side needs no backlog of its own: its log thread
+//! starts after `OpenLog`, so its queue still holds every line from `DllMain`.
+//!
+//! The file is created on the first line written after the location is
+//! known, not when it is named: a process that logs nothing (`RUST_LOG=off`,
+//! the conformance runner) leaves no empty file behind. A location that
+//! cannot be created or opened falls back to stderr with one line saying so.
+
+use core::ffi::c_void;
+use std::{
+    fs::{File, OpenOptions},
+    io::Write,
+    os::fd::AsRawFd,
+    path::PathBuf,
+    sync::{
+        Mutex,
+        atomic::{AtomicI32, AtomicU32, Ordering},
+    },
+};
+
+/// Bytes the backlog keeps while the location is pending.
+///
+/// The gap between `InitLogger` and `OpenLog` holds a handful of lines; the
+/// cap only matters for a process that loads d3d9.dll and never creates a
+/// device, where the backlog would otherwise grow for the process lifetime.
+const BACKLOG_CAP: usize = 1024 * 1024;
+
+/// Where a line goes.
+enum Sink {
+    /// Location not known yet: keep the line for the file that will come.
+    ///
+    /// `truncated` records that the cap dropped lines, so the file can say
+    /// its start is incomplete.
+    Pending { backlog: Vec<u8>, truncated: bool },
+    /// Location known, file not created yet: the first line creates it.
+    Lazy {
+        path: PathBuf,
+        backlog: Vec<u8>,
+        truncated: bool,
+    },
+    /// The open log file.
+    Open(File),
+    /// The location failed; stderr is the fallback.
+    Stderr,
+}
+
+static SINK: Mutex<Sink> = Mutex::new(Sink::Pending {
+    backlog: Vec::new(),
+    truncated: false,
+});
+
+/// The open file's descriptor for the lock-free crash paths; `-1` when closed.
+static LOG_FD: AtomicI32 = AtomicI32::new(-1);
+
+/// Where GPU traces go: the log directory plus the process prefix.
+static TRACE_BASE: Mutex<Option<(PathBuf, String, u32)>> = Mutex::new(None);
+
+/// Traces written by this process so far, for numbering the next one.
+static TRACE_COUNT: AtomicU32 = AtomicU32::new(0);
+
+/// Name the log location: `<dir>/<stem>-<pid>.log`, created on the first line.
+///
+/// Returns the path the file will have. Nothing is created here; a location
+/// that turns out unusable is reported by the first write, which then falls
+/// back to stderr.
+pub fn open(dir: &str, stem: &str, pid: u32) -> PathBuf {
+    let dir = PathBuf::from(dir);
+    let path = dir.join(mtld3d_shared::log_paths::log_file_name(stem, pid));
+    let mut guard = SINK.lock().expect("log file mutex poisoned");
+    let (backlog, truncated) = match core::mem::replace(&mut *guard, Sink::Stderr) {
+        Sink::Pending { backlog, truncated }
+        | Sink::Lazy {
+            backlog, truncated, ..
+        } => (backlog, truncated),
+        // A second `Direct3DCreate9` names the location again: the file
+        // already open keeps everything, and stderr has no backlog.
+        Sink::Open(file) => {
+            *guard = Sink::Open(file);
+            return path;
+        }
+        Sink::Stderr => (Vec::new(), false),
+    };
+    *guard = Sink::Lazy {
+        path: path.clone(),
+        backlog,
+        truncated,
+    };
+    drop(guard);
+    *TRACE_BASE.lock().expect("trace base mutex poisoned") = Some((dir, stem.to_owned(), pid));
+    path
+}
+
+/// Give up on a file: the backlog and everything after it go to stderr.
+pub fn fall_back_to_stderr() {
+    let mut guard = SINK.lock().expect("log file mutex poisoned");
+    let spill = match core::mem::replace(&mut *guard, Sink::Stderr) {
+        Sink::Pending { backlog, .. } | Sink::Lazy { backlog, .. } => Some(backlog),
+        Sink::Open(file) => {
+            *guard = Sink::Open(file);
+            None
+        }
+        Sink::Stderr => None,
+    };
+    drop(guard);
+    if let Some(backlog) = spill {
+        let _ = std::io::stderr().lock().write_all(&backlog);
+    }
+}
+
+/// Create the file at `path` and write the backlog, or explain why not.
+fn create(path: &PathBuf, backlog: &[u8], truncated: bool) -> Result<File, String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("{}: {e}", parent.display()))?;
+    }
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(path)
+        .map_err(|e| format!("{}: {e}", path.display()))?;
+    if truncated {
+        let _ =
+            file.write_all(b"[mtld3d::unix] log file: lines before the location were dropped\n");
+    }
+    file.write_all(backlog)
+        .map_err(|e| format!("{}: {e}", path.display()))?;
+    Ok(file)
+}
+
+/// Write one line: into the backlog, the file, or stderr, per the state.
+///
+/// The file is unbuffered, so one call is one `write(2)` and nothing waits
+/// in userspace when the process dies; a failed write falls back to stderr.
+pub fn write_all(bytes: &[u8]) {
+    let mut guard = SINK.lock().expect("log file mutex poisoned");
+    // Whatever stderr gets is written after the lock is released.
+    let spill: Option<Vec<u8>> = match &mut *guard {
+        Sink::Pending { backlog, truncated } => {
+            if backlog.len() + bytes.len() <= BACKLOG_CAP {
+                backlog.extend_from_slice(bytes);
+            } else {
+                *truncated = true;
+            }
+            None
+        }
+        Sink::Lazy {
+            path,
+            backlog,
+            truncated,
+        } => match create(path, backlog, *truncated) {
+            Ok(mut file) => {
+                let ok = file.write_all(bytes).is_ok();
+                LOG_FD.store(file.as_raw_fd(), Ordering::Release);
+                *guard = if ok { Sink::Open(file) } else { Sink::Stderr };
+                None
+            }
+            Err(e) => {
+                let mut out = format!("[mtld3d::unix] log file: {e}; logging to stderr instead\n")
+                    .into_bytes();
+                out.extend_from_slice(backlog);
+                out.extend_from_slice(bytes);
+                *guard = Sink::Stderr;
+                Some(out)
+            }
+        },
+        Sink::Open(file) => {
+            if file.write_all(bytes).is_ok() {
+                None
+            } else {
+                LOG_FD.store(-1, Ordering::Release);
+                *guard = Sink::Stderr;
+                Some(bytes.to_vec())
+            }
+        }
+        Sink::Stderr => Some(bytes.to_vec()),
+    };
+    drop(guard);
+    if let Some(out) = spill {
+        let _ = std::io::stderr().lock().write_all(&out);
+    }
+}
+
+/// The descriptor a signal handler writes: the log file's, or stderr's.
+#[must_use]
+pub fn raw_fd() -> i32 {
+    let fd = LOG_FD.load(Ordering::Acquire);
+    if fd < 0 { 2 } else { fd }
+}
+
+/// Append `len` bytes at `ptr` from a signal handler.
+///
+/// Reads the descriptor without the mutex, so it is async-signal-safe like
+/// the `write(2)` on stderr it replaces; a line written before the file
+/// exists goes to stderr, since creating the file is not signal-safe.
+///
+/// # Safety
+///
+/// `ptr` must point at `len` readable bytes.
+pub unsafe fn write_raw(ptr: *const c_void, len: usize) {
+    // SAFETY: write(2) is async-signal-safe; the caller vouches for `ptr`/`len`.
+    unsafe {
+        let _ = libc::write(raw_fd(), ptr, len);
+    }
+}
+
+/// [`write_raw`] over a slice, the shape the crumb dump sink takes.
+pub fn write_bytes(bytes: &[u8]) {
+    // SAFETY: the slice is `len` readable bytes at `ptr` for the call.
+    unsafe { write_raw(bytes.as_ptr().cast::<c_void>(), bytes.len()) };
+}
+
+/// The path of the next GPU trace, next to the log: `<dir>/<stem>-<pid>-<n>.gputrace`.
+///
+/// `None` before the location is known, when the caller keeps its own
+/// default. The directory is created here because the capture writes into
+/// it directly.
+pub fn next_trace_path() -> Option<PathBuf> {
+    let (dir, stem, pid) = TRACE_BASE
+        .lock()
+        .expect("trace base mutex poisoned")
+        .as_ref()
+        .cloned()?;
+    let index = TRACE_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+    let path = dir.join(mtld3d_shared::log_paths::trace_file_name(&stem, pid, index));
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        log::warn!(
+            target: crate::LOG_TARGET,
+            "cannot create the log directory {} for a GPU trace: {e}",
+            dir.display()
+        );
+        return None;
+    }
+    Some(path)
+}
+
+/// The unix side's `env_logger` target.
+pub struct FileSink;
+
+impl Write for FileSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        write_all(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/unix/unix/src/metal/capture.rs
+++ b/unix/unix/src/metal/capture.rs
@@ -5,13 +5,15 @@ use objc2_metal::{MTLCaptureDescriptor, MTLCaptureDestination, MTLCaptureManager
 
 use crate::{LOG_TARGET, metal::handle::IntoRetained};
 
-const CAPTURE_PATH: &str = "/tmp/mtld3d_capture.gputrace";
+/// Where a trace goes when the process has no log directory yet.
+const FALLBACK_PATH: &str = "/tmp/mtld3d_capture.gputrace";
 
 /// Begin a Metal GPU frame capture.
 ///
 /// The capture object is the device passed in (covers all command queues
-/// on it). Output is a `.gputrace` document at `CAPTURE_PATH`, openable
-/// in Xcode.
+/// on it). Output is a `.gputrace` document next to the process's log file,
+/// numbered per press (`log_file::next_trace_path`), or at `FALLBACK_PATH`
+/// when no log location was named; openable in Xcode or with `gpudebug`.
 ///
 /// Apple gates this on `MTL_CAPTURE_ENABLED=1` at process launch; when
 /// the env is unset `startCaptureWithDescriptor` returns an error which
@@ -38,17 +40,22 @@ pub fn start_capture(device_handle: MetalHandle<MTLDeviceKind>) {
     unsafe { desc.setCaptureObject(Some(device.as_ref())) };
     desc.setDestination(MTLCaptureDestination::GPUTraceDocument);
 
+    let path = crate::log_file::next_trace_path().map_or_else(
+        || FALLBACK_PATH.to_owned(),
+        |p| p.to_string_lossy().into_owned(),
+    );
     // Trace path must not exist; remove a stale one from a prior run.
-    let _ = std::fs::remove_dir_all(CAPTURE_PATH);
-    let _ = std::fs::remove_file(CAPTURE_PATH);
+    let _ = std::fs::remove_dir_all(&path);
+    let _ = std::fs::remove_file(&path);
 
-    let path_ns = NSString::from_str(CAPTURE_PATH);
+    let path_ns = NSString::from_str(&path);
     let url = NSURL::fileURLWithPath(&path_ns);
     desc.setOutputURL(Some(&url));
 
     match manager.startCaptureWithDescriptor_error(&desc) {
         Ok(()) => {
-            info!(target: LOG_TARGET, "started GPU capture → {CAPTURE_PATH}");
+            info!(target: LOG_TARGET, "started GPU capture → {path}");
+            *CURRENT_PATH.lock().expect("capture path mutex poisoned") = Some(path);
         }
         Err(err) => {
             let msg = err.localizedDescription();
@@ -68,5 +75,16 @@ pub fn stop_capture() {
         return;
     }
     manager.stopCapture();
-    info!(target: LOG_TARGET, "stopped GPU capture → {CAPTURE_PATH}");
+    let path = CURRENT_PATH
+        .lock()
+        .expect("capture path mutex poisoned")
+        .take();
+    info!(
+        target: LOG_TARGET,
+        "stopped GPU capture → {}",
+        path.as_deref().unwrap_or(FALLBACK_PATH)
+    );
 }
+
+/// The path of the capture in progress, for the stop line.
+static CURRENT_PATH: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);

--- a/windows/core/src/config.rs
+++ b/windows/core/src/config.rs
@@ -82,6 +82,12 @@ pub struct Mtld3dConfig {
     ///
     /// Default: `true`. File key: `shaderCache.enable`.
     pub shader_cache_enable: bool,
+    /// Directory the process's log file and GPU traces go into.
+    ///
+    /// Resolved against the executable's directory; an absolute path stands
+    /// as is. Empty string = `mtld3d-logs` beside the executable. Default:
+    /// `""`. File key: `log.dir`.
+    pub log_dir: String,
     /// Directory to dump raw DXSO bytecode into on first sight of each shader id.
     ///
     /// Empty string = disabled. Default: `""`. File key:
@@ -269,6 +275,7 @@ impl Default for Mtld3dConfig {
             color_space: ColorSpacePolicy::Passthrough,
             cursor_scale: CursorScale::Auto,
             shader_cache_enable: true,
+            log_dir: String::new(),
             bytecode_dump_dir: String::new(),
             skip_shaders: Vec::new(),
             query_flush_immediate: true,
@@ -390,6 +397,7 @@ pub fn log_options(cfg: &Mtld3dConfig) {
         target: crate::LOG_TARGET,
         "config: shaderCache.enable = {}", cfg.shader_cache_enable
     );
+    info!(target: crate::LOG_TARGET, "config: log.dir = {:?}", cfg.log_dir);
     info!(
         target: crate::LOG_TARGET,
         "config: debug.bytecodeDumpDir = {:?}", cfg.bytecode_dump_dir
@@ -468,6 +476,7 @@ fn apply(cfg: &mut Mtld3dConfig, source: &str, key: &str, value: &str) {
         "color.space" => assign_color_space(source, value, &mut cfg.color_space),
         "cursor.scale" => assign_cursor_scale(source, value, &mut cfg.cursor_scale),
         "shaderCache.enable" => assign_bool(source, key, value, &mut cfg.shader_cache_enable),
+        "log.dir" => value.clone_into(&mut cfg.log_dir),
         "debug.bytecodeDumpDir" => value.clone_into(&mut cfg.bytecode_dump_dir),
         "debug.skipShaders" => cfg.skip_shaders = parse_hex_list(value),
         "query.flushImmediate" => assign_bool(source, key, value, &mut cfg.query_flush_immediate),

--- a/windows/core/src/config/tests.rs
+++ b/windows/core/src/config/tests.rs
@@ -28,6 +28,7 @@ fn defaults_match_documented_values() {
     assert_eq!(d.color_space, ColorSpacePolicy::Passthrough);
     assert_eq!(d.cursor_scale, CursorScale::Auto);
     assert!(d.shader_cache_enable);
+    assert!(d.log_dir.is_empty());
     assert!(d.bytecode_dump_dir.is_empty());
     assert!(d.skip_shaders.is_empty());
     assert!(d.query_flush_immediate);
@@ -311,6 +312,14 @@ fn quoted_string_value_preserves_inner_whitespace() {
 fn unquoted_string_value_is_trimmed() {
     let cfg = parse(None, "debug.bytecodeDumpDir = /tmp/x\n", None);
     assert_eq!(cfg.bytecode_dump_dir, "/tmp/x");
+}
+
+#[test]
+fn log_dir_is_a_plain_string() {
+    let cfg = parse(None, "log.dir = logs\\mtld3d\n", None);
+    assert_eq!(cfg.log_dir, "logs\\mtld3d");
+    let cfg = parse(None, "", Some("log.dir=C:\\mtld3d-logs"));
+    assert_eq!(cfg.log_dir, "C:\\mtld3d-logs");
 }
 
 #[test]

--- a/windows/d3d9/src/capture.rs
+++ b/windows/d3d9/src/capture.rs
@@ -20,8 +20,8 @@
 //! `take_request()` and arms `frame_dump_present`, which marks the first
 //! and last frame of the run with `FrameDataFlags::GPU_CAPTURE_START` /
 //! `GPU_CAPTURE_STOP`. The encoder thread brackets those frames with the
-//! `StartGpuCapture` / `StopGpuCapture` thunks. Output is
-//! `/tmp/mtld3d_capture.gputrace`, overwritten per press.
+//! `StartGpuCapture` / `StopGpuCapture` thunks. The trace lands next to
+//! the process's log file, numbered per press.
 //!
 //! [`FrameDump::FRAMES`]: crate::device::frame_dump::FrameDump::FRAMES
 

--- a/windows/d3d9/src/crash.rs
+++ b/windows/d3d9/src/crash.rs
@@ -52,7 +52,6 @@ const STATUS_STACK_BUFFER_OVERRUN: u32 = 0xC000_0409;
 const STATUS_ASSERTION_FAILURE: u32 = 0xC000_0420;
 
 const EXCEPTION_CONTINUE_SEARCH: i32 = 0;
-const STD_ERROR_HANDLE: u32 = 0xFFFF_FFF4;
 const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: u32 = 4;
 
 static INSTALLED: AtomicBool = AtomicBool::new(false);
@@ -295,14 +294,6 @@ unsafe extern "system" {
         buffer: *mut MemoryBasicInformation,
         length: usize,
     ) -> usize;
-    fn GetStdHandle(handle: u32) -> *mut c_void;
-    fn WriteFile(
-        h_file: *mut c_void,
-        buf: *const u8,
-        n: u32,
-        written: *mut u32,
-        overlapped: *mut c_void,
-    ) -> i32;
 }
 
 /// Install the VEH and the panic hook. Idempotent.
@@ -519,25 +510,9 @@ fn emit_fatal(code: u32, addr: *mut c_void) {
 }
 
 fn write_stderr(bytes: &[u8]) {
-    // The unix side first: a launcher-spawned game has no usable stderr
-    // handle, so that route is the one that reaches the launcher's log.
+    // Synchronously through the unix side, into the process's log file: a
+    // launcher-spawned game has no usable stderr handle of its own.
     crate::log_sink::write_raw(bytes);
-    // SAFETY: kernel32 stable export.
-    let h = unsafe { GetStdHandle(STD_ERROR_HANDLE) };
-    if h.is_null() {
-        return;
-    }
-    let mut written = 0u32;
-    // SAFETY: WriteFile on STD_ERROR_HANDLE with a valid buffer slice.
-    unsafe {
-        let _ = WriteFile(
-            h,
-            bytes.as_ptr(),
-            u32::try_from(bytes.len()).unwrap_or(u32::MAX),
-            &raw mut written,
-            core::ptr::null_mut(),
-        );
-    }
 }
 
 fn push(buf: &mut [u8], pos: &mut usize, bytes: &[u8]) {

--- a/windows/d3d9/src/lib.rs
+++ b/windows/d3d9/src/lib.rs
@@ -141,12 +141,15 @@ pub extern "system" fn dll_main(instance: *mut c_void, reason: u32, _reserved: *
 #[unsafe(export_name = "Direct3DCreate9")]
 #[must_use]
 pub extern "system" fn direct3d_create9(_sdk_version: u32) -> *mut c_void {
+    // First touch resolves `mtld3d.conf` and logs the option set; later
+    // call sites read `&*config::CONFIG` cheaply. The log location it names
+    // reaches the unix side before the logging thread starts, so every line
+    // queued since `DllMain` lands in the file.
+    let cfg = &*config::CONFIG;
+    log_sink::open(cfg);
     // The first entry point outside `DllMain`: the logging thread can start
     // here (DllMain runs under the loader lock and must not spawn threads).
     log_sink::start();
-    // First touch resolves `mtld3d.conf` and logs the option set; later
-    // call sites read `&*config::CONFIG` cheaply.
-    let _cfg = &*config::CONFIG;
     Box::into_raw(Box::new(Direct3D9::new())).cast::<c_void>()
 }
 

--- a/windows/d3d9/src/log_sink.rs
+++ b/windows/d3d9/src/log_sink.rs
@@ -5,18 +5,131 @@
 //! so the API and encoder threads pay an allocation and a queue push per line
 //! and nothing else. One logging thread, started by [`start`] from the first
 //! `Direct3DCreate9` (never from `DllMain`, which runs under the loader lock),
-//! drains the queue and forwards each line through the `WriteLog` thunk to the
-//! process's unix stderr. Lines logged before the thread exists wait in the
-//! queue; the queue keeps their order.
+//! drains the queue and forwards each line through the `WriteLog` thunk into
+//! the process's log file, which the unix side owns. Lines logged before the
+//! thread exists wait in the queue; the queue keeps their order.
+//!
+//! [`open`] names that file's location first: the directory `log.dir` picks,
+//! or `mtld3d-logs` next to the executable, as a unix path the unix side can
+//! create, plus the executable's stem and the pid that make the file name.
 
-use std::sync::{
-    LazyLock, Mutex,
-    mpsc::{Receiver, Sender, channel},
+use core::ffi::{c_char, c_void};
+use std::{
+    os::windows::ffi::OsStrExt,
+    path::Path,
+    sync::{
+        LazyLock, Mutex,
+        mpsc::{Receiver, Sender, channel},
+    },
 };
 
-use mtld3d_shared::WriteLogParams;
+use log::warn;
+use mtld3d_shared::{OpenLogParams, WriteLogParams};
 
-use crate::unix_call::unix_call;
+use crate::{LOG_TARGET, unix_call::unix_call};
+
+unsafe extern "system" {
+    fn GetProcessHeap() -> *mut c_void;
+    fn HeapFree(heap: *mut c_void, flags: u32, mem: *mut c_void) -> i32;
+    fn GetModuleHandleA(module_name: *const u8) -> *mut c_void;
+    fn GetProcAddress(module: *mut c_void, proc_name: *const u8) -> *mut c_void;
+}
+
+/// Wine's kernel32 extension: the unix path of a DOS path, heap-allocated.
+///
+/// Resolved by name at run time, since the SDK import library we link
+/// against does not carry it. Wine declares it `CDECL`, not `WINAPI`: on
+/// i686 the caller pops the argument, and a stdcall type here corrupts the
+/// caller's stack.
+type WineGetUnixFileName = unsafe extern "C" fn(*const u16) -> *mut c_char;
+
+/// Name the process's log location to the unix side.
+///
+/// The directory is `log.dir` resolved against the executable's directory
+/// (an absolute value stands as is), or `mtld3d-logs` beside the executable
+/// when the key is empty; it is created here, the file itself by the unix
+/// side with the first line it writes. When the directory cannot be created
+/// or has no unix path, the thunk still goes out, empty, so the unix side
+/// releases its backlog to stderr instead of holding it forever.
+pub fn open(cfg: &mtld3d_core::config::Mtld3dConfig) {
+    let location = log_location(cfg);
+    let (unix_dir, stem) = match &location {
+        Ok(pair) => (pair.0.as_str(), pair.1.as_str()),
+        Err(why) => {
+            warn!(target: LOG_TARGET, "log file: {why}, logging to stderr");
+            ("", "")
+        }
+    };
+    let (Ok(dir_len), Ok(stem_len)) = (u32::try_from(unix_dir.len()), u32::try_from(stem.len()))
+    else {
+        return;
+    };
+    let mut params = OpenLogParams {
+        dir_ptr: unix_dir.as_ptr() as usize as u64,
+        stem_ptr: stem.as_ptr() as usize as u64,
+        dir_len,
+        stem_len,
+        pid: std::process::id(),
+        pad0: 0,
+    };
+    unix_call(&mut params);
+}
+
+/// The log directory as a unix path plus the executable's stem, or why not.
+fn log_location(cfg: &mtld3d_core::config::Mtld3dConfig) -> Result<(String, String), String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe() unavailable ({e})"))?;
+    let exe_dir = exe.parent().unwrap_or_else(|| Path::new("."));
+    let dir = if cfg.log_dir.is_empty() {
+        exe_dir.join("mtld3d-logs")
+    } else {
+        exe_dir.join(&cfg.log_dir)
+    };
+    std::fs::create_dir_all(&dir).map_err(|e| format!("cannot create {} ({e})", dir.display()))?;
+    let stem = exe.file_stem().map_or_else(
+        || String::from("mtld3d"),
+        |s| s.to_string_lossy().into_owned(),
+    );
+    let unix_dir = unix_path(&dir).ok_or_else(|| format!("no unix path for {}", dir.display()))?;
+    Ok((unix_dir, stem))
+}
+
+/// The unix path of a DOS path, through Wine's `wine_get_unix_file_name`.
+fn unix_path(dos: &Path) -> Option<String> {
+    // SAFETY: kernel32 is loaded for the life of the process; the name is
+    // NUL-terminated.
+    let kernel32 = unsafe { GetModuleHandleA(c"kernel32.dll".as_ptr().cast::<u8>()) };
+    if kernel32.is_null() {
+        return None;
+    }
+    // SAFETY: a live module handle and a NUL-terminated export name.
+    let proc =
+        unsafe { GetProcAddress(kernel32, c"wine_get_unix_file_name".as_ptr().cast::<u8>()) };
+    if proc.is_null() {
+        return None;
+    }
+    // SAFETY: the export has this signature in every Wine that carries it.
+    let get_unix_file_name: WineGetUnixFileName = unsafe { core::mem::transmute(proc) };
+    let wide: Vec<u16> = dos
+        .as_os_str()
+        .encode_wide()
+        .chain(core::iter::once(0))
+        .collect();
+    // SAFETY: `wide` is a NUL-terminated UTF-16 string live for the call;
+    // the result is a NUL-terminated string on the process heap or null.
+    let raw = unsafe { get_unix_file_name(wide.as_ptr()) };
+    if raw.is_null() {
+        return None;
+    }
+    // SAFETY: `raw` is a valid NUL-terminated C string until freed below.
+    let path = unsafe { core::ffi::CStr::from_ptr(raw) }
+        .to_string_lossy()
+        .into_owned();
+    // SAFETY: the process heap handle is a stable kernel32 pseudo-handle.
+    let heap = unsafe { GetProcessHeap() };
+    // SAFETY: `raw` came from the process heap per the kernel32 contract.
+    let _ = unsafe { HeapFree(heap, 0, raw.cast::<c_void>()) };
+    Some(path)
+}
 
 struct Queue {
     tx: Sender<Vec<u8>>,
@@ -84,7 +197,7 @@ pub fn write_raw(line: &[u8]) {
     forward(line);
 }
 
-/// One formatted line across the boundary; the unix side writes it to stderr.
+/// One formatted line across the boundary; the unix side writes it to the log file.
 fn forward(line: &[u8]) {
     let Ok(len) = u32::try_from(line.len()) else {
         return;

--- a/windows/shim/src/lib.rs
+++ b/windows/shim/src/lib.rs
@@ -1,7 +1,7 @@
 use core::ffi::c_void;
 
 use log::{error, info};
-use mtld3d_shared::identity;
+use mtld3d_shared::{WriteLogParams, identity};
 
 const LOG_TARGET: &str = "mtld3d::shim";
 
@@ -25,8 +25,39 @@ pub extern "system" fn dll_main(instance: *mut c_void, reason: u32, _reserved: *
         return 1;
     }
 
-    mtld3d_shared::init_logger();
+    // The dispatcher stub initialises the unix call on first use, so the
+    // sink is usable from here; the unix side keeps the line for the
+    // process's log file.
+    mtld3d_shared::init_logger_to(Box::new(LogSink));
     attach_process(instance)
+}
+
+/// The shim's `env_logger` target: each line straight through `WriteLog`.
+///
+/// The shim logs a line or two at load; a synchronous thunk per line is
+/// cheaper than a queue and thread of its own.
+struct LogSink;
+
+impl std::io::Write for LogSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let Ok(len) = u32::try_from(buf.len()) else {
+            return Ok(buf.len());
+        };
+        let mut params = WriteLogParams {
+            ptr: buf.as_ptr() as usize as u64,
+            len,
+            pad0: 0,
+        };
+        let _ = dispatch_unix_call(
+            <WriteLogParams as mtld3d_shared::Thunk>::CODE,
+            (&raw mut params).cast::<c_void>(),
+        );
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
## Symptoms

Every mtld3d line went to the process's stderr through the unix side. A game a launcher spawned has no usable standard handles of its own, and the launcher's log dies with its pipe: twice during the #76 investigation a Steam self-update relaunched steam.exe and the whole run's log was lost. The launcher also rotates its log per launch, so an earlier run's lines were gone once the game was started again, and the F12 trace landed in `/tmp` away from the log it belonged to.

## Changes

Every line of both halves goes to a file, never to the standard streams. Each process writes `<exe>-<pid>.log` into a directory beside the executable, `mtld3d-logs` by default or what the new `log.dir` key in `mtld3d.conf` names (relative to the executable's directory or absolute), so a launch never overwrites the log of the one before it. The GPU traces F12 captures go next to it as `<exe>-<pid>-<n>.gputrace`, numbered per press.

The unix side owns the file. `Direct3DCreate9` resolves the config, converts the directory to a unix path through Wine's `wine_get_unix_file_name`, and sends it with the executable's stem and the pid through a new `OpenLog` thunk before it starts the PE log thread, so every line queued since `DllMain` reaches the file; the unix logger has run since `InitLogger`, and its lines wait in the file sink's backlog until then. The file is created with the first line written after that, so a process that logs nothing (`RUST_LOG=off`, the conformance runner) leaves nothing behind; a location that cannot be created falls back to stderr with one line saying so. The `WriteLog` handler, the unix `env_logger` target, both crash handlers and both crumb dumpers write the same file (the signal paths on its raw descriptor, or fd 2 before it exists). The shim's own lines go through `WriteLog` too. No target colours any more (`WriteStyle::Never`), since nothing is a terminal.

## Alternatives

Mirroring the file next to stderr, as an earlier attempt did, kept the launcher pipe as a second consumer and needed a tee; with no consumer of stderr left, the file is the only sink. A single file per executable would have lost the previous run on every launch.

## Verification

`make check` green; `make test` green on both architectures, each test process leaving its log under `mtld3d-logs` next to the test executable. Unit tests cover the key, the thunk layout and the file names.
