### PR TITLE
make: ISOLATED=1 runs the tests against a private Wine tree per checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 /windows/target
 /unix/target
+/.wine-isolated
 .DS_Store
 
 # Editor / IDE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,21 @@ Two commands, both green before you commit:
 touched, that churn is its own pull request, not a hand-revert and not a passenger
 in yours.
 
+Every test leg installs the build into the Wine tree `WINE_SDK` names (and into
+`WINE_INSTALL_DIR` when set) before it runs, so two checkouts testing at once
+overwrite each other's `d3d9.dll` and `mtld3d.so`, and a game launched from that
+tree meanwhile runs whichever build landed last. `make test ISOLATED=1` avoids
+both: it clones the SDK and the ambient prefix once into `.wine-isolated/`
+inside the checkout (APFS clones, so neither costs space or a prefix boot) and
+points the tools, the install and the prefix at the clones. Use it whenever
+another worktree may be testing or a game is running; a plain `make install`
+still targets the shared trees on purpose, since that is how the game gets a
+build. The clones and the persistent wineserver of the private prefix stay
+behind for the next run; `make clean-isolated` takes them down, and
+`make clean-isolated-all` does so for every worktree of the repository. A failing run
+whose log shows a `d3d9.dll v` stamp that is not your checkout's is that
+collision, not a regression.
+
 Both agent runners configured in this tree already print the conventions digest
 at session start and run `scripts/audit.sh --file` after every edit, so a
 violation surfaces while you write rather than at commit time. The digest at

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,27 @@
 ifndef WINE_SDK
 $(error WINE_SDK is not set)
 endif
+
+# ISOLATED=1 runs every install-bearing target against a private clone of the
+# Wine SDK inside this checkout: the SDK the tools come from, the tree the
+# builds install into and the prefix the tests boot all move under
+# `.wine-isolated`, so parallel worktrees, and the game bundle a maintainer is
+# playing from, never see each other's builds. APFS clones both trees for free
+# on the same volume: the SDK from `WINE_SDK`, the prefix from the ambient
+# `WINEPREFIX` (or `~/.wine`) so no prefix boots from scratch; each clone is
+# made once and reused, and `clean-isolated` removes them. Without the knob,
+# `make install` and every test leg keep targeting the shared trees, which is
+# how the game gets a build.
+ISOLATED_ROOT := $(CURDIR)/.wine-isolated
+ifeq ($(ISOLATED),1)
+ISOLATED_PREFIX_SOURCE := $(or $(WINEPREFIX),$(HOME)/.wine)
+$(shell [ -d $(ISOLATED_ROOT)/sdk ] || { mkdir -p $(ISOLATED_ROOT) && { cp -c -R $(WINE_SDK) $(ISOLATED_ROOT)/sdk 2>/dev/null || { rm -rf $(ISOLATED_ROOT)/sdk && cp -R $(WINE_SDK) $(ISOLATED_ROOT)/sdk; }; }; })
+$(shell [ -d $(ISOLATED_ROOT)/prefix ] || [ ! -d $(ISOLATED_PREFIX_SOURCE) ] || { cp -c -R $(ISOLATED_PREFIX_SOURCE) $(ISOLATED_ROOT)/prefix 2>/dev/null || { rm -rf $(ISOLATED_ROOT)/prefix && cp -R $(ISOLATED_PREFIX_SOURCE) $(ISOLATED_ROOT)/prefix; }; })
+WINE_SDK := $(ISOLATED_ROOT)/sdk
+WINE_INSTALL_DIR := $(ISOLATED_ROOT)/sdk
+export WINEPREFIX := $(ISOLATED_ROOT)/prefix
+$(info ==> ISOLATED=1: Wine SDK, install dir and prefix under $(ISOLATED_ROOT))
+endif
 export WINE_SDK
 
 # The Wine tools this Makefile runs, named by absolute path out of the same
