### PR TITLE
Install into the compat-database subtree when the Wine tree has one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,41 +262,79 @@ install: install-windows-i686 install-windows-x86_64 install-unix-x64 install-un
 # leg installs the one PE arch it exercises plus the one unix `.so` its Wine
 # loads, and only `install` (and `bundle`) covers everything.
 #
+# A Wine tree holds mtld3d in one of two layouts. A tree bundled with a compat
+# database keeps every Direct3D implementation in its own subtree and picks one
+# per process: `lib/wine/d3d9/mtld3d/<arch>` is prepended to the builtin search
+# and the default dirs carry only fake-module markers (winebuild
+# `--fake-module`, the placeholder wineboot stamps into the prefix so the
+# prepended tree's DLL loads). An older tree loads straight from the default
+# dirs. `MTLD3D_TREE` names the subtree a given root uses, and each leaf writes
+# into it, re-stamping the markers in the new layout so a root whose markers
+# an earlier install overwrote is whole again.
+#
 # The d3d9.dll copies under lib/wine get the builtin signature in place: the
 # loader ignores unsigned PEs on the builtin search path. Symbols travel with
 # each binary, the `.pdb` beside every PE and the `.dSYM` beside the `.so`, so a
 # local crash symbolicates against the installed files with no extra flags.
+define MTLD3D_TREE
+if [ -d $(1)/lib/wine/d3d9/mtld3d ]; then echo $(1)/lib/wine/d3d9/mtld3d; else echo $(1)/lib/wine; fi
+endef
+
 install-windows-i686: windows-i686
 	for dir in $(INSTALL_DIRS); do \
-		cp $(OUT_i386)/mtld3d.dll  $(OUT_i386)/mtld3d.pdb  $$dir/lib/wine/i386-windows/ ; \
-		cp $(OUT_i386)/d3d9.dll    $(OUT_i386)/d3d9.pdb    $$dir/lib/wine/i386-windows/ ; \
-		$(WINEBUILD) --builtin $$dir/lib/wine/i386-windows/d3d9.dll ; \
+		tree=$$($(call MTLD3D_TREE,$$dir)) ; \
+		mkdir -p $$tree/i386-windows ; \
+		cp $(OUT_i386)/mtld3d.dll  $(OUT_i386)/mtld3d.pdb  $$tree/i386-windows/ ; \
+		cp $(OUT_i386)/d3d9.dll    $(OUT_i386)/d3d9.pdb    $$tree/i386-windows/ ; \
+		$(WINEBUILD) --builtin $$tree/i386-windows/d3d9.dll ; \
+		if [ $$tree != $$dir/lib/wine ]; then \
+			rm -f $$dir/lib/wine/i386-windows/d3d9.pdb $$dir/lib/wine/i386-windows/mtld3d.pdb ; \
+			$(WINEBUILD) --fake-module -o $$dir/lib/wine/i386-windows/d3d9.dll   -m32 --dll $$tree/i386-windows/d3d9.dll ; \
+			$(WINEBUILD) --fake-module -o $$dir/lib/wine/i386-windows/mtld3d.dll -m32 --dll $$tree/i386-windows/mtld3d.dll ; \
+		fi ; \
 	done
 
 install-windows-x86_64: windows-x86_64
 	for dir in $(INSTALL_DIRS); do \
-		cp $(OUT_x64)/mtld3d.dll   $(OUT_x64)/mtld3d.pdb   $$dir/lib/wine/x86_64-windows/ ; \
-		cp $(OUT_x64)/d3d9.dll     $(OUT_x64)/d3d9.pdb     $$dir/lib/wine/x86_64-windows/ ; \
-		$(WINEBUILD) --builtin $$dir/lib/wine/x86_64-windows/d3d9.dll ; \
+		tree=$$($(call MTLD3D_TREE,$$dir)) ; \
+		mkdir -p $$tree/x86_64-windows ; \
+		cp $(OUT_x64)/mtld3d.dll   $(OUT_x64)/mtld3d.pdb   $$tree/x86_64-windows/ ; \
+		cp $(OUT_x64)/d3d9.dll     $(OUT_x64)/d3d9.pdb     $$tree/x86_64-windows/ ; \
+		$(WINEBUILD) --builtin $$tree/x86_64-windows/d3d9.dll ; \
+		if [ $$tree != $$dir/lib/wine ]; then \
+			rm -f $$dir/lib/wine/x86_64-windows/d3d9.pdb $$dir/lib/wine/x86_64-windows/mtld3d.pdb ; \
+			$(WINEBUILD) --fake-module -o $$dir/lib/wine/x86_64-windows/d3d9.dll   -m64 --dll $$tree/x86_64-windows/d3d9.dll ; \
+			$(WINEBUILD) --fake-module -o $$dir/lib/wine/x86_64-windows/mtld3d.dll -m64 --dll $$tree/x86_64-windows/mtld3d.dll ; \
+		fi ; \
 	done
 
 # Both unix arches create the directory the Wine tree lacks: a Wine only ever
 # loads the one matching its own build, so the other copy is inert, and a tree
-# that later gains an arm64 loader is already served.
+# that later gains an arm64 loader is already served. In the subtree layout the
+# default unix dir carries no mtld3d.so at all, so one an earlier install left
+# there goes.
 install-unix-x64: unix-x64
 	for dir in $(INSTALL_DIRS); do \
