### PR TITLE
Bound the whole test process in the e2e runner, not only its stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -596,7 +596,9 @@ test-unit:
 # deadlock stays away and ~130 s when it hits); a CI runner, whose device
 # creation cannot overlap at all, stays at 1 either way. TIMEOUT=<secs> is
 # how long a process may go without reporting a result before the runner
-# kills it and charges the hang to the test that was running (default 60).
+# kills it and charges the hang to the test that was running (default 60);
+# the same bound covers a process that has closed stdout but will not exit,
+# and a process tree that keeps stderr open after the process is gone.
 #
 # A scaled or Intel-variant run reports the whole suite instead of stopping at
 # the first failure, and FAIL_FAST=0 asks for that on any run. The point of

--- a/unix/Cargo.lock
+++ b/unix/Cargo.lock
@@ -241,6 +241,9 @@ version = "0.8.0"
 [[package]]
 name = "mtld3d-e2e"
 version = "0.8.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mtld3d-shared"

--- a/unix/e2e/Cargo.toml
+++ b/unix/e2e/Cargo.toml
@@ -7,5 +7,8 @@ license.workspace = true
 description.workspace = true
 authors.workspace = true
 
+[dependencies]
+libc = { workspace = true }
+
 [lints]
 workspace = true

--- a/unix/e2e/src/run.rs
+++ b/unix/e2e/src/run.rs
@@ -6,15 +6,22 @@
 //! sign of a hung test: the watchdog kills it once no line has arrived for
 //! the caller's timeout. stderr is collected whole; it carries the panic
 //! reports and Wine's own diagnostics, read after the process has ended.
+//!
+//! The same timeout bounds the end of the process: one that closes stdout
+//! and then never exits, or leaves a descendant holding stderr open, is
+//! killed once the timeout passes with no exit or no end of stderr. The
+//! child runs in a process group of its own so the kill takes every process
+//! Wine forked under it, and never the wineserver the caller booted for the
+//! whole run, which belongs to the caller's group.
 
 use std::{
     io::{BufRead, BufReader, Read},
-    os::unix::process::ExitStatusExt,
+    os::unix::process::{CommandExt, ExitStatusExt},
     path::Path,
-    process::{Command, Stdio},
+    process::{Child, Command, ExitStatus, Stdio},
     sync::mpsc,
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 /// How a process ended.
@@ -26,6 +33,8 @@ pub enum ExitKind {
     Signal(i32),
     /// The watchdog killed it after this long without a line on stdout.
     TimedOut(Duration),
+    /// It closed stdout and was killed after this long without exiting.
+    Hung(Duration),
 }
 
 impl ExitKind {
@@ -36,6 +45,9 @@ impl ExitKind {
             Self::Code(code) => format!("exit code {code}"),
             Self::Signal(signal) => format!("signal {signal}"),
             Self::TimedOut(after) => format!("no output for {} s", after.as_secs()),
+            Self::Hung(after) => {
+                format!("no exit for {} s after its last line", after.as_secs())
+            }
         }
     }
 }
@@ -46,11 +58,16 @@ pub struct Exit {
     pub stderr: String,
 }
 
+/// How often the bounded wait for the process's exit looks again.
+const EXIT_POLL: Duration = Duration::from_millis(20);
+
 /// Run `wine <exe> <args...>` in the exe's directory, streaming stdout lines to `on_line`.
 ///
 /// Killed, and reported as [`ExitKind::TimedOut`], once `timeout` passes
-/// without a stdout line. The environment is inherited whole: the caller
-/// owns `MTLD3D_CONFIG` and the Wine variables.
+/// without a stdout line; killed, and reported as [`ExitKind::Hung`], once
+/// it passes after stdout closed without the process exiting. The
+/// environment is inherited whole: the caller owns `MTLD3D_CONFIG` and the
+/// Wine variables.
 ///
 /// # Errors
 ///
