### PR TITLE
Stop a conformance leg on the driver's GPU-hang line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,8 @@ jobs:
   # part of `make test`: many subtests fail by design, so this gates on a
   # regression rather than on zero failures. The per-subtest budget is raised
   # from its 180 s default because the GPU here is paravirtual, and a subtest
-  # killed for taking too long is reported as a crash.
+  # killed for taking too long is reported as a crash; a subtest the GPU
+  # hangs under never reaches it (see the step below).
   # This gates on the same baseline the local runs use, in both directions:
   # a count above its pin is a regression, a count below it is a stale
   # baseline (also fatal, see CONFORMANCE.md). The desktop-mode sites that
@@ -228,19 +229,23 @@ jobs:
       # family is a runner, so its counts are recorded here and committed from
       # the artifact below (each arch's file carries its own leg; the merge is
       # leg-scoped, so the two sections are copied in side by side).
-      # The paravirtual GPU hangs now and then under a long subtest (the
-      # driver reports kIOAccelCommandBufferCallbackErrorHang and every later
-      # command buffer is ignored, or the subtest never returns and the
-      # runner kills it at its budget). A regression never looks like that,
-      # so a leg whose raw output carries the signature gets one more
-      # attempt; a second hang, or any other failure, gates.
+      # The paravirtual GPU hangs now and then under a long subtest: the
+      # driver reports kIOAccelCommandBufferCallbackErrorHang on the test
+      # process's stderr, every later command buffer is ignored, and the GPU
+      # stays that way for the rest of the machine's life (a second attempt
+      # on the same runner hung again, in the next subtest's fresh process).
+      # The runner reads that line as it arrives, stops the subtest and ends
+      # the leg, so the hang costs seconds rather than the subtest's budget;
+      # what is left for this step is to say what the failure means. A
+      # regression never looks like that, and the machine will not recover,
+      # so the answer is a re-run of the failed jobs, which lands on a fresh
+      # runner, not another attempt here.
       - run: |
