### PR TITLE
Default query.flushImmediate to the spec-correct wait, keep the immediate answer for WoW via a profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,12 @@ memory headroom, or the games that rely on the looser behaviour:
   staging is released once its upload retires, so serving the lock re-creates
   the buffer, and a *partial* lock taken after such a release leaves the pixels
   outside its rect no longer matching the GPU copy (warned once per texture).
-- **`GetData(D3DGETDATA_FLUSH)` returns `S_OK` immediately** for a pending
-  occlusion query instead of blocking until the GPU has the count. Games use
-  that poll loop as a fence against 2004-era drivers without hazard tracking,
-  which Metal does explicitly, so the wait buys no correctness and stalls the
-  API thread, the frame-time bottleneck. `query.flushImmediate = false`
-  restores the spec-correct wait.
+- **`GetData(D3DGETDATA_FLUSH)` can answer immediately** for a pending
+  occlusion query instead of blocking until the GPU has the count, under
+  `query.flushImmediate = true`. The default is the spec-correct wait; the
+  `wow` profile turns the immediate answer on, because both World of Warcraft
+  clients use the poll loop only as a fence after every loading-screen upload
+  batch and never read the count.
 - **Depth stores are elided** where nothing reads the buffer back, so content
   that relies on depth surviving a pass it never cleared can read stale depth.
   Preserving it unconditionally would cost the optimization on every frame of
@@ -436,7 +436,8 @@ and the environment override it key by key.
 
 | Profile | Application | What it sets and why |
 |---|---|---|
-| `gta-iv` | Grand Theft Auto IV | `adapter.spoof=amd`, because the renderer branches on the reported vendor and stalls in its own identifier parsing on the NVIDIA identity. `caps.dfFormats=false`, because with the DF fourccs advertised it picks a mixed DF24 plus INTZ depth path that no hardware of its era offered. `query.flushImmediate=false`, because its occlusion culling needs real pixel counts rather than an immediate answer. `depth.aliasSameSize=true`, because its late alpha, sky and glow passes z-test one INTZ depth texture against scene depth rendered into a same-size sibling. |
+| `gta-iv` | Grand Theft Auto IV | `adapter.spoof=amd`, because the renderer branches on the reported vendor and stalls in its own identifier parsing on the NVIDIA identity. `caps.dfFormats=false`, because with the DF fourccs advertised it picks a mixed DF24 plus INTZ depth path that no hardware of its era offered. `depth.aliasSameSize=true`, because its late alpha, sky and glow passes z-test one INTZ depth texture against scene depth rendered into a same-size sibling. |
+| `wow` | World of Warcraft (1.12 and 3.3.5 clients) | `query.flushImmediate=true`, because both clients poll `GetData(D3DGETDATA_FLUSH)` as a GPU fence after every loading-screen upload batch and never read the count, so the spec-correct wait would cost seconds per load for nothing. |
 
 Every crate logs via `log` + `env_logger`. All targets sit under `mtld3d::*`
 and `env_logger` matches by `::`-separated prefix, so `RUST_LOG=mtld3d=warn` is

--- a/mtld3d.conf
+++ b/mtld3d.conf
@@ -172,30 +172,23 @@
 # Query   #
 ###########
 
-# Return `S_OK` immediately on `GetData(D3DGETDATA_FLUSH)` for a
-# `Pending` occlusion query instead of kernel-blocking on
-# `MTLCommandBuffer::waitUntilCompleted`.
+# Answer `GetData(D3DGETDATA_FLUSH)` on a pending occlusion query at
+# once, with the permissive "fully visible" count, instead of waiting
+# for the GPU to finish the frame that holds the query.
 #