@@ -70,23 +87,27 @@ pub fn run(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .process_group(0)
         .spawn()
         .map_err(|e| format!("failed to spawn {} {}: {e}", wine.display(), exe.display()))?;
 
     let stdout = child.stdout.take().ok_or("stdout not piped")?;
     let mut stderr = child.stderr.take().ok_or("stderr not piped")?;
     let (lines, received) = mpsc::channel::<String>();
-    let stdout_reader = thread::spawn(move || {
+    // Neither reader is joined: each ends when its pipe does, and a pipe a
+    // killed process tree held open ends with the kill.
+    thread::spawn(move || {
         for line in BufReader::new(stdout).lines().map_while(Result::ok) {
             if lines.send(line).is_err() {
                 break;
             }
         }
     });
-    let stderr_reader = thread::spawn(move || {
+    let (stderr_tx, stderr_rx) = mpsc::channel::<String>();
+    thread::spawn(move || {
         let mut buf = Vec::new();
         let _ = stderr.read_to_end(&mut buf);
-        String::from_utf8_lossy(&buf).into_owned()
+        let _ = stderr_tx.send(String::from_utf8_lossy(&buf).into_owned());
     });
 
     let mut timed_out = false;
@@ -94,20 +115,34 @@ pub fn run(
         match received.recv_timeout(timeout) {
             Ok(line) => on_line(&line),
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                let _ = child.kill();
+                kill_group(&child);
                 timed_out = true;
                 break;
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         }
     }
-    let status = child
-        .wait()
-        .map_err(|e| format!("wait on {} failed: {e}", exe.display()))?;
-    let _ = stdout_reader.join();
-    let stderr = stderr_reader.join().unwrap_or_default();
+    let (status, hung) = if let Some(status) = wait_bounded(&mut child, timeout) {
+        (status, false)
+    } else {
+        kill_group(&child);
+        let status = child
+            .wait()
+            .map_err(|e| format!("wait on {} failed: {e}", exe.display()))?;
+        (status, true)
+    };
+    let stderr = stderr_rx.recv_timeout(timeout).unwrap_or_else(|_| {
+        kill_group(&child);
+        let mut stderr = stderr_rx.recv_timeout(EXIT_POLL).unwrap_or_default();
+        stderr.push_str(
+            "[e2e] stderr not collected in full: the process tree held it open past the timeout\n",
+        );
+        stderr
+    });
     let kind = if timed_out {
         ExitKind::TimedOut(timeout)
+    } else if hung {
+        ExitKind::Hung(timeout)
     } else if let Some(signal) = status.signal() {
         ExitKind::Signal(signal)
     } else {
@@ -115,3 +150,37 @@ pub fn run(
     };
     Ok(Exit { kind, stderr })
 }
+
+/// The process's exit status if it exits within `timeout`, `None` if it does not.
+fn wait_bounded(child: &mut Child, timeout: Duration) -> Option<ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        // A wait that fails is treated as a process that will not exit: the
+        // caller kills the group and waits again, and that wait reports.
+        if let Ok(Some(status)) = child.try_wait() {
+            return Some(status);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        thread::sleep(EXIT_POLL);
+    }
+}
+
+/// SIGKILL the child's process group: the child and everything it forked.
+///
+/// The child is its own group leader (`process_group(0)` at spawn), so the
+/// group id is its pid. A group that is already gone is not an error.
+fn kill_group(child: &Child) {
+    let Ok(pid) = i32::try_from(child.id()) else {
+        return;
+    };
+    // SAFETY: kill(2) with a negative pid signals the group; it touches no
+    // memory of ours and a stale id is reported as ESRCH, not acted on.
+    unsafe {
+        let _ = libc::kill(-pid, libc::SIGKILL);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/unix/e2e/src/run/tests.rs
+++ b/unix/e2e/src/run/tests.rs
@@ -1,0 +1,73 @@
+//! The process deadlines: `/bin/sh` plays Wine, a script plays the test binary.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+use super::{ExitKind, run};
+
+/// A script in a fresh directory under the target dir, run as `sh <script>`.
+fn script(name: &str, body: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("mtld3d-e2e-run-{}-{name}", std::process::id()));
+    fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join(format!("{name}.sh"));
+    fs::write(&path, body).expect("script");
+    path
+}
+
+fn run_script(path: &Path, timeout: Duration) -> (super::Exit, Duration, Vec<String>) {
+    let mut lines = Vec::new();
+    let started = Instant::now();
+    let exit = run(&PathBuf::from("/bin/sh"), path, &[], timeout, &mut |line| {
+        lines.push(line.to_owned());
+    })
+    .expect("spawn sh");
+    (exit, started.elapsed(), lines)
+}
+
+#[test]
+fn a_clean_exit_reports_its_code_and_stderr() {
+    let path = script("clean", "echo one\necho two >&2\nexit 3\n");
+    let (exit, _, lines) = run_script(&path, Duration::from_secs(5));
+    assert_eq!(exit.kind, ExitKind::Code(3));
+    assert_eq!(lines, ["one"]);
+    assert_eq!(exit.stderr, "two\n");
+}
+
+#[test]
+fn silence_on_stdout_is_killed_after_the_timeout() {
+    let path = script("silent", "echo start\nsleep 30\n");
+    let timeout = Duration::from_millis(500);
+    let (exit, elapsed, lines) = run_script(&path, timeout);
+    assert_eq!(exit.kind, ExitKind::TimedOut(timeout));
+    assert_eq!(lines, ["start"]);
+    assert!(elapsed < Duration::from_secs(5), "took {elapsed:?}");
+}
+
+#[test]
+fn a_process_that_closes_stdout_and_never_exits_is_killed_and_reported_hung() {
+    let path = script("hung", "echo last\nexec 1>&-\nexec 2>&-\nsleep 30\n");
+    let timeout = Duration::from_millis(500);
+    let (exit, elapsed, lines) = run_script(&path, timeout);
+    assert_eq!(exit.kind, ExitKind::Hung(timeout));
+    assert_eq!(lines, ["last"]);
+    assert!(elapsed < Duration::from_secs(5), "took {elapsed:?}");
+}
+
+#[test]
+fn a_descendant_holding_stderr_does_not_park_the_run() {
+    // The script exits at once; its background child keeps stderr open.
+    let path = script("holder", "echo done\n(sleep 30 >/dev/null) &\nexit 0\n");
+    let timeout = Duration::from_millis(500);
+    let (exit, elapsed, lines) = run_script(&path, timeout);
+    assert_eq!(exit.kind, ExitKind::Code(0));
+    assert_eq!(lines, ["done"]);
+    assert!(
+        exit.stderr.contains("stderr not collected in full"),
+        "stderr: {:?}",
+        exit.stderr
+    );
+    assert!(elapsed < Duration::from_secs(5), "took {elapsed:?}");
+}


### PR DESCRIPTION
Fixes #391.

## Symptom

`e2e (macos-26, x86_64)` on the #386 merge run sat in `make test-e2e-x86_64` for 26 minutes with no output until it was cancelled by hand; the job's cleanup then killed an orphaned `mtld3d-e2e` and a wineserver. The last line was the `snmalloc_drift` result, `unload` reported nothing, and `TIMEOUT=240` never fired.

## Cause

The runner's only deadline was `recv_timeout` on the next stdout line. Once that loop ended, `child.wait()`, the stderr `read_to_end` and both reader joins were unbounded, so a process that closed stdout and then never exited (the #378 fault) parked the runner until the job timeout.

## Change

The child runs in a process group of its own and every kill is a SIGKILL of that group, so the Wine loader, the PE process and whatever they forked go together; the persistent wineserver the Makefile boots belongs to make's group and is untouched. After the stdout loop the exit is polled for `TIMEOUT`, then the group is killed and the end reports as `no exit for N s after its last line` (`ExitKind::Hung`). stderr arrives over a channel with the same bound; a miss kills the group and the collected text says it was cut short. The reader threads are not joined any more, each ends with its pipe. `attribute.rs` needs no change: such an end is charged like any other non-clean one.

## Alternatives

A single deadline for the whole process would charge a slow but healthy suite; the per-stage bound keeps `TIMEOUT` meaning "this long with nothing happening". Killing only the child pid leaves a wineserver or a PE process the loader forked holding the pipes, which is the stderr hang.

## Verification

`cargo nextest run -p mtld3d-e2e`: four new host tests in `run/tests.rs` (clean exit, silent process, closed-stdout hang, a descendant holding stderr), each returning within the 500 ms bound. The release runner against a script that closes stdout and sleeps, with `--timeout 2`, returns in 4 s and reports the end. `make check` green. `make test ISOLATED=1` green on x86_64 and 446/447 on i686, the one failure being `unload::exception_after_free_library_survives` on main's `d3d9.dll`, which is #378 and is now charged and moved past instead of parked on; green on both once #378 lands. Rules check: `libc` added to `mtld3d-e2e` from the workspace dependencies, no new version or crate; `ExitKind`'s inventoried derives unchanged; no static, config key, wire field or lint suppression; the uncollected stderr is reported, not swallowed.
