### PR TITLE
Name the log file after the host pid, not Wine's

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,8 +462,10 @@ thunk from its init path.
 Every line goes to a file, never to the process's standard streams: a game a
 launcher spawned has no usable ones, and a launcher's own log dies with its
 pipe. Each process writes `<exe>-<pid>.log` into `mtld3d-logs` beside the
-executable, so a launch never overwrites the log of the one before it, and
-the GPU traces F12 captures land next to it as `<exe>-<pid>-<n>.gputrace`.
+executable, `<pid>` being the macOS process id `ps` shows (not Wine's, which
+repeats from launch to launch), so a launch never overwrites the log of the
+one before it, and the GPU traces F12 captures land next to it as
+`<exe>-<pid>-<n>.gputrace`.
 `log.dir` in `mtld3d.conf` moves the directory; the file appears with the
 first line written, so a process that logs nothing leaves nothing behind, and
 the directory keeps only the ten newest logs and the ten newest traces.

--- a/unix/shared/src/log_paths.rs
+++ b/unix/shared/src/log_paths.rs
@@ -3,7 +3,9 @@
 //! Both sides agree on them: the PE side names the directory, the unix side
 //! opens the files. One log per process, so a launch never overwrites the
 //! log of the one before it, and the GPU traces of a process sit next to
-//! its log under the same prefix.
+//! its log under the same prefix. `pid` is the host (macOS) process id, not
+//! Wine's: Wine numbers its processes per wineserver and hands the first one
+//! the same id every launch, so it cannot tell two runs apart.
 
 /// The log file of process `pid` running executable `stem`: `<stem>-<pid>.log`.
 #[must_use]