-          leg() { make conformance-${{ matrix.runner == 'macos-15-intel' && (inputs.record_intel_baseline && 'baseline-intel-' || 'intel-') || '' }}${{ matrix.arch }} STAGE="$STAGE"; }
-          if ! leg; then
-            grep -lqE 'TIMED OUT|GPU Hang' "$MTLD3D_CONFORMANCE_RAW_DIR"/*.log 2>/dev/null || exit 1
-            echo "::warning::a subtest hung on this runner's GPU; running the leg once more"
-            mv "$MTLD3D_CONFORMANCE_RAW_DIR" "$MTLD3D_CONFORMANCE_RAW_DIR-first-attempt"
-            leg
+          if ! make conformance-${{ matrix.runner == 'macos-15-intel' && (inputs.record_intel_baseline && 'baseline-intel-' || 'intel-') || '' }}${{ matrix.arch }} STAGE="$STAGE"; then
+            if grep -lq kIOAccelCommandBufferCallbackErrorHang "$MTLD3D_CONFORMANCE_RAW_DIR"/*.log 2>/dev/null; then
+              echo "::error::this runner's GPU hung and stays hung for the rest of the job, so the leg was cut short; not a regression when the other conformance jobs are green. Re-run the failed jobs to get a fresh machine: gh run rerun ${{ github.run_id }} --failed"
+            fi
+            exit 1
           fi
         env:
           MTLD3D_CONFORMANCE_TIMEOUT_SECS: "600"
@@ -256,7 +261,7 @@ jobs:
         if: always()
         with:
           name: conformance-raw-${{ matrix.runner }}-${{ matrix.arch }}
-          path: ${{ runner.temp }}/conformance-raw*
+          path: ${{ runner.temp }}/conformance-raw
           retention-days: 14
           if-no-files-found: error
       - uses: actions/upload-artifact@v4

--- a/unix/Cargo.lock
+++ b/unix/Cargo.lock
@@ -237,6 +237,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 [[package]]
 name = "mtld3d-conformance"
 version = "0.8.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mtld3d-e2e"

--- a/unix/conformance/CONFORMANCE.md
+++ b/unix/conformance/CONFORMANCE.md
@@ -50,6 +50,18 @@ the Metal-validation lines), which is what the per-cluster audit below was built
 from — the *actual-vs-expected* values distinguish a real defect from an
 acceptable `caps` difference. Off unless the variable is set.
 
+The runner reads the test process's stderr as it arrives, and the driver's
+GPU-hang line (`kIOAccelCommandBufferCallbackErrorHang`, or the
+`...SubmissionsIgnored` line the driver prints for every command buffer it
+drops afterwards) stops the subtest at once and ends the leg: exit code 3, no
+verdict, no baseline write. Every count after that line is a read off a GPU
+that runs nothing, and waiting out the subtest's budget would only make the
+same non-verdict cost minutes. On the Intel CI image the paravirtual GPU stays
+hung for the rest of the machine's life, so the later subtests would hang too
+and the job names the re-run of the failed jobs, which lands on a fresh runner.
+A hang on a real GPU is worth a look on its own (a shader that hangs the GPU is
+a bug), but the leg has to run again for its counts either way.
+
 There is no conformance-specific input to set. The test binaries ship inside the
 Wine SDK bundle (`$WINE_SDK/lib/wine/tests/{i386,x86_64}-windows/d3d9_test.exe`,
 published by the [wine-build](https://github.com/athei/wine-build) bundle step),

--- a/unix/conformance/Cargo.toml
+++ b/unix/conformance/Cargo.toml
@@ -7,5 +7,8 @@ license.workspace = true
 description.workspace = true
 authors.workspace = true
 
+[dependencies]
+libc = { workspace = true }
+
 [lints]
 workspace = true

--- a/unix/conformance/src/isolate.rs
+++ b/unix/conformance/src/isolate.rs
@@ -9,7 +9,9 @@
 //! fired in every run at the same count is deterministic; one that fired in only
 //! some runs, or at a varying count, is flaky. The output is the evidence for
 //! tagging a site `flaky` in `CONFORMANCE.md` (see [`crate::triage`]). This is
-//! measurement, not a gate — it never sets a non-zero exit code.
+//! measurement, not a gate — it never sets a non-zero exit code, with one
+//! exception: a GPU hang ends the measurement, since every run after it would
+//! read off a GPU that runs nothing, and the caller exits for it.
 
 use std::{collections::BTreeMap, fmt::Write as _, path::Path};
 
@@ -55,6 +57,10 @@ struct Aggregate {
     runs: u32,
     /// Runs that crashed/aborted/timed out (the per-subtest crash bit).
     crash_runs: u32,
+    /// The run the GPU hung under, which ended the measurement.
+    ///
+    /// Counted in `crash_runs` too; the runs after it never happened.
+    hung_run: Option<u32>,
     /// Failing (gating) sites and their flap stats.
     sites: BTreeMap<Site, SiteFlap>,
     /// Total occurrences of Wine's own `flaky`-macro-marked failures (non-gating) across all runs.
@@ -64,6 +70,8 @@ struct Aggregate {
 }
 
 /// Run every selected subtest of one test binary `repeat` times and print a flap report.
+///
+/// Returns the subtest a GPU hang stopped the measurement under, if one did.
 ///
 /// # Errors
 ///
@@ -75,7 +83,7 @@ pub fn run_flap(
     leg: Leg,
     subtests: &[Subtest],
     repeat: u32,
-) -> Result<(), String> {
+) -> Result<Option<Subtest>, String> {
     println!(
         "flap characterization: {repeat} run(s) per combo (counts shown as value×runs; \
          a site is FLAPS unless it fired in every run at one constant count)\n"
@@ -83,11 +91,16 @@ pub fn run_flap(
     for &subtest in subtests {
         let agg = characterize(wine, exe, leg, subtest, repeat)?;
         print!("{}", render(leg, subtest, &agg));
+        if agg.hung_run.is_some() {
+            return Ok(Some(subtest));
+        }
     }
-    Ok(())
+    Ok(None)
 }
 
 /// Run one subtest `repeat` times, folding each run into an [`Aggregate`].
+///
+/// Stops at the run the GPU hangs under.
 fn characterize(
     wine: &Path,
     exe: &Path,
@@ -99,10 +112,15 @@ fn characterize(
     for i in 1..=repeat {
         // Liveness to stderr — a full subtest can take many seconds.
         eprintln!("  [{leg}/{subtest}] run {i}/{repeat}…");
-        let result = run::run_subtest(wine, exe, leg, subtest)?.result;
+        let run = run::run_subtest(wine, exe, leg, subtest)?;
+        let result = run.result;
         agg.runs += 1;
         if result.crash {
             agg.crash_runs += 1;
+        }
+        if run.gpu_hang {
+            agg.hung_run = Some(i);
+            break;
         }
         for (site, &count) in &result.sites {
             let flap = agg.sites.entry(site.clone()).or_default();
@@ -129,6 +147,12 @@ fn render(leg: Leg, subtest: Subtest, agg: &Aggregate) -> String {
         "{leg}/{subtest}  N={runs}  crash {}/{runs}",
         agg.crash_runs
     );
+    if let Some(run) = agg.hung_run {
+        let _ = writeln!(
+            out,
+            "  GPU hang in run {run}; the measurement ends here and the runs after it never ran"
+        );
+    }
 
     let mut stable: Vec<&Site> = Vec::new();
     for (site, flap) in &agg.sites {

--- a/unix/conformance/src/main.rs
+++ b/unix/conformance/src/main.rs
@@ -13,6 +13,11 @@
 //! fail by design given our documented stub/limitation list. It is a
 //! tracked-score tool that exits non-zero only on a *regression* vs the
 //! baseline.
+//!
+//! Exit codes: 0 for a leg that holds its baseline, 1 for a regression, a
+//! stale baseline or a Metal-validation error, 2 for a usage or spawn error,
+//! and [`run::GPU_HANG_EXIT`] for a leg cut short by a GPU hang, which has no
+//! verdict at all.
 
 mod classify;
 mod cli;
@@ -61,14 +66,17 @@ fn real_main() -> Result<ExitCode, String> {
     // `--repeat N>1` is characterization, not a gate: run each selected subtest N
     // times and print a flap report, then exit 0 regardless of what fluttered.
     if config.repeat > 1 {
-        isolate::run_flap(&config.wine, &config.exe, leg, &subtests, config.repeat)?;
-        return Ok(ExitCode::SUCCESS);
+        let hung = isolate::run_flap(&config.wine, &config.exe, leg, &subtests, config.repeat)?;
+        return Ok(hung.map_or(ExitCode::SUCCESS, |subtest| gpu_hang_verdict(leg, subtest)));
     }
 
     let mut current: BTreeMap<(Leg, Subtest), SubtestResult> = BTreeMap::new();
     let mut validation_errors = 0;
     for &subtest in &subtests {
         let run = run::run_subtest(&config.wine, &config.exe, leg, subtest)?;
+        if run.gpu_hang {
+            return Ok(gpu_hang_verdict(leg, subtest));
+        }
         validation_errors += run.validation_errors;
         current.insert((leg, subtest), run.result);
     }
@@ -131,6 +139,17 @@ fn real_main() -> Result<ExitCode, String> {
     let report = diff::diff(&baseline, &classes, &current);
     print!("{}", report.text);
     Ok(verdict(&report, validation_errors))
+}
+
+/// The exit for a leg a GPU hang cut short: no diff, no baseline write.
+///
+/// A `--update-baseline` run must never record what a hung GPU read, and a
+/// diff of a truncated leg would report every later site as gone. The leg
+/// has to run again on a GPU that works; on a hosted runner that is a fresh
+/// machine, since the hang outlives the process there.
+fn gpu_hang_verdict(leg: Leg, subtest: Subtest) -> ExitCode {
+    println!("conformance: GPU HANG in {leg}/{subtest}; the leg was cut short and has no verdict");
+    ExitCode::from(run::GPU_HANG_EXIT)
 }
 
 /// Turn a run's diff report and its Metal-validation error count into an exit code.

--- a/unix/conformance/src/run.rs
+++ b/unix/conformance/src/run.rs
@@ -7,11 +7,16 @@
 
 use std::{
     collections::BTreeSet,
+    fmt::Write as _,
     fs,
-    io::Read,
-    os::unix::process::ExitStatusExt,
+    io::{BufRead, BufReader, Read},
+    os::unix::process::{CommandExt, ExitStatusExt},
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::{Child, Command, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     thread,
     time::{Duration, Instant},
 };
@@ -30,6 +35,25 @@ use crate::{
 /// finish in seconds.
 const DEFAULT_TIMEOUT_SECS: u64 = 180;
 const HEADLESS_DLL_OVERRIDES: &str = "mscoree,mshtml=";
+
+/// The driver's codes for a hung GPU, as Metal prints them to stderr.
+///
+/// The first names the command buffer that hung the GPU, the second every
+/// one the driver ignores afterwards for the process's earlier errors. Both
+/// mean the same for the counts: every read after the line comes off a GPU
+/// that runs nothing, so the subtest is stopped the moment either arrives
+/// and the leg ends there (see [`GPU_HANG_EXIT`]).
+const GPU_HANG_MARKERS: [&str; 2] = [
+    "kIOAccelCommandBufferCallbackErrorHang",
+    "kIOAccelCommandBufferCallbackErrorSubmissionsIgnored",
+];
+
+/// The runner's exit code for a leg a GPU hang cut short.
+///
+/// Distinct from a regression (1) and a usage or spawn error (2): the leg
+/// has no verdict. On a hosted runner the GPU stays hung for the rest of the
+/// machine's life, so the answer is a fresh machine, not another attempt.
+pub const GPU_HANG_EXIT: u8 = 3;
 
 /// How many Metal API-validation error messages a leg may log and still pass.
 ///
@@ -56,6 +80,12 @@ pub struct SubtestRun {
     pub result: SubtestResult,
     /// Distinct Metal API-validation error messages the subtest logged.
     pub validation_errors: usize,
+    /// The GPU hung under the subtest, which was stopped on the driver's line.
+    ///
+    /// Every later subtest would run on a GPU that ignores its command
+    /// buffers, so the leg's counts past this point mean nothing: the caller
+    /// stops the leg and exits with [`GPU_HANG_EXIT`].
+    pub gpu_hang: bool,
 }
 
 /// Whether the Metal-validation error messages a run logged fail its leg.
@@ -97,6 +127,17 @@ pub fn wine_version(wine: &Path) -> String {
 /// variant adds the config entries the run is measured under, and the whole
 /// leg is the label the results, raw logs and validation lines are recorded
 /// under.
+///
+/// stderr is read as it arrives, and the driver's GPU-hang line kills the
+/// process at once rather than after its budget: what the subtest reads from
+/// then on is zeros off a GPU that runs nothing, and the wait would only make
+/// the same verdict cost minutes.
+///
+/// The child runs in a process group of its own, and a kill, for the hang or
+/// for the budget, takes the whole group: the pipes end with the last process
+/// holding them, so a descendant cannot park the run past the kill. The
+/// wineserver the caller booted for the whole run is in the caller's group
+/// and is never touched.
 ///
 /// # Errors
 ///
@@ -162,23 +203,24 @@ pub fn run_subtest(
         )
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .process_group(0)
         .spawn()
         .map_err(|e| format!("failed to spawn {}: {e}", wine.display()))?;
 
     // Drain stdout/stderr on their own threads so a full pipe buffer can't
     // wedge the child while we poll for the timeout.
     let mut child_stdout = child.stdout.take().expect("stdout piped");
-    let mut child_stderr = child.stderr.take().expect("stderr piped");
+    let child_stderr = child.stderr.take().expect("stderr piped");
     let out_reader = thread::spawn(move || {
         let mut buf = Vec::new();
         let _ = child_stdout.read_to_end(&mut buf);
         buf
     });
-    let err_reader = thread::spawn(move || {
-        let mut buf = Vec::new();
-        let _ = child_stderr.read_to_end(&mut buf);
-        buf
-    });
+    let hung = Arc::new(AtomicBool::new(false));
+    let err_reader = {
+        let hung = Arc::clone(&hung);
+        thread::spawn(move || drain_stderr(child_stderr, &hung))
+    };
 
     let timeout = subtest_timeout();
     let start = Instant::now();
@@ -190,8 +232,14 @@ pub fn run_subtest(
         {
             break status;
         }
+        if hung.load(Ordering::Relaxed) {
+            kill_group(&child);
+            break child
+                .wait()
+                .map_err(|e| format!("reap of hung {} failed: {e}", wine.display()))?;
+        }
         if start.elapsed() >= timeout {
-            let _ = child.kill();
+            kill_group(&child);
             timed_out = true;
             break child
                 .wait()
@@ -201,6 +249,9 @@ pub fn run_subtest(
     };
     let stdout = out_reader.join().unwrap_or_default();
     let stderr = err_reader.join().unwrap_or_default();
+    // Read after the join, so a line the process printed just before ending
+    // on its own counts too: its later reads were zeros all the same.
+    let gpu_hang = hung.load(Ordering::Relaxed);
 
     // Surface Metal API-validation failures (the layer runs in `nslog` mode, so
     // these are logged rather than aborting). Deduplicated, address/number
@@ -211,15 +262,27 @@ pub fn run_subtest(
 
     // A timeout is a hang — treat it like a fatal signal so it surfaces as a
     // crash (and a regression vs a clean baseline) rather than a silent count.
-    let signaled = timed_out || status.signal().is_some();
+    // A GPU hang is one too: the counts stop meaning anything at its line.
+    let signaled = timed_out || gpu_hang || status.signal().is_some();
     let mut combined = String::from_utf8_lossy(&stdout).into_owned();
     combined.push_str(&String::from_utf8_lossy(&stderr));
     if timed_out {
-        use std::fmt::Write as _;
         let _ = write!(
             combined,
             "\n[conformance] subtest TIMED OUT after {}s and was killed\n",
             timeout.as_secs()
+        );
+    }
+    if gpu_hang {
+        let after = start.elapsed().as_secs();
+        eprintln!(
+            "  [{leg}/{subtest}] GPU hang: the driver reported it after {after}s; the subtest \
+             was stopped and the leg ends here"
+        );
+        let _ = write!(
+            combined,
+            "\n[conformance] GPU HANG reported by the driver after {after}s; the subtest was \
+             stopped and the leg ends here\n"
         );
     }
 
@@ -234,7 +297,49 @@ pub fn run_subtest(
     Ok(SubtestRun {
         result: scan::parse_subtest_output(&combined, signaled),
         validation_errors,
+        gpu_hang,
     })
+}
+
+/// Drain stderr into a buffer, raising `hung` on the driver's GPU-hang line.
+///
+/// Line by line, so the line is seen while the process still runs and the
+/// poll loop can kill it on the flag instead of waiting out the budget. The
+/// buffer keeps every byte, invalid UTF-8 included: the check reads a lossy
+/// copy of each line and the drain never stops on one.
+fn drain_stderr(stderr: impl Read, hung: &AtomicBool) -> Vec<u8> {
+    let mut reader = BufReader::new(stderr);
+    let mut buf = Vec::new();
+    let mut line = Vec::new();
+    while let Ok(1..) = reader.read_until(b'\n', &mut line) {
+        if is_gpu_hang_line(&String::from_utf8_lossy(&line)) {
+            hung.store(true, Ordering::Relaxed);
+        }
+        buf.append(&mut line);
+    }
+    buf
+}
+
+/// Whether a stderr line is the driver reporting a hung GPU.
+fn is_gpu_hang_line(line: &str) -> bool {
+    GPU_HANG_MARKERS.iter().any(|marker| line.contains(marker))
+}
+
+/// SIGKILL the child's process group: the child and everything it forked.
+///
+/// The child is its own group leader (`process_group(0)` at spawn), so the
+/// group id is its pid. A group that is already gone is not an error. The
+/// e2e runner keeps the same function for the same reason; the two runners
+/// are separate binaries with no crate between them for a process helper.
+fn kill_group(child: &Child) {
+    let Ok(pid) = i32::try_from(child.id()) else {
+        return;
+    };
+    // SAFETY: kill(2) with a negative pid signals the group; it touches no
+    // memory of ours and a stale id is reported as ESRCH, not acted on.
+    unsafe {
+        let _ = libc::kill(-pid, libc::SIGKILL);
+    }
 }
 
 /// Persist a subtest's raw output to `$MTLD3D_CONFORMANCE_RAW_DIR/<leg>-<subtest>.log`.

--- a/unix/conformance/src/run/tests.rs
+++ b/unix/conformance/src/run/tests.rs
@@ -1,12 +1,25 @@
-//! Unit tests for the Metal-validation reporting and its gate.
+//! Unit tests for the Metal-validation gate and the GPU-hang stop.
 //!
 //! The recogniser picks the layer's error messages out of a subtest's stderr,
 //! keeps the detail lines under each one, collapses volatile numbers so a
 //! repeated message reports once, and leaves ordinary Wine and Metal chatter
 //! alone. The gate then fails a leg for any message that survives: after the
 //! warning filter there is no benign one left.
+//!
+//! The hang tests let `/bin/sh` play Wine and a script play the test binary:
+//! the driver's line has to stop the subtest within seconds, not at its
+//! budget, and has to mark the run so its counts never reach a baseline.
 
-use super::{normalize_numbers, validation_errors, validation_gate_failed};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+use super::{
+    is_gpu_hang_line, normalize_numbers, run_subtest, validation_errors, validation_gate_failed,
+};
+use crate::model::{Arch, Gpu, Leg, Subtest, Variant};
 
 /// The two draw errors the mismatched-sampler-type case logged, verbatim.
 const MISMATCHED_SAMPLER: &str = "\
@@ -81,5 +94,85 @@ fn numbers_and_addresses_collapse() {
     assert_eq!(
         normalize_numbers("texture at index 3 (0xdeadbeef) must be <= 16"),
         "texture at index N (0xN) must be <= N"
+    );
+}
+
+/// The two lines the paravirtual GPU's driver printed on the Intel CI image, verbatim.
+const DRIVER_HANG: &str = "2026-09-05 05:23:06.572 wine[86111:201735] Execution of the command \
+    buffer was aborted due to an error during execution. Caused GPU Hang Error \
+    (00000003:kIOAccelCommandBufferCallbackErrorHang)";
+const DRIVER_IGNORED: &str = "2026-09-05 05:23:06.667 wine[86111:201735] Execution of the \
+    command buffer was aborted due to an error during execution. Ignored (for causing \
+    prior/excessive GPU errors) (00000004:kIOAccelCommandBufferCallbackErrorSubmissionsIgnored)";
+
+#[test]
+fn the_drivers_hang_lines_are_recognised_and_nothing_else_is() {
+    assert!(is_gpu_hang_line(DRIVER_HANG));
+    assert!(is_gpu_hang_line(DRIVER_IGNORED));
+    for line in [
+        "2026-08-28 11:59:28.959 wine[27403:71131] Metal API Validation Enabled",
+        "visual.c:9100: Test failed: Got unexpected colour 0x00000000.",
+        "0000:err:d3d9: GPU hang is not what this line reports",
+    ] {
+        assert!(!is_gpu_hang_line(line), "{line}");
+    }
+}
+
+/// A script in a fresh directory under the temp dir, run as `sh <script> <subtest>`.
+///
+/// `/bin/sh` plays Wine and the script plays `d3d9_test.exe`; `run_subtest`
+/// only asks that the exe be a file. A script that has to outlive its lines
+/// sleeps in a child of its own, which holds the pipes past the shell: the
+/// kill has to take the group, or the run would wait for that child.
+fn script(name: &str, body: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "mtld3d-conformance-run-{}-{name}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join("d3d9_test.sh");
+    fs::write(&path, body).expect("script");
+    path
+}
+
+const LEG: Leg = Leg {
+    arch: Arch::I686,
+    variant: Variant::Native,
+    gpu: Gpu::Apple,
+};
+
+/// The bound the spawn tests hold the runner to: well under any subtest budget.
+const PROMPT: Duration = Duration::from_secs(5);
+
+#[test]
+fn a_subtest_that_hangs_the_gpu_is_stopped_at_once() {
+    let exe = script(
+        "hang",
+        &format!("echo 'visual.c:100: Test failed: x'\necho '{DRIVER_HANG}' >&2\nsleep 30\n"),
+    );
+    let started = Instant::now();
+    let run = run_subtest(Path::new("/bin/sh"), &exe, LEG, Subtest::Visual).expect("spawn sh");
+    let elapsed = started.elapsed();
+    assert!(run.gpu_hang);
+    assert!(run.result.crash, "a leg cut short is not a clean count");
+    assert!(
+        elapsed < PROMPT,
+        "took {elapsed:?}: the runner waited instead of killing"
+    );
+}
+
+#[test]
+fn a_hang_line_before_a_clean_exit_still_counts() {
+    let exe = script(
+        "hang-exit",
+        &format!(
+            "echo '{DRIVER_IGNORED}' >&2\necho 'visual: 10 tests executed (0 marked as todo, 0 failures), 0 skipped.'\nexit 0\n"
+        ),
+    );
+    let run = run_subtest(Path::new("/bin/sh"), &exe, LEG, Subtest::Visual).expect("spawn sh");
+    assert!(run.gpu_hang);
+    assert!(
+        run.result.crash,
+        "a process that survived its hang still read zeros; its counts must not reach the baseline"
     );
 }


### PR DESCRIPTION
Fixes #398.

## Symptoms

The `conformance (macos-15-intel, x86_64)` job sat 20 to 30 minutes and then failed while its siblings finished in under 4 minutes. In the PR #377 first attempt (artifact 9963988383) Metal printed `Caused GPU Hang Error (00000003:kIOAccelCommandBufferCallbackErrorHang)` to the test process's stderr 40 s into `visual`, the subtest read zeros until the runner killed it at the 600 s budget, the next subtest's fresh process (`stateblock`) logged the same line, and the workflow's in-job retry hung again in `visual` and `stateblock` on the same runner. 31 minutes for a job whose re-run on a fresh machine took 4. The runner could not see the line early: stderr was drained with `read_to_end` and read after the process was gone.

## Changes

- The runner reads stderr line by line. On `kIOAccelCommandBufferCallbackErrorHang`, or the `kIOAccelCommandBufferCallbackErrorSubmissionsIgnored` line the driver prints for every command buffer it drops afterwards, it kills the subtest at once, marks the run (crash bit set, trailer in the raw log) and ends the leg with exit code 3 and no verdict, so nothing read off the wedged GPU reaches a diff or a `--update-baseline` write. A line seen just before the process ended on its own counts the same way. Repeat mode stops at the hung run and names it in the flap report.
- The child runs in a process group of its own and the kill, for the hang or for the budget, takes the group, as the e2e runner does since #396. The plain `child.kill()` waited for any descendant holding the pipes (measured: 60 s on a 15 s budget with a `sleep` child). The wineserver the Makefile boots is in the caller's group and untouched. `libc` from the workspace joins the crate's dependencies for `kill(2)`; the ten-line `kill_group` is a copy of the e2e runner's, since the two are separate binaries and the shared crate is the wire contract.
- The workflow drops the in-job retry (the GPU does not recover on that machine; the `TIMED OUT` branch never had an observed instance, the one "never returned" case being #382, a death). When the raw logs carry the marker the job annotates itself with `gh run rerun <run-id> --failed`. The artifact path goes back to the single raw dir.
- CONFORMANCE.md documents the stop and the exit code; the runner's module doc lists all exit codes.

Not in scope: #382 (the `device` subtest dying in `test_wndproc`, no hang line), handled separately.

## Alternatives

- Keep the in-job retry and skip it only on the driver line: the retry then covers a silent budget hit only, which has not been observed, and it would still cost a full budget per hung subtest. Dropped instead.
- A shorter per-subtest budget on the Intel legs: it bounds the wait but still costs minutes per hang and does not stop the leg. The 600 s budget stays as the bound for a silent hang.
- Matching Metal's generic "Execution of the command buffer was aborted" text: that also catches a page fault or other GPU error, which can be a real regression whose later counts are worth seeing. Only the two hang codes stop the leg.

## Verification

- `make check` (fmt, clippy nursery + pedantic, audit, doc) and `make test-unit` (1041 + 243 tests) green.
- New tests in `unix/conformance/src/run/tests.rs`: the recogniser on both verbatim driver lines and three lines that must not match; `/bin/sh` as Wine with a script that prints the hang line and sleeps in a child that holds the pipes, stopped in 70 ms with `gpu_hang` and `crash` set; a hang line before a clean exit still marks the run.
- Real binaries, before and after: the pre-change runner sat out its whole 15 s budget on the hang line and, with a `sleep` child holding the pipes, waited the child's full 60 s; the new runner returns in 0.06 s with exit 3 on the hang path and at exactly the budget on the timeout path, with no descendant left behind.
- The workflow step's shell was exercised by hand with a raw log carrying the marker, one without, and no logs: exit 1 all three times, the `::error` only with the marker.
- Rules check: no config key, no env var, no wire field, no derive, no `#[allow]`; one `bool` on `SubtestRun` (its only one); one new dependency, `libc`, already a workspace dependency of the e2e runner and the unix crate; `kill_group` duplicated from the e2e runner by intent, stated in its doc comment. The hang path itself cannot be forced on a hosted runner; if the Intel x86_64 leg hangs on this PR's run, the job should end within seconds of the driver line and carry the annotation.
