### PR TITLE
Keep the ten newest logs and traces in the log directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,8 @@ pipe. Each process writes `<exe>-<pid>.log` into `mtld3d-logs` beside the
 executable, so a launch never overwrites the log of the one before it, and
 the GPU traces F12 captures land next to it as `<exe>-<pid>-<n>.gputrace`.
 `log.dir` in `mtld3d.conf` moves the directory; the file appears with the
-first line written, so a process that logs nothing leaves nothing behind.
+first line written, so a process that logs nothing leaves nothing behind, and
+the directory keeps only the ten newest logs and the ten newest traces.
 
 ## Contributing
 

--- a/mtld3d.conf
+++ b/mtld3d.conf
@@ -49,7 +49,8 @@
 # `<exe>-<pid>-<n>.gputrace`. The file appears with the first line written,
 # so a process that logs nothing (`RUST_LOG=off`) leaves nothing behind. A
 # directory that cannot be created falls back to stderr with one line
-# saying so.
+# saying so. The directory keeps the ten newest logs and the ten newest
+# traces; creating one past that removes the oldest of its kind.
 #
 # Default: "" (`mtld3d-logs` next to the executable)
 # Supported values: a directory path, relative to the executable's

--- a/unix/unix/src/log_file.rs
+++ b/unix/unix/src/log_file.rs
@@ -14,18 +14,26 @@
 //! known, not when it is named: a process that logs nothing (`RUST_LOG=off`,
 //! the conformance runner) leaves no empty file behind. A location that
 //! cannot be created or opened falls back to stderr with one line saying so.
+//!
+//! The directory keeps the [`KEEP`] newest logs and the [`KEEP`] newest
+//! traces: creating a log or a trace first removes the oldest of its kind
+//! past that count, so a game launched every day does not pile up files.
 
 use core::ffi::c_void;
 use std::{
     fs::{File, OpenOptions},
     io::Write,
     os::fd::AsRawFd,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         Mutex,
         atomic::{AtomicI32, AtomicU32, Ordering},
     },
+    time::SystemTime,
 };
+
+/// Logs, and separately traces, the directory keeps; older ones go.
+const KEEP: usize = 10;
 
 /// Bytes the backlog keeps while the location is pending.
 ///
@@ -117,9 +125,12 @@ pub fn fall_back_to_stderr() {
 }
 
 /// Create the file at `path` and write the backlog, or explain why not.
+///
+/// Makes room first: the oldest logs beyond [`KEEP`] minus this one go.
 fn create(path: &PathBuf, backlog: &[u8], truncated: bool) -> Result<File, String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("{}: {e}", parent.display()))?;
+        prune(parent, "log", KEEP - 1);
     }
     let mut file = OpenOptions::new()
         .append(true)
@@ -238,8 +249,49 @@ pub fn next_trace_path() -> Option<PathBuf> {
         );
         return None;
     }
+    prune(&dir, "gputrace", KEEP - 1);
     Some(path)
 }