-# D3D9-era games use the FLUSH-poll loop as a poor-man's GPU fence
-# to compensate for 2004-era drivers that lacked resource hazard
-# tracking. Metal tracks hazards explicitly between command
-# buffers, so the fence does no correctness work — it just throttles
-# our API thread (the project's bottleneck) while the GPU (which
-# has headroom) is given time it doesn't need. Returning `S_OK`
-# immediately lets the game proceed; the actual visibility count
-# finalizes naturally on the next `begin_frame` intake if it is
-# ever read via the non-FLUSH path (e.g. sun/moon lens-flare,
-# which uses `flags = 0`).
+# The wait is what D3D9 specifies, and an engine that polls with FLUSH
+# normally reads the number it gets back: Grand Theft Auto IV culls
+# its coronas by it, Source computes the visible fraction of its sun
+# and lens flares from it. The immediate answer is for a title that
+# uses the poll loop only as a GPU fence and never reads the count,
+# where the wait costs API-thread time for nothing: both World of
+# Warcraft clients fence every loading-screen upload batch that way,
+# and their built-in profile sets this to true.
 #
-# Flip to `false` to restore the spec-correct kernel wait. Worth
-# trying if a game appears to read the actual pixel count
-# immediately after FLUSH and depends on it being accurate (no
-# tested game does this in practice).
-#
-# Default: true
+# Default: false
 # Supported values: true, false
 
-# query.flushImmediate = true
+# query.flushImmediate = false
 
 
 #########