--- a/unix/shared/src/params.rs
+++ b/unix/shared/src/params.rs
@@ -89,7 +89,9 @@ impl Thunk for WriteLogParams {
 /// from `DllMain`, so the location travels separately. `dir` is the unix
 /// path of the log directory, `stem` the executable's file name without its
 /// extension, both UTF-8 without a terminator and kept alive by the PE side
-/// for the call; `pid` names the process. The unix side opens
+/// for the call. The unix side names the process itself, by its host pid:
+/// the Windows pid the PE side sees is Wine's, and Wine hands the first
+/// process of every fresh wineserver the same one. It opens
 /// `<dir>/<stem>-<pid>.log` on the first line it writes and numbers the
 /// traces `<dir>/<stem>-<pid>-<n>.gputrace`.
 #[repr(C, align(8))]
@@ -98,8 +100,6 @@ pub struct OpenLogParams {
     pub stem_ptr: u64, // in: *const u8
     pub dir_len: u32,  // in: byte count
     pub stem_len: u32, // in: byte count
-    pub pid: u32,
-    pub pad0: u32,
 }
 
 impl Thunk for OpenLogParams {

--- a/unix/shared/src/params/tests.rs
+++ b/unix/shared/src/params/tests.rs
@@ -42,9 +42,9 @@ fn attach_metal_layer_layout() {
 #[test]
 fn open_log_layout() {
     use super::OpenLogParams;
-    // 2*u64 + 4*u32 = 16 + 16 = 32
+    // 2*u64 + 2*u32 = 16 + 8 = 24
     assert_eq!(core::mem::align_of::<OpenLogParams>(), 8);
-    assert_eq!(core::mem::size_of::<OpenLogParams>(), 32);
+    assert_eq!(core::mem::size_of::<OpenLogParams>(), 24);
 }
 
 #[test]

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -105,7 +105,7 @@ pub extern "C" fn open_log_handler(args: *mut c_void) -> i32 {
         crate::log_file::fall_back_to_stderr();
         return STATUS_UNSUCCESSFUL;
     };
-    let path = crate::log_file::open(dir, stem, params.pid);
+    let path = crate::log_file::open(dir, stem);
     info!(target: LOG_TARGET, "log file: {}", path.display());
     STATUS_SUCCESS
 }

--- a/unix/unix/src/log_file.rs
+++ b/unix/unix/src/log_file.rs
@@ -77,10 +77,16 @@ static TRACE_COUNT: AtomicU32 = AtomicU32::new(0);
 
 /// Name the log location: `<dir>/<stem>-<pid>.log`, created on the first line.
 ///
+/// `pid` is this process's host pid, the one `ps` shows. The PE side's own
+/// pid would not do: it is Wine's process id, and a fresh wineserver hands
+/// its first process the same one every launch, so every run of a game would
+/// append to one file and the retention below would never see a second.
+///
 /// Returns the path the file will have. Nothing is created here; a location
 /// that turns out unusable is reported by the first write, which then falls
 /// back to stderr.
-pub fn open(dir: &str, stem: &str, pid: u32) -> PathBuf {
+pub fn open(dir: &str, stem: &str) -> PathBuf {
+    let pid = std::process::id();
     let dir = PathBuf::from(dir);
     let path = dir.join(mtld3d_shared::log_paths::log_file_name(stem, pid));
     let mut guard = SINK.lock().expect("log file mutex poisoned");

--- a/unix/unix/src/log_file/tests.rs
+++ b/unix/unix/src/log_file/tests.rs
@@ -1,9 +1,10 @@
-//! Retention of the log directory.
+//! Naming and retention of the log directory.
 //!
-//! `prune` keeps the newest `keep` entries of one extension by modification time and removes
-//! the rest, whether file (a log) or directory (a trace bundle), and leaves the other extension
-//! alone. The modification times are set explicitly so the order does not depend on how fast
-//! the files were created.
+//! `open` names the file after the host pid, the only process id that differs from one launch
+//! to the next. `prune` keeps the newest `keep` entries of one extension by modification time
+//! and removes the rest, whether file (a log) or directory (a trace bundle), and leaves the
+//! other extension alone. The modification times are set explicitly so the order does not
+//! depend on how fast the files were created.
 
 use std::{
     fs::{self, File},
@@ -11,7 +12,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use super::prune;
+use super::{fall_back_to_stderr, open, prune};
 
 /// A fresh directory under the system temp dir, removed when dropped.
 struct Scratch(PathBuf);
@@ -100,4 +101,18 @@ fn nothing_to_prune_below_the_cap() {
     dir.file("game-1.log", 10);
     prune(&dir.0, "log", 3);
     assert_eq!(dir.names(), ["game-1.log"]);
+}
+
+#[test]
+fn names_the_log_after_the_host_pid() {
+    let dir = Scratch::new("name");
+    let path = open(&dir.0.to_string_lossy(), "game");
+    // Back to stderr before any line creates the file: the sink is process-wide.
+    fall_back_to_stderr();
+    let expected = dir.0.join(format!("game-{}.log", std::process::id()));
+    assert_eq!(path, expected);
+    assert!(
+        dir.names().is_empty(),
+        "naming the location creates nothing"
+    );
 }

--- a/windows/d3d9/src/log_sink.rs
+++ b/windows/d3d9/src/log_sink.rs
@@ -11,7 +11,9 @@
 //!
 //! [`open`] names that file's location first: the directory `log.dir` picks,
 //! or `mtld3d-logs` next to the executable, as a unix path the unix side can
-//! create, plus the executable's stem and the pid that make the file name.
+//! create, plus the executable's stem for the file name. The pid in the name
+//! is the unix side's own: the one this side sees is Wine's process id, which
+//! repeats from one launch to the next.
 
 use core::ffi::{c_char, c_void};
 use std::{
@@ -69,8 +71,6 @@ pub fn open(cfg: &mtld3d_core::config::Mtld3dConfig) {
         stem_ptr: stem.as_ptr() as usize as u64,
         dir_len,
         stem_len,
-        pid: std::process::id(),
-        pad0: 0,
     };
     unix_call(&mut params);
 }


### PR DESCRIPTION
## Symptoms

A game's `mtld3d-logs` directory holds one file, `WoW-32.log`, with every session since the file sink landed appended into it (nine `log file:` banners from three builds), and the ten-newest retention never removes anything. F12 traces collide the same way: every launch writes `WoW-32-1.gputrace`.

## Cause

The PE side sent `std::process::id()` in `OpenLogParams`, which under Wine is the Windows process id. Wineserver hands its first process id 0x20 = 32 on every fresh start, and the launcher starts a fresh wineserver per run, so every launch was process 32. The unix side opens the file in append mode, so the runs piled into one file and the retention had nothing to count.

## Changes

The unix side, which owns the file, now stamps the name with its own `std::process::id()`. The .so is an ordinary macOS dylib, so that is the host pid `ps` shows, unique per launch. `OpenLogParams` loses its `pid` field and the pad (24 bytes now), the layout test follows, and the docs on both sides plus the README say which pid the name carries and why Wine's would not do. A game that loads d3d9.dll twice in one process, as WoW does, still writes one file.

## Alternatives

A timestamp in the name sorts by name, but the second `OpenLog` of the same process would compute a different name than the file already open, and the README contract is `<exe>-<pid>`; a pid that is actually unique keeps it.

## Verification

`make check`, `make test-unit` (new `names_the_log_after_the_host_pid`, `open_log_layout` at 24 bytes), both e2e suites (433 + 433 passed). After the i686 run the test binaries' `mtld3d-logs` holds exactly ten logs with distinct host pids in their names. Verified on WoW: each launch now produces its own `WoW-<pid>.log`.