+
+/// Remove the oldest entries in `dir` with extension `ext` beyond the newest `keep`.
+///
+/// Age is the modification time; entries whose metadata cannot be read are
+/// left alone. A trace is a directory bundle, a log a file; both go whole.
+///
+/// Nothing here logs, on purpose: the log-file creation calls this under
+/// the sink's mutex, and a log line from inside would re-enter the sink and
+/// deadlock. A removal that fails (two processes sharing one directory can
+/// race for the same file) is simply tried again at the next creation.
+fn prune(dir: &Path, ext: &str, keep: usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut aged: Vec<(SystemTime, PathBuf)> = entries
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == ext))
+        .filter_map(|p| {
+            let modified = std::fs::metadata(&p).ok()?.modified().ok()?;
+            Some((modified, p))
+        })
+        .collect();
+    if aged.len() <= keep {
+        return;
+    }
+    // Newest last; a tie keeps the order stable by name.
+    aged.sort();
+    let doomed = aged.len() - keep;
+    for (_, path) in aged.into_iter().take(doomed) {
+        let _ = if path.is_dir() {
+            std::fs::remove_dir_all(&path)
+        } else {
+            std::fs::remove_file(&path)
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests;
 
 /// The unix side's `env_logger` target.
 pub struct FileSink;

--- a/unix/unix/src/log_file/tests.rs
+++ b/unix/unix/src/log_file/tests.rs
@@ -1,0 +1,103 @@
+//! Retention of the log directory.
+//!
+//! `prune` keeps the newest `keep` entries of one extension by modification time and removes
+//! the rest, whether file (a log) or directory (a trace bundle), and leaves the other extension
+//! alone. The modification times are set explicitly so the order does not depend on how fast
+//! the files were created.
+
+use std::{
+    fs::{self, File},
+    path::PathBuf,
+    time::{Duration, SystemTime},
+};
+
+use super::prune;
+
+/// A fresh directory under the system temp dir, removed when dropped.
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new(tag: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!("mtld3d-prune-{}-{tag}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("scratch dir");
+        Self(dir)
+    }
+
+    /// A file named `name` whose modification time is `age` seconds before now.
+    fn file(&self, name: &str, age: u64) {
+        let path = self.0.join(name);
+        let file = File::create(&path).expect("scratch file");
+        file.set_modified(SystemTime::now() - Duration::from_secs(age))
+            .expect("set mtime");
+    }
+
+    /// A directory named `name` (a trace bundle) `age` seconds old.
+    fn bundle(&self, name: &str, age: u64) {
+        let path = self.0.join(name);
+        fs::create_dir(&path).expect("scratch bundle");
+        File::create(path.join("payload")).expect("bundle payload");
+        File::open(&path)
+            .expect("open bundle")
+            .set_modified(SystemTime::now() - Duration::from_secs(age))
+            .expect("set mtime");
+    }
+
+    fn names(&self) -> Vec<String> {
+        let mut names: Vec<String> = fs::read_dir(&self.0)
+            .expect("read scratch")
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn keeps_the_newest_logs_and_removes_the_oldest() {
+    let dir = Scratch::new("logs");
+    for age in 1..=5 {
+        dir.file(&format!("game-{age}.log"), age * 10);
+    }
+    prune(&dir.0, "log", 3);
+    assert_eq!(dir.names(), ["game-1.log", "game-2.log", "game-3.log"]);
+}
+
+#[test]
+fn leaves_the_other_extension_alone() {
+    let dir = Scratch::new("mixed");
+    dir.file("game-1.log", 30);
+    dir.file("game-2.log", 20);
+    dir.bundle("game-1-1.gputrace", 40);
+    dir.bundle("game-1-2.gputrace", 10);
+    prune(&dir.0, "log", 1);
+    assert_eq!(
+        dir.names(),
+        ["game-1-1.gputrace", "game-1-2.gputrace", "game-2.log"]
+    );
+}
+
+#[test]
+fn removes_a_trace_bundle_whole() {
+    let dir = Scratch::new("traces");
+    dir.bundle("game-1-1.gputrace", 30);
+    dir.bundle("game-1-2.gputrace", 20);
+    dir.bundle("game-1-3.gputrace", 10);
+    prune(&dir.0, "gputrace", 2);
+    assert_eq!(dir.names(), ["game-1-2.gputrace", "game-1-3.gputrace"]);
+}
+
+#[test]
+fn nothing_to_prune_below_the_cap() {
+    let dir = Scratch::new("few");
+    dir.file("game-1.log", 10);
+    prune(&dir.0, "log", 3);
+    assert_eq!(dir.names(), ["game-1.log"]);
+}


### PR DESCRIPTION
Follow-up to #352.

## Symptoms

Every process leaves a log behind, and every F12 press a trace of several hundred megabytes, so `mtld3d-logs` beside a game grows without bound.

## Changes

The directory keeps the ten newest logs and, separately, the ten newest traces. Creating a log file first removes the oldest `.log` entries beyond nine, and naming a trace path removes the oldest `.gputrace` bundles beyond nine, so the new one makes ten. Age is the modification time; entries whose metadata cannot be read are left alone, and a failed removal is retried at the next creation rather than logged: the log-file creation prunes under the sink's own mutex, and a log line from inside it re-enters the sink and deadlocks (it showed as 60 s test timeouts when concurrent test processes raced to remove the same file). A trace bundle is removed whole. The count is a constant in `log_file.rs`; `mtld3d.conf` and the README describe the retention.

## Verification

`make check` and `make test` green. Unit tests in `unix/unix/src/log_file/tests.rs` pin the pruning on a scratch directory with explicit modification times: newest kept, other extension untouched, bundles removed whole, nothing removed below the cap.