--- a/unix/conformance/src/run.rs
+++ b/unix/conformance/src/run.rs
@@ -142,12 +142,6 @@ pub fn run_subtest(
         // (or a SHADER_CACHE_SCHEMA bump) is always reflected without having to
         // delete a stale cache by hand.
         //
-        // `query.flushImmediate=false`: restore the spec-correct *blocking*
-        // `GetData(D3DGETDATA_FLUSH)` for occlusion queries. The runtime default
-        // (`true`) returns a permissive stub immediately for API-thread
-        // throughput, but conformance wants the real GPU pixel count, so flip it
-        // off here (occlusion-only; EVENT/TIMESTAMP `GetData` are unaffected).
-        //
         // `color.hdr.enable=false`: the shipped default is on, but it resolves
         // off the running machine's panel, so an EDR Mac would present through
         // the tone-mapping shader while another machine blits. The baseline has
@@ -155,7 +149,7 @@ pub fn run_subtest(
         // path here.
         .env(
             "MTLD3D_CONFIG",
-            "shaderCache.enable=false;query.flushImmediate=false;color.hdr.enable=false",
+            "shaderCache.enable=false;color.hdr.enable=false",
         )
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/windows/core/src/app_profile.rs
+++ b/windows/core/src/app_profile.rs
@@ -41,8 +41,21 @@ static PROFILES: &[AppProfile] = &[
         company: Some("Rockstar Games"),
         product: Some("Grand Theft Auto IV"),
         original_filename: None,
-        settings: "adapter.spoof=amd;caps.dfFormats=false;\
-                   query.flushImmediate=false;depth.aliasSameSize=true",
+        settings: "adapter.spoof=amd;caps.dfFormats=false;depth.aliasSameSize=true",
+    },
+    // World of Warcraft, the 1.12 and 3.3.5 clients alike. Both use the
+    // `GetData(D3DGETDATA_FLUSH)` poll loop as a GPU fence after every
+    // loading-screen upload batch and never read the count it returns, so the
+    // spec-correct wait only costs them seconds per load; the immediate answer
+    // keeps that time and changes nothing they render. The sun and moon lens
+    // flares read their queries without FLUSH and still get the real counts.
+    AppProfile {
+        name: "wow",
+        exe: "WoW.exe",
+        company: Some("Blizzard Entertainment"),
+        product: Some("World of Warcraft"),
+        original_filename: None,
+        settings: "query.flushImmediate=true",
     },
 ];
 
@@ -117,16 +130,17 @@ impl AppIdentity {
 
 /// The built-in profile for this application, if it has one.
 ///
-/// Logs the outcome either way: which profile took effect, or that none did.
-/// Both answers are the first thing to establish when a game behaves
-/// differently than its options say it should.
+/// Logs the outcome either way: which profile took effect and the options it
+/// sets, or that none did. Both answers are the first thing to establish when a
+/// game behaves differently than its options say it should.
 #[must_use]
 pub fn lookup(id: &AppIdentity) -> Option<&'static AppProfile> {
     let profile = PROFILES.iter().find(|p| p.matches(id));
     match profile {
         Some(p) => info!(
             target: LOG_TARGET,
-            "app profile: {} matched {} ({}, {})", p.name, id.exe, id.company, id.product
+            "app profile: {} matched {} ({}, {}): {}",
+            p.name, id.exe, id.company, id.product, p.settings
         ),
         None => info!(target: LOG_TARGET, "app profile: none for {}", id.exe),
     }

--- a/windows/core/src/app_profile/tests.rs
+++ b/windows/core/src/app_profile/tests.rs
@@ -53,6 +53,24 @@ fn the_gta_iv_profile_matches_the_real_binarys_resource() {
 }
 
 #[test]
+fn the_wow_profile_matches_both_clients_and_keeps_the_immediate_answer() {
+    for version in ["Version 1.12", "Version 3.3"] {
+        let blob = blob(&[
+            ("CompanyName", "Blizzard Entertainment"),
+            ("ProductName", "World of Warcraft"),
+            ("ProductVersion", version),
+        ]);
+        let id = AppIdentity::new("WoW.exe".to_owned(), Some(&blob));
+        let profile = lookup(&id).expect("the wow profile matches");
+        assert_eq!(profile.name(), "wow");
+        assert!(!parse(None, "", None).query_flush_immediate);
+        assert!(parse(Some(profile), "", None).query_flush_immediate);
+    }
+    let nameless = AppIdentity::new("WoW.exe".to_owned(), None);
+    assert!(lookup(&nameless).is_none());
+}
+
+#[test]
 fn a_pinned_field_is_a_substring_test() {
     let suffixed = blob(&[
         ("CompanyName", "Rockstar Games, Inc."),

--- a/windows/core/src/config.rs
+++ b/windows/core/src/config.rs
@@ -111,15 +111,14 @@ pub struct Mtld3dConfig {
     pub skip_shaders: Vec<u64>,
     /// Return `S_OK` immediately on `GetData(D3DGETDATA_FLUSH)` for a `Pending` occlusion query.
     ///
-    /// Skips the kernel block on `MTLCommandBuffer::waitUntilCompleted`.
-    /// Default: `true` — D3D9-era games use the FLUSH-poll loop as a
-    /// poor-man's GPU fence to work around 2004-era drivers that lacked
-    /// resource hazard tracking. Metal tracks hazards explicitly, so the
-    /// fence buys nothing and just throttles our API thread (the
-    /// project's bottleneck). Flip to `false` to restore the
-    /// spec-correct kernel wait if a game ever needs the actual
-    /// pixel count immediately after FLUSH. File key:
-    /// `query.flushImmediate`.
+    /// Skips the kernel block on `MTLCommandBuffer::waitUntilCompleted` and
+    /// answers with the permissive count instead. Default: `false`, the
+    /// spec-correct wait, because an engine that polls with FLUSH reads the
+    /// count it gets back (a pixel-visibility fraction, an occlusion cull).
+    /// `true` is for a title that uses the poll loop only as a GPU fence and
+    /// never reads the number: the `wow` profile sets it, since both clients
+    /// fence every loading-screen upload batch that way and the wait costs
+    /// seconds per load. File key: `query.flushImmediate`.
     pub query_flush_immediate: bool,
     /// A newly bound same-size depth-stencil texture inherits the previous one's contents.
     ///
@@ -289,7 +288,7 @@ impl Default for Mtld3dConfig {
             log_dir: String::new(),
             bytecode_dump_dir: String::new(),
             skip_shaders: Vec::new(),
-            query_flush_immediate: true,
+            query_flush_immediate: false,
             depth_alias_same_size: false,
             buffer_ignore_lock_bounds: false,
             vbib_retention_cap_bytes: 512 * 1024 * 1024,

--- a/windows/core/src/config/tests.rs
+++ b/windows/core/src/config/tests.rs
@@ -32,7 +32,7 @@ fn defaults_match_documented_values() {
     assert!(d.log_dir.is_empty());
     assert!(d.bytecode_dump_dir.is_empty());
     assert!(d.skip_shaders.is_empty());
-    assert!(d.query_flush_immediate);
+    assert!(!d.query_flush_immediate);
     assert!(!d.buffer_ignore_lock_bounds);
     assert_eq!(d.vbib_retention_cap_bytes, 512 * 1024 * 1024);
     assert_eq!(d.pagebox_pool_cap_bytes, 128 * 1024 * 1024);

--- a/windows/d3d9/src/config.rs
+++ b/windows/d3d9/src/config.rs
@@ -38,8 +38,8 @@ fn load() -> Mtld3dConfig {
         .filter(|s| !s.trim().is_empty());
     let profile = app_profile();
     let file_src = read_conf_file();
-    if env_override.is_some() {
-        info!(target: LOG_TARGET, "mtld3d.conf: applying MTLD3D_CONFIG overrides");
+    if let Some(env) = &env_override {
+        info!(target: LOG_TARGET, "mtld3d.conf: applying MTLD3D_CONFIG overrides: {env}");
     }
     let cfg = parse(
         profile,


### PR DESCRIPTION
## Symptoms

The immediate answer on `GetData(D3DGETDATA_FLUSH)` was the shipped default, which is the wrong way round. An engine that polls with FLUSH normally reads the count it gets back: GTA IV culls its coronas by it, Source computes the visible fraction of its sun and lens flares from it. Every such game needed a profile or a conf edit to get real pixel counts, while the one title the shortcut exists for, World of Warcraft, got it for free only because it happened to be the default.

The log also announced its override layers without saying what they applied: `app profile: gta-iv matched ...` and `mtld3d.conf: applying MTLD3D_CONFIG overrides` named the layer but not the keys.

## Changes

`query.flushImmediate` now defaults to `false`, the spec-correct GPU wait, so a new game gets real counts without a profile.

A built-in `wow` profile (exe `WoW.exe`, company `Blizzard Entertainment`, product `World of Warcraft`, which both the 1.12 and the 3.3.5 client carry in their version resource) sets `query.flushImmediate=true`. Both clients use the poll loop only as a GPU fence after every loading-screen upload batch and never read the number, where the wait costs seconds per load. The sun and moon lens flares read their queries without FLUSH and still get the real counts.

The GTA IV profile drops its now-redundant `query.flushImmediate=false`, and so does the conformance runner's `MTLD3D_CONFIG`, which no longer has to pin the wait.

The profile match line and the `MTLD3D_CONFIG` line both print the entries they apply, in the same form: `app profile: wow matched WoW.exe (Blizzard Entertainment, World of Warcraft): query.flushImmediate=true` and `mtld3d.conf: applying MTLD3D_CONFIG overrides: <entries>`.

README and mtld3d.conf are reworded to describe the new default and the profile.

## Alternatives

Keeping the immediate answer as the default and adding profiles for each game that reads the count was rejected: the games that read it are the norm and the spec is on their side, so the deviation belongs in the profile of the one game that benefits from it.

## Verification

`make check` clean. `make test`: 1026 core, 199 conformance-CLI and 436 end-to-end tests on both legs pass, including the new `the_wow_profile_matches_both_clients_and_keeps_the_immediate_answer` and the updated `defaults_match_documented_values`.

WoW 1.12 (TurtleWoW) launched with the installed build: the log prints the matched profile with its key and `config: query.flushImmediate = true`, loading times unchanged. The version resource of the binary was decoded and matches the profile's constraints.