@@ -170,7 +191,9 @@ SDK_UNIX_ARCH ?= $(if $(findstring arm64,$(shell file -b $(WINE_SDK)/bin/wine)),
 # plain invocations.
 DENY_WARNINGS := --config 'build.warnings="deny"'
 
-INSTALL_DIRS := $(WINE_SDK) $(WINE_INSTALL_DIR)
+# Sorted for its side effect of dropping a duplicate: under ISOLATED=1 both
+# name the same clone, and the install loops must write it once.
+INSTALL_DIRS := $(sort $(WINE_SDK) $(WINE_INSTALL_DIR))
 
 # Both overridable, unlike the rest of these: the HUD and the validation layer
 # are here to catch Metal misuse on a real GPU, and a caller running against a
@@ -225,7 +248,7 @@ BUILD_ID     := $(shell git describe --tags --always 2>/dev/null || \
 # Wine install, never into a file named after the target.
 .PHONY: all windows windows-i686 windows-x86_64 unix unix-x64 unix-arm64 \
 	install install-windows-i686 install-windows-x86_64 install-unix-x64 install-unix-arm64 \
-	bundle stage configure-test-prefix \
+	bundle stage configure-test-prefix clean-isolated clean-isolated-all \
 	test test-unit test-e2e-i686 test-e2e-x86_64 \
 	conformance conformance-i686 conformance-x86_64 \
 	conformance-baseline conformance-baseline-i686 conformance-baseline-x86_64 \
@@ -726,6 +749,30 @@ check:
 clean:
 	cd windows && cargo +$(RUST_STABLE) clean
 	cd unix && cargo +$(RUST_STABLE) clean
+
+# Take down what ISOLATED=1 left in this checkout: the persistent wineserver of
+# the private prefix (and the winedevice residents it keeps), then the clones.
+# Named after the knob rather than folded into `clean`, which is about cargo
+# output and must stay usable while an isolated test is running.
+clean-isolated:
+	if [ -x $(ISOLATED_ROOT)/sdk/bin/wineserver ] && [ -d $(ISOLATED_ROOT)/prefix ]; then \
+		WINEPREFIX=$(ISOLATED_ROOT)/prefix $(ISOLATED_ROOT)/sdk/bin/wineserver -k >/dev/null 2>&1 ; \
+		WINEPREFIX=$(ISOLATED_ROOT)/prefix $(ISOLATED_ROOT)/sdk/bin/wineserver -w >/dev/null 2>&1 ; \
+	fi
+	rm -rf $(ISOLATED_ROOT)
+
+# The same for every worktree of this repository, from any of them: git knows
+# the worktrees, and each one cleans its own environment. A wineserver still
+# running out of a `.wine-isolated/sdk` afterwards belongs to a checkout that
+# was removed with its environment up (`git worktree remove` takes the
+# directory, not the process), so it is ended directly; the path is specific
+# enough that nothing else matches.
+clean-isolated-all:
+	git worktree list --porcelain | sed -n 's/^worktree //p' | while read -r wt; do \
+		[ -d "$$wt/.wine-isolated" ] || continue ; \
+		$(MAKE) -C "$$wt" clean-isolated ; \
+	done
+	pkill -f '/\.wine-isolated/sdk/bin/wineserver' 2>/dev/null || true
 
 upgrade:
 	cd windows && cargo +$(RUST_STABLE) update


### PR DESCRIPTION
## Symptoms

Every test leg installs the build into the Wine SDK before it runs, and into the game bundle when `WINE_INSTALL_DIR` names one. Two checkouts running `make test` at the same time overwrite each other's `d3d9.dll` and `mtld3d.so`, and a game launched from the bundle meanwhile runs whichever build landed last. The tell is an e2e failure whose log carries another checkout's version stamp, for example `mtld3d.so v0.7.0-19-g1a48fdf` next to `d3d9.dll v0.7.0-18-g00e0308`.

## Root cause

`INSTALL_DIRS` is the shared SDK plus the bundle, and every install-bearing target writes there unconditionally. There is no supported way to point one checkout at a tree of its own; the only workaround is setting `WINE_SDK`, `WINE_INSTALL_DIR` and `WINEPREFIX` by hand for every invocation.

## Changes

`ISOLATED=1` clones the SDK and the ambient prefix (`WINEPREFIX`, or `~/.wine`) once into `.wine-isolated/` inside the checkout, both as APFS clones so neither costs space until written and no prefix boots from scratch, and re-points `WINE_SDK`, `WINE_INSTALL_DIR` and `WINEPREFIX` at the clones before the tool paths resolve. `INSTALL_DIRS` is sorted so the two names collapsing onto the clone install once. Nothing downstream changes: `configure-test-prefix`, the persistent wineserver, conformance and the unix-arch probe all read `WINE_SDK`. `make clean-isolated` shuts down the private prefix's persistent wineserver (with the winedevice residents it keeps) and removes the clones; it is separate from `clean`, which is about cargo output and stays usable while an isolated test runs. `make clean-isolated-all` does the same for every worktree of the repository from any of them, and ends a wineserver still running out of a `.wine-isolated/sdk` whose checkout was removed with the environment up. Without the knob every target keeps its shared-tree behaviour, which is how the game gets a build. `.gitignore` covers the clones and CONTRIBUTING's gates section says when to use the knob and how to clean up.

## Alternatives

A private prefix alone: does not stop the install into the shared SDK, which is where the collision is.

A per-checkout `WINE_SDK` set by hand: works, and is what the issue-loop scripts do, but is easy to forget and leaves the bundle exposed to a stray `make test`.

A fresh prefix boot instead of a clone: a gigabyte written and a wineboot per checkout for nothing the tests need; the clone carries the registry keys `configure-test-prefix` sets and the boot-time DLL markers already.

## Verification

`make test ISOLATED=1` from this worktree while two other worktrees ran their own suites and a game bundle was in use: the shared SDK's `lib/wine` mtime did not move and both legs installed into `.wine-isolated/sdk`. Results: unit tests 1035 + 202 passed; e2e x86_64 440/440 passed; e2e i686 439/439 passed with `FILTER='not binary(unload)'`, because `unload::exception_after_free_library_survives` fails on `main` under load independently of this change (#378, the log thread outliving `FreeLibrary`). `make check` green. `make clean-isolated` ends the private wineserver and removes the directory (verified with `pgrep` before and after); a following `make test-e2e-i686 ISOLATED=1 FILTER='binary(smoke)'` re-clones both trees and passes in 18 seconds end to end. `make clean-isolated-all` run against a worktree whose `.wine-isolated` had been deleted under a live wineserver (what `git worktree remove` leaves) ended that server and its winedevice residents.