-		mkdir -p $$dir/lib/wine/$(UNIX_WINEDIR_x64) ; \
-		cp $(OUT_unix_x64)/mtld3d.so        $$dir/lib/wine/$(UNIX_WINEDIR_x64)/ ; \
-		rm -rf $$dir/lib/wine/$(UNIX_WINEDIR_x64)/mtld3d.so.dSYM ; \
-		cp -R $(OUT_unix_x64)/mtld3d.so.dSYM   $$dir/lib/wine/$(UNIX_WINEDIR_x64)/ ; \
+		tree=$$($(call MTLD3D_TREE,$$dir)) ; \
+		mkdir -p $$tree/$(UNIX_WINEDIR_x64) ; \
+		cp $(OUT_unix_x64)/mtld3d.so        $$tree/$(UNIX_WINEDIR_x64)/ ; \
+		rm -rf $$tree/$(UNIX_WINEDIR_x64)/mtld3d.so.dSYM ; \
+		cp -R $(OUT_unix_x64)/mtld3d.so.dSYM   $$tree/$(UNIX_WINEDIR_x64)/ ; \
+		if [ $$tree != $$dir/lib/wine ]; then \
+			rm -rf $$dir/lib/wine/$(UNIX_WINEDIR_x64)/mtld3d.so $$dir/lib/wine/$(UNIX_WINEDIR_x64)/mtld3d.so.dSYM ; \
+		fi ; \
 	done
 
 install-unix-arm64: unix-arm64
 	for dir in $(INSTALL_DIRS); do \
-		mkdir -p $$dir/lib/wine/$(UNIX_WINEDIR_arm64) ; \
-		cp $(OUT_unix_arm64)/mtld3d.so      $$dir/lib/wine/$(UNIX_WINEDIR_arm64)/ ; \
-		rm -rf $$dir/lib/wine/$(UNIX_WINEDIR_arm64)/mtld3d.so.dSYM ; \
-		cp -R $(OUT_unix_arm64)/mtld3d.so.dSYM $$dir/lib/wine/$(UNIX_WINEDIR_arm64)/ ; \
+		tree=$$($(call MTLD3D_TREE,$$dir)) ; \
+		mkdir -p $$tree/$(UNIX_WINEDIR_arm64) ; \
+		cp $(OUT_unix_arm64)/mtld3d.so      $$tree/$(UNIX_WINEDIR_arm64)/ ; \
+		rm -rf $$tree/$(UNIX_WINEDIR_arm64)/mtld3d.so.dSYM ; \
+		cp -R $(OUT_unix_arm64)/mtld3d.so.dSYM $$tree/$(UNIX_WINEDIR_arm64)/ ; \
+		if [ $$tree != $$dir/lib/wine ]; then \
+			rm -rf $$dir/lib/wine/$(UNIX_WINEDIR_arm64)/mtld3d.so $$dir/lib/wine/$(UNIX_WINEDIR_arm64)/mtld3d.so.dSYM ; \
+		fi ; \
 	done
 
 # Distribution bundle, serving both install routes (see INSTALL.md, which is

--- a/README.md
+++ b/README.md
@@ -324,10 +324,13 @@ published to crates.io.
 Frame pointers are off by default; `FP=1 make` forces them on for the guest-pc
 sampling profiler, whose stack walks follow the guest frame-pointer chain.
 
-`make install` copies the PE DLLs into `lib/wine/{i386,x86_64}-windows/` and
-the `.so` into `lib/wine/{x86_64,aarch64}-unix/`, stamping the Wine-builtin
-signature onto the `d3d9.dll` copies, because the loader ignores unsigned PEs
-on the builtin search path. The build outputs themselves stay unsigned so they
+`make install` copies the PE DLLs into `{i386,x86_64}-windows/` and the `.so`
+into `{x86_64,aarch64}-unix/` under the tree the Wine build reads mtld3d from:
+`lib/wine/d3d9/mtld3d/` in a bundle with a compat database, which keeps every
+Direct3D implementation in its own subtree and leaves only fake-module markers
+in the default dirs (the install re-stamps those), or `lib/wine/` itself in an
+older tree. The `d3d9.dll` copies get the Wine-builtin signature, because the
+loader ignores unsigned PEs on the builtin search path. The build outputs themselves stay unsigned so they
 can also serve as a native DLL override, and `make bundle` packs both flavors
 into `windows/target/mtld3d.tar.xz`. Debug symbols travel with every binary, a
 `.pdb` beside each PE and a `.dSYM` beside the `.so` (`make` runs `dsymutil`,


### PR DESCRIPTION
## Symptoms

A Wine bundle built with a compat database keeps every Direct3D implementation in its own subtree and picks one per process: mtld3d's DLLs and `.so` live under `lib/wine/d3d9/mtld3d/<arch>`, which the database prepends to the builtin search, and the default dirs hold only fake-module markers. `make install` still wrote into the default dirs, so on such a tree the loader kept picking the copies the bundle shipped. Every end-to-end run after the redeploy exercised stale binaries and failed on tests whose code the loaded DLL did not have (`buffer.ignoreLockBounds` unknown, the fullscreen mode-set missing), while the freshly built DLL in `lib/wine/i386-windows` sat unused.

## Changes

Each install leaf resolves the tree a root uses (`lib/wine/d3d9/mtld3d` when it exists, `lib/wine` otherwise) and writes there. In the subtree layout it also re-stamps the two fake-module markers in the default dirs with `winebuild --fake-module` and removes the copies an earlier install left there, so a root is whole again after one install. Older trees are unchanged. The README's install paragraph describes both layouts.

## Verification

`make audit` clean. `make test` on a tree with the subtree layout loads the just-built DLL again (both architectures, 432 tests each), and the Mach9 bundle plus the SDK tree both carry the installed build under `d3d9/mtld3d` with 1536-byte markers in the default dirs.
