### PR TITLE
Record how a conformance subtest ended, and name a fault outside our image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,19 @@ on:
           log files uploaded.
         type: string
         default: ''
+      conformance_repeat:
+        description: >-
+          Run one conformance subtest this many times on every conformance
+          job instead of gating, with every run's raw output and the layer's
+          debug log uploaded (the way to catch a subtest that dies one run
+          in a few).
+        type: string
+        default: ''
+      conformance_only:
+        description: The subtest a `conformance_repeat` dispatch runs.
+        type: choice
+        options: [device, visual, stateblock, d3d9ex]
+        default: device
 
 permissions:
   contents: read
@@ -262,7 +275,15 @@ jobs:
       # regression never looks like that, and the machine will not recover,
       # so the answer is a re-run of the failed jobs, which lands on a fresh
       # runner, not another attempt here.
+      # A `conformance_repeat` dispatch runs one subtest that many times in
+      # place of the gate, on every job, and leaves the reading to the
+      # artifact: each run's raw output ends with how the process ended, and
+      # the layer's debug log sits beside it.
       - run: |
+          if [ -n "$CONFORMANCE_REPEAT" ]; then
+            make conformance-isolate ONLY="$CONFORMANCE_ONLY" ARCH=${{ matrix.arch }} REPEAT="$CONFORMANCE_REPEAT" VARIANT=${{ matrix.runner == 'macos-15-intel' && 'intel' || 'native' }} LOG=debug STAGE="$STAGE"
+            exit
+          fi
           if ! make conformance-${{ matrix.runner == 'macos-15-intel' && (inputs.record_intel_baseline && 'baseline-intel-' || 'intel-') || '' }}${{ matrix.arch }} STAGE="$STAGE"; then
             if grep -lq kIOAccelCommandBufferCallbackErrorHang "$MTLD3D_CONFORMANCE_RAW_DIR"/*.log 2>/dev/null; then
               echo "::error::this runner's GPU hung and stays hung for the rest of the job, so the leg was cut short; not a regression when the other conformance jobs are green. Re-run the failed jobs to get a fresh machine: gh run rerun ${{ github.run_id }} --failed"
@@ -276,6 +297,8 @@ jobs:
           # job's own log reduces to per-site counts, and counts alone cannot
           # say why this environment diverges.
           MTLD3D_CONFORMANCE_RAW_DIR: ${{ runner.temp }}/conformance-raw
+          CONFORMANCE_REPEAT: ${{ inputs.conformance_repeat }}
+          CONFORMANCE_ONLY: ${{ inputs.conformance_only }}
 
       # `always()`, because a diverging run is exactly the one whose output is
       # worth reading, and the job reports failure whenever it diverges.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,7 @@ instead of quietly simplifying.
 make conformance                       # both architectures, diffed against the baseline
 make conformance-i686                  # one architecture, one runner process
 make conformance-isolate ONLY=visual ARCH=x86_64 REPEAT=1
+make conformance-isolate ONLY=device ARCH=i686 REPEAT=20 VARIANT=intel LOG=debug
 make conformance-baseline-i686         # re-record this architecture's entries
 ```
 
@@ -241,7 +242,11 @@ asks `render_scale_is_identity()` and pins its exact shape at the identity
 rather than failing that leg. Every image gates. The Intel image reads the conformance baseline's `@mac2` entries,
 which only it can record: dispatch the workflow with `record_intel_baseline`
 and commit the `@mac2` sections from the `baseline-mac2-<arch>` artifacts
-(`unix/conformance/CONFORMANCE.md` has the procedure). Run `make conformance`
+(`unix/conformance/CONFORMANCE.md` has the procedure). A conformance subtest
+that dies on one image now and then is caught by dispatching with
+`conformance_repeat=<n>`, which runs it that many times on every image and
+uploads each run's raw output, ending in how the process ended, with the
+layer's debug log beside it. Run `make conformance`
 locally when your change touches the render or shader-emission path. The
 manual
 `probe-metal` job is how an image is checked before it is added, and it runs

--- a/Makefile
+++ b/Makefile
@@ -664,10 +664,15 @@ CONFORMANCE_RUN = $(CONFORMANCE_BIN) --wine $(WINE_SDK)/bin/wine --assets $(CURD
 # $(1) = arch (i686|x86_64), $(2) = extra runner args. Checks the exe up front
 # so a bundle that predates the published test binaries says so, rather than
 # failing four times inside the runner.
+# LOG=<filter> is the RUST_LOG the test processes run under (the runner's
+# default is `off`: the counts are the measurement). With
+# MTLD3D_CONFORMANCE_RAW_DIR set, each process's log file lands in a directory
+# beside its raw output, so LOG=debug there keeps what the layer did before a
+# process ended without its summary.
 define conformance_leg
 	$(MAKE) configure-test-prefix
 	test -f $(D3D9_TEST_$(1)) || { echo "$(D3D9_TEST_$(1)) is missing: re-bundle the Wine SDK, this one predates the published d3d9 test binaries" >&2; exit 2; }
-	$(CONFORMANCE_RUN) --arch $(1) --exe $(D3D9_TEST_$(1)) $(2)
+	$(CONFORMANCE_RUN) --arch $(1) --exe $(D3D9_TEST_$(1)) $(2) $(if $(LOG),--log $(LOG))
 endef
 
 conformance: conformance-i686 conformance-x86_64
@@ -710,13 +715,18 @@ conformance-baseline-intel-x86_64: install-windows-x86_64 install-unix-$(SDK_UNI
 
 # Flap characterization: run ONE subtest REPEAT times and print a per-site flap
 # report (which sites fire deterministically vs flutter run-to-run), the
-# evidence for tagging a site `flaky` in CONFORMANCE.md. Tune with ONLY (device|
-# visual|stateblock|d3d9ex), ARCH (i686|x86_64), REPEAT (default 20).
+# evidence for tagging a site `flaky` in CONFORMANCE.md, and the way to make a
+# subtest that dies one run in a few die in one sitting. Tune with ONLY (device|
+# visual|stateblock|d3d9ex), ARCH (i686|x86_64), REPEAT (default 20), VARIANT
+# (native|intel, the `intel` legs' forced answers) and LOG (see above). With
+# MTLD3D_CONFORMANCE_RAW_DIR set, every run keeps its own raw output,
+# `<leg>-<subtest>-<n>.log`, and its process's log file beside it.
 ONLY ?= device
 ARCH ?= i686
 REPEAT ?= 20
+VARIANT ?= native
 conformance-isolate: install-windows-$(ARCH) install-unix-$(SDK_UNIX_ARCH)
-	$(call conformance_leg,$(ARCH),--only $(ONLY) --repeat $(REPEAT))
+	$(call conformance_leg,$(ARCH),--only $(ONLY) --repeat $(REPEAT) --variant $(VARIANT))
 
 fmt:
 	cd windows && cargo +$(RUST_NIGHTLY) fmt

--- a/unix/conformance/CONFORMANCE.md
+++ b/unix/conformance/CONFORMANCE.md
@@ -62,6 +62,30 @@ and the job names the re-run of the failed jobs, which lands on a fresh runner.
 A hang on a real GPU is worth a look on its own (a shader that hangs the GPU is
 a bug), but the leg has to run again for its counts either way.
 
+A raw log is stdout followed by stderr, and ends with how the process ended:
+`[conformance] subtest exited: code N` or `signal N` (a number, never a name,
+so a fault the process survived cannot read as a crash to the scanner), or the
+`TIMED OUT` line when the runner killed it. A run without the framework's
+`tests executed` summary is a crash whatever else it holds, and this line is
+what tells an unhandled Win32 exception (Wine ends the process with the
+exception code, of which unix keeps the low byte: `code 5` is an access
+violation) from a signal (11 `SIGSEGV`, 10 `SIGBUS`, 6 `SIGABRT`, 9 `SIGKILL`).
+A run that reached its summary reads `code 0` once a device existed (the layer
+ends the process from its detach, see CONTRIBUTING.md), else the framework's
+failure count capped at 255.
+Each process is also told `log.dir=Z:<dir>/<leg>-<subtest>`, so its log file
+(`d3d9_test-<pid>.log`, and any GPU trace) lands in a directory beside its raw
+output, one per process. The runner's `--log <filter>` (`LOG=` for the Makefile
+targets) is the `RUST_LOG` those processes run under; the default `off` writes
+nothing, and the crash handlers' lines then go to stderr, i.e. into the raw log.
+
+A repeat run (`make conformance-isolate REPEAT=<n>`) keeps every run,
+`<leg>-<subtest>-<n>.log`, with its own log directory. Dispatching the workflow
+with `conformance_repeat=<n>` runs it on every conformance job, under
+`LOG=debug`, and uploads the lot as `conformance-raw-<image>-<arch>`: the way to
+make a subtest that dies one run in a few die in one sitting, on the machine
+where it does.
+
 There is no conformance-specific input to set. The test binaries ship inside the
 Wine SDK bundle (`$WINE_SDK/lib/wine/tests/{i386,x86_64}-windows/d3d9_test.exe`,
 published by the [wine-build](https://github.com/athei/wine-build) bundle step),

--- a/unix/conformance/src/cli.rs
+++ b/unix/conformance/src/cli.rs
@@ -32,13 +32,19 @@ pub struct Config {
     /// Prints a flap report instead of diffing. `1` (the default) keeps the
     /// normal gate.
     pub repeat: u32,
+    /// `--log <filter>`: the `RUST_LOG` the test processes run under.
+    ///
+    /// `off` (the default) for a gating run, whose measurement is the counts.
+    /// A repeat run raises it so the process's log file says what the layer
+    /// did before a process ended without its summary.
+    pub log: String,
 }
 
 /// Parse CLI args (excluding `argv[0]`).
 ///
 /// Recognised flags: `--update-baseline`, `--wine <path>`, `--exe <path>`,
 /// `--arch <arch>`, `--variant <native|intel>`, `--assets <dir>`,
-/// `--only <subtest>`, `--repeat <N>`.
+/// `--only <subtest>`, `--repeat <N>`, `--log <filter>`.
 /// `--wine`, `--exe` and `--arch` are mandatory: the runner resolves no paths of
 /// its own, so the caller (the Makefile) owns every Wine location. One
 /// invocation runs one test binary, which is what lets a 32-bit and a 64-bit CI
@@ -61,6 +67,7 @@ pub fn parse_args(mut args: impl Iterator<Item = String>) -> Result<Config, Stri
     let mut assets: Option<PathBuf> = None;
     let mut only: Option<Subtest> = None;
     let mut repeat: u32 = 1;
+    let mut log = "off".to_owned();
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--update-baseline" => update = true,
@@ -109,6 +116,11 @@ pub fn parse_args(mut args: impl Iterator<Item = String>) -> Result<Config, Stri
                     return Err("--repeat must be >= 1".to_owned());
                 }
             }
+            "--log" => {
+                log = args
+                    .next()
+                    .ok_or_else(|| "--log needs a RUST_LOG filter".to_owned())?;
+            }
             other => return Err(format!("unknown argument {other:?}")),
         }
     }
@@ -129,6 +141,7 @@ pub fn parse_args(mut args: impl Iterator<Item = String>) -> Result<Config, Stri
         assets,
         only,
         repeat,
+        log,
     })
 }
 

--- a/unix/conformance/src/cli/tests.rs
+++ b/unix/conformance/src/cli/tests.rs
@@ -48,6 +48,16 @@ fn variant_defaults_to_native_and_parses_intel() {
 }
 
 #[test]
+fn log_defaults_to_off_and_takes_a_filter() {
+    let config = parse_args(base(&[])).unwrap();
+    assert_eq!(config.log, "off");
+    let config = parse_args(base(&["--log", "mtld3d=debug"])).unwrap();
+    assert_eq!(config.log, "mtld3d=debug");
+    let err = parse_args(base(&["--log"])).unwrap_err();
+    assert!(err.contains("--log"), "{err}");
+}
+
+#[test]
 fn assets_is_none_when_absent() {
     let config = parse_args(base(&[])).unwrap();
     assert!(config.assets.is_none());

--- a/unix/conformance/src/isolate.rs
+++ b/unix/conformance/src/isolate.rs
@@ -13,11 +13,11 @@
 //! exception: a GPU hang ends the measurement, since every run after it would
 //! read off a GPU that runs nothing, and the caller exits for it.
 
-use std::{collections::BTreeMap, fmt::Write as _, path::Path};
+use std::{collections::BTreeMap, fmt::Write as _};
 
 use crate::{
     model::{Leg, Site, Subtest},
-    run,
+    run::{self, Launch},
 };
 
 /// Per-site flap statistics over N runs of one `(arch, subtest)`.
@@ -78,8 +78,7 @@ struct Aggregate {
 /// Propagates a spawn/wait error from [`run::run_subtest`] (a missing
 /// `d3d9_test.exe`, or `wine` failing to launch).
 pub fn run_flap(
-    wine: &Path,
-    exe: &Path,
+    launch: &Launch,
     leg: Leg,
     subtests: &[Subtest],
     repeat: u32,
@@ -89,7 +88,7 @@ pub fn run_flap(
          a site is FLAPS unless it fired in every run at one constant count)\n"
     );
     for &subtest in subtests {
-        let agg = characterize(wine, exe, leg, subtest, repeat)?;
+        let agg = characterize(launch, leg, subtest, repeat)?;
         print!("{}", render(leg, subtest, &agg));
         if agg.hung_run.is_some() {
             return Ok(Some(subtest));
@@ -100,10 +99,10 @@ pub fn run_flap(
 
 /// Run one subtest `repeat` times, folding each run into an [`Aggregate`].
 ///
-/// Stops at the run the GPU hangs under.
+/// Stops at the run the GPU hangs under. Each run is numbered, so a kept raw
+/// output is one file per run rather than the last run overwriting the others.
 fn characterize(
-    wine: &Path,
-    exe: &Path,
+    launch: &Launch,
     leg: Leg,
     subtest: Subtest,
     repeat: u32,
@@ -112,7 +111,7 @@ fn characterize(
     for i in 1..=repeat {
         // Liveness to stderr — a full subtest can take many seconds.
         eprintln!("  [{leg}/{subtest}] run {i}/{repeat}…");
-        let run = run::run_subtest(wine, exe, leg, subtest)?;
+        let run = run::run_subtest(launch, leg, subtest, Some(i))?;
         let result = run.result;
         agg.runs += 1;
         if result.crash {

--- a/unix/conformance/src/main.rs
+++ b/unix/conformance/src/main.rs
@@ -51,6 +51,22 @@ fn main() -> ExitCode {
 fn real_main() -> Result<ExitCode, String> {
     let config = cli::parse_args(std::env::args().skip(1))?;
     let wine_version = run::wine_version(&config.wine);
+    // The raw dir is read once, here, and handed to every spawn as a path:
+    // the test process is told the same directory as a Windows path, which
+    // needs it absolute, and the spawn itself reads no environment.
+    let raw_dir = match std::env::var_os("MTLD3D_CONFORMANCE_RAW_DIR") {
+        Some(dir) => Some(
+            std::path::absolute(&dir)
+                .map_err(|e| format!("MTLD3D_CONFORMANCE_RAW_DIR {}: {e}", dir.display()))?,
+        ),
+        None => None,
+    };
+    let launch = run::Launch {
+        wine: config.wine,
+        exe: config.exe,
+        log: config.log,
+        raw_dir,
+    };
     let leg = Leg {
         arch: config.arch,
         variant: config.variant,
@@ -66,14 +82,14 @@ fn real_main() -> Result<ExitCode, String> {
     // `--repeat N>1` is characterization, not a gate: run each selected subtest N
     // times and print a flap report, then exit 0 regardless of what fluttered.
     if config.repeat > 1 {
-        let hung = isolate::run_flap(&config.wine, &config.exe, leg, &subtests, config.repeat)?;
+        let hung = isolate::run_flap(&launch, leg, &subtests, config.repeat)?;
         return Ok(hung.map_or(ExitCode::SUCCESS, |subtest| gpu_hang_verdict(leg, subtest)));
     }
 
     let mut current: BTreeMap<(Leg, Subtest), SubtestResult> = BTreeMap::new();
     let mut validation_errors = 0;
     for &subtest in &subtests {
-        let run = run::run_subtest(&config.wine, &config.exe, leg, subtest)?;
+        let run = run::run_subtest(&launch, leg, subtest, None)?;
         if run.gpu_hang {
             return Ok(gpu_hang_verdict(leg, subtest));
         }

--- a/unix/conformance/src/run.rs
+++ b/unix/conformance/src/run.rs
@@ -12,7 +12,7 @@ use std::{
     io::{BufRead, BufReader, Read},
     os::unix::process::{CommandExt, ExitStatusExt},
     path::{Path, PathBuf},
-    process::{Child, Command, Stdio},
+    process::{Child, Command, ExitStatus, Stdio},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -63,6 +63,29 @@ pub const GPU_HANG_EXIT: u8 = 3;
 /// because `baseline.txt` is machine-owned per-site counts whose parser
 /// rejects anything else.
 const MAX_VALIDATION_ERRORS: usize = 0;
+
+/// What every spawn of the run shares.
+///
+/// Built once by the caller from the command line and the environment, so
+/// the spawn itself reads neither: a test can hand it a shell script as the
+/// loader and a scratch directory as the raw dir.
+pub struct Launch {
+    /// The Wine loader.
+    pub wine: PathBuf,
+    /// The `d3d9_test.exe` to run.
+    pub exe: PathBuf,
+    /// The `RUST_LOG` filter the test process runs under.
+    ///
+    /// `off` for a gating run: the counts are the measurement and our log is
+    /// noise there. A repeat run raises it to see what the layer did before
+    /// a process ended without its summary.
+    pub log: String,
+    /// Where each subtest's raw output and log file go, when they are kept.
+    ///
+    /// `None` keeps nothing. Set, it is made absolute, since the test process
+    /// is handed the same directory as a Windows path.
+    pub raw_dir: Option<PathBuf>,
+}
 
 /// How many detail lines one validation message keeps.
 ///
@@ -126,7 +149,8 @@ pub fn wine_version(wine: &Path) -> String {
 /// `leg` selects nothing about the binary (the caller already picked it); its
 /// variant adds the config entries the run is measured under, and the whole
 /// leg is the label the results, raw logs and validation lines are recorded
-/// under.
+/// under. `attempt` is the run's number in a repeat run, which keeps every
+/// run's raw output; `None` is the one run of a gating leg.
 ///
 /// stderr is read as it arrives, and the driver's GPU-hang line kills the
 /// process at once rather than after its budget: what the subtest reads from
@@ -143,18 +167,22 @@ pub fn wine_version(wine: &Path) -> String {
 ///
 /// Returns a message when `exe` is not a file or `wine` fails to spawn.
 pub fn run_subtest(
-    wine: &Path,
-    exe: &Path,
+    launch: &Launch,
     leg: Leg,
     subtest: Subtest,
+    attempt: Option<u32>,
 ) -> Result<SubtestRun, String> {
-    if !exe.is_file() {
+    if !launch.exe.is_file() {
         return Err(format!(
             "test exe not found: {}; a Wine SDK bundle carries these under \
              lib/wine/tests, so re-bundle if yours predates them",
-            exe.display()
+            launch.exe.display()
         ));
     }
+    let raw = launch
+        .raw_dir
+        .as_deref()
+        .map(|dir| RawTarget::new(dir, leg, subtest, attempt));
     // Metal API validation is left ON (`nslog` mode) so every conformance run
     // surfaces Metal misuse (format/attachment/binding mismatches, oversized
     // inline binds, …). `nslog` *logs* validation failures to stderr instead of
@@ -168,8 +196,8 @@ pub fn run_subtest(
     // shader that stops reading a slot), all deduplicated to a handful of
     // lines that read exactly like the error lines and bury them. Only errors
     // are reported, so a new validation line means a new misuse.
-    let mut child = Command::new(wine)
-        .arg(exe)
+    let mut child = Command::new(&launch.wine)
+        .arg(&launch.exe)
         .arg(subtest.arg())
         .env("MTL_DEBUG_LAYER", "1")
         .env("MTL_DEBUG_LAYER_ERROR_MODE", "nslog")
@@ -178,34 +206,13 @@ pub fn run_subtest(
         .env("WINEDEBUG", "-all")
         .env("WINEDLLOVERRIDES", HEADLESS_DLL_OVERRIDES)
         .env("WINEMSYNC", "1")
-        .env("RUST_LOG", "off")
-        // `shaderCache.enable=false`: disable the persistent on-disk shader
-        // cache (`mtld3d_shaders.bin`) for every conformance run so the DLL
-        // compiles shaders fresh each run — a change to the shader translator
-        // (or a SHADER_CACHE_SCHEMA bump) is always reflected without having to
-        // delete a stale cache by hand.
-        //
-        // `color.hdr.enable=false`: the shipped default is on, but it resolves
-        // off the running machine's panel, so an EDR Mac would present through
-        // the tone-mapping shader while another machine blits. The baseline has
-        // to mean the same thing on every machine that runs it, so pin the SDR
-        // path here.
-        //
-        // The leg's variant appends its own entries: the `intel` variant turns
-        // every `intel.*` key on so the whole suite runs under the answers an
-        // Intel/AMD Mac gives.
-        .env(
-            "MTLD3D_CONFIG",
-            format!(
-                "shaderCache.enable=false;color.hdr.enable=false{}",
-                leg.variant.config_entries()
-            ),
-        )
+        .env("RUST_LOG", &launch.log)
+        .env("MTLD3D_CONFIG", config_entries(leg, raw.as_ref()))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .process_group(0)
         .spawn()
-        .map_err(|e| format!("failed to spawn {}: {e}", wine.display()))?;
+        .map_err(|e| format!("failed to spawn {}: {e}", launch.wine.display()))?;
 
     // Drain stdout/stderr on their own threads so a full pipe buffer can't
     // wedge the child while we poll for the timeout.
@@ -228,7 +235,7 @@ pub fn run_subtest(
     let status = loop {
         if let Some(status) = child
             .try_wait()
-            .map_err(|e| format!("wait on {} failed: {e}", wine.display()))?
+            .map_err(|e| format!("wait on {} failed: {e}", launch.wine.display()))?
         {
             break status;
         }
@@ -236,14 +243,14 @@ pub fn run_subtest(
             kill_group(&child);
             break child
                 .wait()
-                .map_err(|e| format!("reap of hung {} failed: {e}", wine.display()))?;
+                .map_err(|e| format!("reap of hung {} failed: {e}", launch.wine.display()))?;
         }
         if start.elapsed() >= timeout {
             kill_group(&child);
             timed_out = true;
             break child
                 .wait()
-                .map_err(|e| format!("reap of timed-out {} failed: {e}", wine.display()))?;
+                .map_err(|e| format!("reap of timed-out {} failed: {e}", launch.wine.display()))?;
         }
         thread::sleep(Duration::from_millis(50));
     };
@@ -272,6 +279,8 @@ pub fn run_subtest(
             "\n[conformance] subtest TIMED OUT after {}s and was killed\n",
             timeout.as_secs()
         );
+    } else {
+        let _ = write!(combined, "\n{}\n", exit_trailer(status));
     }
     if gpu_hang {
         let after = start.elapsed().as_secs();
@@ -290,9 +299,11 @@ pub fn run_subtest(
     // assertion message + the Metal-validation lines) for offline triage. The
     // normal run reduces this to per-site counts and drops the text; the actual
     // vs. expected values it carries are what distinguish a real defect from an
-    // accepted pixel/caps difference. Off unless `MTLD3D_CONFORMANCE_RAW_DIR` is
-    // set; a write failure is reported but never fails the run.
-    save_raw_output(leg, subtest, &combined);
+    // accepted pixel/caps difference. A write failure is reported but never
+    // fails the run.
+    if let Some(raw) = &raw {
+        raw.save(&combined);
+    }
 
     Ok(SubtestRun {
         result: scan::parse_subtest_output(&combined, signaled),
@@ -342,27 +353,101 @@ fn kill_group(child: &Child) {
     }
 }
 
-/// Persist a subtest's raw output to `$MTLD3D_CONFORMANCE_RAW_DIR/<leg>-<subtest>.log`.
+/// How the process ended, as the raw log's last line.
 ///
-/// Only when that variable is set. A no-op (and silent) when it is unset.
-fn save_raw_output(leg: Leg, subtest: Subtest, combined: &str) {
-    let Ok(dir) = std::env::var("MTLD3D_CONFORMANCE_RAW_DIR") else {
-        return;
-    };
-    let dir = PathBuf::from(dir);
-    if let Err(e) = fs::create_dir_all(&dir) {
-        eprintln!(
-            "  [conformance] could not create raw dir {}: {e}",
-            dir.display()
-        );
-        return;
+/// A process that ends without the framework's summary is a crash whatever
+/// else its output holds, and this line is what tells the shapes apart. Wine
+/// ends a process with an unhandled Win32 exception through the exception
+/// code, of which unix keeps the low byte, so an access violation
+/// (`0xC0000005`) reads as `code 5`. A run that reached its summary exits
+/// with `code 0` once a device existed (the layer ends the process from its
+/// detach), else with the framework's failure count capped at 255. A signal
+/// is the number alone (11 `SIGSEGV`, 10 `SIGBUS`, 6 `SIGABRT`, 9 `SIGKILL`):
+/// the scanner's crash markers are signal names, and a name here would turn
+/// a fault the process survived into a crash.
+fn exit_trailer(status: ExitStatus) -> String {
+    match (status.code(), status.signal()) {
+        (Some(code), _) => format!("[conformance] subtest exited: code {code}"),
+        (None, Some(signal)) => format!("[conformance] subtest exited: signal {signal}"),
+        (None, None) => "[conformance] subtest exited: unknown status".to_owned(),
     }
-    let path = dir.join(format!("{leg}-{subtest}.log"));
-    if let Err(e) = fs::write(&path, combined) {
-        eprintln!(
-            "  [conformance] could not write raw log {}: {e}",
-            path.display()
+}
+
+/// The `MTLD3D_CONFIG` a subtest runs under.
+///
+/// `shaderCache.enable=false`: disable the persistent on-disk shader cache
+/// (`mtld3d_shaders.bin`) for every conformance run so the DLL compiles
+/// shaders fresh each run — a change to the shader translator (or a
+/// `SHADER_CACHE_SCHEMA` bump) is always reflected without having to delete a
+/// stale cache by hand.
+///
+/// `color.hdr.enable=false`: the shipped default is on, but it resolves off
+/// the running machine's panel, so an EDR Mac would present through the
+/// tone-mapping shader while another machine blits. The baseline has to mean
+/// the same thing on every machine that runs it, so pin the SDR path here.
+///
+/// The leg's variant appends its own entries: the `intel` variant turns every
+/// `intel.*` key on so the whole suite runs under the answers an Intel/AMD Mac
+/// gives. A kept run adds `log.dir`, so the process's log file lands beside
+/// its raw output.
+fn config_entries(leg: Leg, raw: Option<&RawTarget>) -> String {
+    let mut entries = format!(
+        "shaderCache.enable=false;color.hdr.enable=false{}",
+        leg.variant.config_entries()
+    );
+    if let Some(raw) = raw {
+        let _ = write!(entries, ";log.dir={}", raw.log_dir_dos());
+    }
+    entries
+}
+
+/// Where one subtest's raw output and its process's log file go.
+///
+/// `<dir>/<leg>-<subtest>[-<attempt>].log` for the output and a directory of
+/// the same stem for the log file, one per process, so the layer's retention
+/// of ten files per directory never prunes one run's log to make room for
+/// another's.
+struct RawTarget {
+    dir: PathBuf,
+    stem: String,
+}
+
+impl RawTarget {
+    fn new(dir: &Path, leg: Leg, subtest: Subtest, attempt: Option<u32>) -> Self {
+        let stem = attempt.map_or_else(
+            || format!("{leg}-{subtest}"),
+            |n| format!("{leg}-{subtest}-{n}"),
         );
+        Self {
+            dir: dir.to_path_buf(),
+            stem,
+        }
+    }
+
+    /// The log directory as the test process names it.
+    ///
+    /// The layer reads `log.dir` on the Windows side, where the unix root is
+    /// drive `Z:`, the same convention the e2e legs use for their `LOG_DIR`.
+    fn log_dir_dos(&self) -> String {
+        format!("Z:{}", self.dir.join(&self.stem).display())
+    }
+
+    /// Persist the raw output; a failure is reported and never fails the run.
+    fn save(&self, combined: &str) {
+        if let Err(e) = fs::create_dir_all(&self.dir) {
+            eprintln!(
+                "  [conformance] could not create raw dir {}: {e}",
+                self.dir.display()
+            );
+            return;
+        }
+        let path = self.dir.join(format!("{}.log", self.stem));
+        if let Err(e) = fs::write(&path, combined) {
+            eprintln!(
+                "  [conformance] could not write raw log {}: {e}",
+                path.display()
+            );
+        }
     }
 }
 

--- a/unix/conformance/src/run/tests.rs
+++ b/unix/conformance/src/run/tests.rs
@@ -6,18 +6,23 @@
 //! alone. The gate then fails a leg for any message that survives: after the
 //! warning filter there is no benign one left.
 //!
-//! The hang tests let `/bin/sh` play Wine and a script play the test binary:
-//! the driver's line has to stop the subtest within seconds, not at its
-//! budget, and has to mark the run so its counts never reach a baseline.
+//! The spawn tests let `/bin/sh` play Wine and a script play the test binary.
+//! The driver's hang line has to stop the subtest within seconds, not at its
+//! budget, and has to mark the run so its counts never reach a baseline. The
+//! raw log has to end with how the process ended, since a run without the
+//! framework's summary is a crash whose shape only that line tells, and the
+//! process has to be handed a `log.dir` beside its raw output so its log file
+//! reaches whoever reads the raw dir.
 
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::PathBuf,
     time::{Duration, Instant},
 };
 
 use super::{
-    is_gpu_hang_line, normalize_numbers, run_subtest, validation_errors, validation_gate_failed,
+    Launch, is_gpu_hang_line, normalize_numbers, run_subtest, validation_errors,
+    validation_gate_failed,
 };
 use crate::model::{Arch, Gpu, Leg, Subtest, Variant};
 
@@ -135,11 +140,33 @@ fn script(name: &str, body: &str) -> PathBuf {
     path
 }
 
+/// The spawn a script stands in for, keeping nothing.
+fn launch(exe: PathBuf) -> Launch {
+    Launch {
+        wine: PathBuf::from("/bin/sh"),
+        exe,
+        log: "off".to_owned(),
+        raw_dir: None,
+    }
+}
+
+/// The spawn a script stands in for, keeping its raw output in the script's directory.
+fn launch_kept(exe: PathBuf) -> Launch {
+    let dir = exe.parent().expect("script dir").to_path_buf();
+    Launch {
+        raw_dir: Some(dir),
+        ..launch(exe)
+    }
+}
+
 const LEG: Leg = Leg {
     arch: Arch::I686,
     variant: Variant::Native,
     gpu: Gpu::Apple,
 };
+
+/// The framework's summary line, so a run reads as complete.
+const SUMMARY: &str = "device: 10 tests executed (0 marked as todo, 1 failures), 0 skipped.";
 
 /// The bound the spawn tests hold the runner to: well under any subtest budget.
 const PROMPT: Duration = Duration::from_secs(5);
@@ -151,7 +178,7 @@ fn a_subtest_that_hangs_the_gpu_is_stopped_at_once() {
         &format!("echo 'visual.c:100: Test failed: x'\necho '{DRIVER_HANG}' >&2\nsleep 30\n"),
     );
     let started = Instant::now();
-    let run = run_subtest(Path::new("/bin/sh"), &exe, LEG, Subtest::Visual).expect("spawn sh");
+    let run = run_subtest(&launch(exe), LEG, Subtest::Visual, None).expect("spawn sh");
     let elapsed = started.elapsed();
     assert!(run.gpu_hang);
     assert!(run.result.crash, "a leg cut short is not a clean count");
@@ -169,10 +196,77 @@ fn a_hang_line_before_a_clean_exit_still_counts() {
             "echo '{DRIVER_IGNORED}' >&2\necho 'visual: 10 tests executed (0 marked as todo, 0 failures), 0 skipped.'\nexit 0\n"
         ),
     );
-    let run = run_subtest(Path::new("/bin/sh"), &exe, LEG, Subtest::Visual).expect("spawn sh");
+    let run = run_subtest(&launch(exe), LEG, Subtest::Visual, None).expect("spawn sh");
     assert!(run.gpu_hang);
     assert!(
         run.result.crash,
         "a process that survived its hang still read zeros; its counts must not reach the baseline"
     );
+}
+
+#[test]
+fn a_run_records_its_exit_code_and_keeps_its_log_beside_the_raw_output() {
+    let exe = script(
+        "exit-code",
+        &format!(
+            "echo 'device.c:10: Test failed: x'; echo '{SUMMARY}'; echo \"$MTLD3D_CONFIG\"; exit 5\n"
+        ),
+    );
+    let launch = launch_kept(exe);
+    let dir = launch.raw_dir.clone().expect("kept");
+    let run = run_subtest(&launch, LEG, Subtest::Device, None).expect("spawn sh");
+    assert!(!run.result.crash);
+
+    let raw = fs::read_to_string(dir.join("i686-device.log")).expect("raw log kept");
+    assert!(
+        raw.trim_end()
+            .ends_with("[conformance] subtest exited: code 5"),
+        "{raw}"
+    );
+    // The process is told the same directory as a Windows path, one
+    // directory per run, so the layer's retention never prunes across runs.
+    let expected = format!("log.dir=Z:{}", dir.join("i686-device").display());
+    assert!(raw.contains(&expected), "{raw}");
+}
+
+#[test]
+fn a_run_ended_by_a_signal_records_the_number_and_is_a_crash() {
+    let exe = script(
+        "signal",
+        "echo 'device.c:10: Test failed: x'; kill -SEGV $$\n",
+    );
+    let launch = launch_kept(exe);
+    let dir = launch.raw_dir.clone().expect("kept");
+    let run = run_subtest(&launch, LEG, Subtest::Device, None).expect("spawn sh");
+    assert!(run.result.crash);
+    let raw = fs::read_to_string(dir.join("i686-device.log")).expect("raw log kept");
+    assert!(
+        raw.trim_end()
+            .ends_with("[conformance] subtest exited: signal 11"),
+        "{raw}"
+    );
+}
+
+#[test]
+fn a_repeat_run_keeps_one_raw_log_per_attempt() {
+    let exe = script("repeat", &format!("echo '{SUMMARY}'\n"));
+    let launch = launch_kept(exe);
+    let dir = launch.raw_dir.clone().expect("kept");
+    for attempt in 1..=2 {
+        run_subtest(&launch, LEG, Subtest::Visual, Some(attempt)).expect("spawn sh");
+    }
+    assert!(dir.join("i686-visual-1.log").is_file());
+    assert!(dir.join("i686-visual-2.log").is_file());
+    assert!(!dir.join("i686-visual.log").exists());
+}
+
+#[test]
+fn nothing_is_kept_and_no_log_dir_is_named_without_a_raw_dir() {
+    let exe = script(
+        "no-raw-dir",
+        &format!("echo \"$MTLD3D_CONFIG\"; echo '{SUMMARY}'\n"),
+    );
+    let dir = exe.parent().expect("script dir").to_path_buf();
+    run_subtest(&launch(exe), LEG, Subtest::Device, None).expect("spawn sh");
+    assert!(!dir.join("i686-device.log").exists());
 }

--- a/unix/unix/src/crash.rs
+++ b/unix/unix/src/crash.rs
@@ -1,7 +1,7 @@
 //! Always-on unix-side crash handler.
 //!
 //! Installed once from `init_logger_handler`. Catches SIGSEGV, SIGBUS,
-//! SIGABRT. The handler is async-signal-safe — it only calls
+//! SIGILL, SIGABRT. The handler is async-signal-safe — it only calls
 //! `libc::write` on the log file's descriptor and `mtld3d_shared::crumb::dump_recent` (which is
 //! itself async-signal-safe). On a fatal signal in OUR code the handler:
 //!
@@ -28,13 +28,15 @@
 //!
 //! One line is still written before such a fault is forwarded when its PC
 //! lies in a native image (a framework, libobjc, libsystem, Wine's own
-//! `.so`): `fault outside mtld3d.so:` with the signal number, the PC, the
-//! image and the thread. A fault there on a thread Wine does not own (ours,
-//! or a Metal completion thread) ends the process inside Wine's handler with
-//! nothing else said, and the game's log then has to name the image and the
-//! thread at least. Guest code and translated code resolve to no image and
-//! stay silent: those faults are Wine's ordinary work. The line is capped at
-//! a few per process and carries no signal name, since a fault Wine recovers
+//! `.so`): `fault outside mtld3d.so:` with the signal number, the thread id
+//! and name, the PC as image plus offset and nearest symbol, then the return
+//! addresses into our own dylib found on the faulting stack. A fault there on
+//! a thread Wine does not own (ours, or a Metal completion thread) ends the
+//! process inside Wine's handler with nothing else said, and the game's log
+//! then has to name the image, the thread and our frames under it at least.
+//! Guest code and translated code resolve to no image and stay silent: those
+//! faults are Wine's ordinary work. The report is capped at a few per process
+//! and carries no signal name, since a fault Wine recovers
 //! must not read as a crash to anything that scans the log for one.
 //!
 //! `RUST_BACKTRACE=1` is also set here (if unset) so the default Rust
@@ -76,7 +78,8 @@ impl PrevDisposition {
 }
 
 /// Previous dispositions of the signals we install, indexed by [`signal_slot`].
-static PREV: [PrevDisposition; 3] = [
+static PREV: [PrevDisposition; 4] = [
+    PrevDisposition::new(),
     PrevDisposition::new(),
     PrevDisposition::new(),
     PrevDisposition::new(),
@@ -88,6 +91,7 @@ const fn signal_slot(signo: c_int) -> Option<usize> {
         libc::SIGSEGV => Some(0),
         libc::SIGBUS => Some(1),
         libc::SIGABRT => Some(2),
+        libc::SIGILL => Some(3),
         _ => None,
     }
 }
@@ -116,6 +120,9 @@ pub fn install() {
     if std::env::var_os("MTLD3D_NO_CRASH_HANDLER").is_none() {
         install_signal_handler(libc::SIGSEGV);
         install_signal_handler(libc::SIGBUS);
+        // A trap instruction: a framework's own assertion (`__builtin_trap`)
+        // ends a process this way, and so does a jump into non-code.
+        install_signal_handler(libc::SIGILL);
     }
     install_signal_handler(libc::SIGABRT);
 }
@@ -388,17 +395,21 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
 /// Name a fault in someone else's native code before it is handed back.
 ///
 /// Only when the PC resolves to an image: guest and translated code do not,
-/// and a fault there is Wine's ordinary work. Three writes rather than one
-/// buffer, because an image path can be longer than the line buffer. Stops
-/// after [`FOREIGN_REPORT_LIMIT`] lines, since a game may probe with faults
-/// of its own and every one would cost a lookup.
+/// and a fault there is Wine's ordinary work. The line carries the thread id,
+/// the PC as image plus offset (a load address on its own names nothing once
+/// the process is gone) and the nearest symbol dyld knows, and is followed by
+/// the return addresses into our dylib on the faulting stack, which is what
+/// ties a fault in a framework to the call of ours that provoked it. Written
+/// in pieces rather than one buffer, because an image path can be longer than
+/// the line buffer. Stops after [`FOREIGN_REPORT_LIMIT`] reports, since a game
+/// may probe with faults of its own and every one would cost the lookups.
 fn report_foreign_fault(signo: c_int, ctx: *mut c_void) {
-    /// How many faults outside our image get a line.
+    /// How many faults outside our image get a report.
     const FOREIGN_REPORT_LIMIT: u32 = 4;
     static REPORTS: AtomicU32 = AtomicU32::new(0);
 
     let pc = fault_pc(ctx);
-    let Some(image) = dladdr_image(pc) else {
+    let Some(info) = dladdr_info(pc) else {
         return;
     };
     if REPORTS.fetch_add(1, Ordering::AcqRel) >= FOREIGN_REPORT_LIMIT {
@@ -413,6 +424,8 @@ fn report_foreign_fault(signo: c_int, ctx: *mut c_void) {
         b"[mtld3d::unix] fault outside mtld3d.so: signo=",
     );
     push_decimal(&mut b, &mut p, signo.cast_unsigned());
+    push(&mut b, &mut p, b" tid=");
+    push_hex(&mut b, &mut p, thread_id());
     push(&mut b, &mut p, b" pc=");
     push_hex(&mut b, &mut p, pc);
     push(&mut b, &mut p, b" image=");
@@ -420,16 +433,37 @@ fn report_foreign_fault(signo: c_int, ctx: *mut c_void) {
     unsafe {
         let _ = libc::write(fd, b.as_ptr().cast::<c_void>(), p);
     }
-    // SAFETY: `image` is the NUL-terminated path dyld owns for a loaded
+    // SAFETY: `dli_fname` is the NUL-terminated path dyld owns for a loaded
     // image; `strlen` is async-signal-safe.
-    let image_len = unsafe { libc::strlen(image) };
-    // SAFETY: write(2) is async-signal-safe; `image_len` bytes at `image` are
-    // the path just measured.
+    let image_len = unsafe { libc::strlen(info.dli_fname) };
+    // SAFETY: write(2) is async-signal-safe; `image_len` bytes at `dli_fname`
+    // are the path just measured.
     unsafe {
-        let _ = libc::write(fd, image.cast::<c_void>(), image_len);
+        let _ = libc::write(fd, info.dli_fname.cast::<c_void>(), image_len);
     }
     let mut b = [0u8; 192];
     let mut p = 0;
+    push(&mut b, &mut p, b"+");
+    push_hex(
+        &mut b,
+        &mut p,
+        pc.wrapping_sub(info.dli_fbase as usize as u64),
+    );
+    if !info.dli_sname.is_null() {
+        push(&mut b, &mut p, b" sym=");
+        // SAFETY: `dli_sname` is the NUL-terminated symbol name dyld owns;
+        // `strlen` is async-signal-safe.
+        let name_len = unsafe { libc::strlen(info.dli_sname) };
+        // SAFETY: `name_len` bytes at `dli_sname` are the name just measured.
+        let name = unsafe { core::slice::from_raw_parts(info.dli_sname.cast::<u8>(), name_len) };
+        push(&mut b, &mut p, &name[..name_len.min(96)]);
+        push(&mut b, &mut p, b"+");
+        push_hex(
+            &mut b,
+            &mut p,
+            pc.wrapping_sub(info.dli_saddr as usize as u64),
+        );
+    }
     push(&mut b, &mut p, b" thread=");
     push_thread_name(&mut b, &mut p);
     push(&mut b, &mut p, b"\n");
@@ -437,6 +471,58 @@ fn report_foreign_fault(signo: c_int, ctx: *mut c_void) {
     unsafe {
         let _ = libc::write(fd, b.as_ptr().cast::<c_void>(), p);
     }
+
+    // The faulting stack, bounded by the thread's own stack top: the fault
+    // may be one Wine recovers, and a read past the top would re-fault into
+    // the re-entrancy guard and end a process that would have lived.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    {
+        let sp = mcontext_u64(ctx, SP_OFFSET);
+        let words = stack_words_above(sp);
+        if words > 0 {
+            let mut b = [0u8; 192];
+            let mut p = 0;
+            push(
+                &mut b,
+                &mut p,
+                b"[mtld3d::unix] mtld3d.so return addrs on stack (",
+            );
+            push_decimal(&mut b, &mut p, u32::try_from(words).unwrap_or(u32::MAX));
+            push(&mut b, &mut p, b" words scanned):\n");
+            // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
+            unsafe {
+                let _ = libc::write(fd, b.as_ptr().cast::<c_void>(), p);
+            }
+            our_frames_on_stack(sp, words);
+        }
+    }
+}
+
+/// The calling thread's system-wide id, the one `ps -M` and a sample show.
+fn thread_id() -> u64 {
+    let mut id = 0u64;
+    // SAFETY: `pthread_threadid_np` with a null thread reads the calling
+    // thread's own id into `id`; it touches thread-local state only.
+    unsafe {
+        libc::pthread_threadid_np(0, &raw mut id);
+    }
+    id
+}
+
+/// How many 4-byte words lie between `sp` and the calling thread's stack top.
+///
+/// Capped at [`STACK_SCAN_WORDS`]. Zero when the top is unknown or below
+/// `sp`, which skips the scan rather than guessing.
+fn stack_words_above(sp: u64) -> usize {
+    // SAFETY: `pthread_self` is always safe to call; reads the current TLS.
+    let me = unsafe { libc::pthread_self() };
+    // SAFETY: `pthread_get_stackaddr_np` on the calling thread reads its
+    // pthread record; it is the documented way to the stack's high end.
+    let top = unsafe { libc::pthread_get_stackaddr_np(me) } as usize as u64;
+    if top <= sp {
+        return 0;
+    }
+    usize::try_from((top - sp) / 4).map_or(STACK_SCAN_WORDS, |w| w.min(STACK_SCAN_WORDS))
 }
 
 /// Append the calling thread's name.
@@ -470,31 +556,11 @@ fn push_thread_name(buf: &mut [u8; 192], pos: &mut usize) {
 fn scan_stack_for_our_frames(sp: u64) {
     /// Header for the guest-stack pass below.
     const GUEST_HDR: &[u8] = b"[mtld3d::unix] guest (PE) stack words:\n";
-    /// Stack words to inspect, and the print caps for each pass.
-    const WORDS: usize = 4096;
-    const OURS_CAP: u32 = 48;
+    /// Print cap for the guest pass.
     const GUEST_CAP: u32 = 64;
 
+    our_frames_on_stack(sp, STACK_SCAN_WORDS);
     let base = sp as *const u8;
-    let mut printed = 0u32;
-    let mut slot = 0usize;
-    while slot < WORDS && printed < OURS_CAP {
-        // SAFETY: an offset into stack memory near `sp`; an unmapped read below
-        // re-faults into the re-entrancy guard (terminating), which bounds the
-        // walk.
-        let word = unsafe { base.add(slot * 4) };
-        // SAFETY: as above; `read_unaligned` tolerates a 4-byte-aligned 32-bit
-        // stack.
-        let addr = unsafe { word.cast::<u64>().read_unaligned() };
-        if addr >= 0x1000 && dladdr_is_ours(addr) {
-            let mut frame = [addr as *mut c_void; 1];
-            // SAFETY: single in-bounds frame pointer; `backtrace_symbols_fd`
-            // resolves via `dladdr` and writes to fd 2.
-            unsafe { backtrace_symbols_fd(frame.as_mut_ptr(), 1, crate::log_file::raw_fd()) };
-            printed += 1;
-        }
-        slot += 1;
-    }
     // Second pass: the 32-bit guest stack. `dladdr` can't see Wine's PE
     // builtins (not dyld images), so collect raw 4-byte words that land in the
     // PE-builtin zone [0x7A00_0000, 0x7C00_0000) (ntdll/user32/win32u/d3d9/…)
@@ -513,7 +579,7 @@ fn scan_stack_for_our_frames(sp: u64) {
     }
     let mut guest_printed = 0u32;
     let mut slot = 0usize;
-    while slot < WORDS && guest_printed < GUEST_CAP {
+    while slot < STACK_SCAN_WORDS && guest_printed < GUEST_CAP {
         // SAFETY: as the loop above, an offset into stack memory near `sp`.
         let word = unsafe { base.add(slot * 4) };
         // SAFETY: as above; an unmapped read re-faults into the re-entrancy
@@ -537,12 +603,47 @@ fn scan_stack_for_our_frames(sp: u64) {
     }
 }
 
-/// The path of the loaded image `addr` lies in, or `None` outside every image.
+/// Stack words a scan inspects from the faulting stack pointer upward.
+const STACK_SCAN_WORDS: usize = 4096;
+
+/// Print the return addresses into our own dylib among `words` stack words above `sp`.
 ///
-/// Guest (PE) pages and translated code are not images dyld knows, so they
-/// resolve to nothing. `dladdr` allocates nothing, which is what lets a
-/// signal handler ask.
-fn dladdr_image(addr: u64) -> Option<*const core::ffi::c_char> {
+/// `backtrace_symbols_fd`-prints each value that `dladdr` resolves into a
+/// module whose path contains `mtld3d`, capped so a deep stack can't flood.
+/// The 4-byte step tolerates a 32-bit guest stack's alignment; a spilled
+/// return address is a stack word on both arches.
+fn our_frames_on_stack(sp: u64, words: usize) {
+    /// Print cap for the pass.
+    const OURS_CAP: u32 = 48;
+
+    let base = sp as *const u8;
+    let mut printed = 0u32;
+    let mut slot = 0usize;
+    while slot < words && printed < OURS_CAP {
+        // SAFETY: an offset into stack memory near `sp`; an unmapped read below
+        // re-faults into the re-entrancy guard (terminating), which bounds the
+        // walk.
+        let word = unsafe { base.add(slot * 4) };
+        // SAFETY: as above; `read_unaligned` tolerates a 4-byte-aligned 32-bit
+        // stack.
+        let addr = unsafe { word.cast::<u64>().read_unaligned() };
+        if addr >= 0x1000 && dladdr_is_ours(addr) {
+            let mut frame = [addr as *mut c_void; 1];
+            // SAFETY: single in-bounds frame pointer; `backtrace_symbols_fd`
+            // resolves via `dladdr` and writes to fd 2.
+            unsafe { backtrace_symbols_fd(frame.as_mut_ptr(), 1, crate::log_file::raw_fd()) };
+            printed += 1;
+        }
+        slot += 1;
+    }
+}
+
+/// What dyld knows about `addr`: its image, and the nearest symbol below it.
+///
+/// `None` outside every image: guest (PE) pages and translated code are not
+/// images dyld knows. `dladdr` allocates nothing, which is what lets a signal
+/// handler ask.
+fn dladdr_info(addr: u64) -> Option<libc::Dl_info> {
     // SAFETY: zeroed `Dl_info` is a valid out-param for `dladdr`.
     let mut info: libc::Dl_info = unsafe { mem::zeroed() };
     // SAFETY: `dladdr` reads `addr` only as an opaque value and fills `info`.
@@ -550,7 +651,12 @@ fn dladdr_image(addr: u64) -> Option<*const core::ffi::c_char> {
     if ok == 0 || info.dli_fname.is_null() {
         return None;
     }
-    Some(info.dli_fname)
+    Some(info)
+}
+
+/// The path of the loaded image `addr` lies in, or `None` outside every image.
+fn dladdr_image(addr: u64) -> Option<*const core::ffi::c_char> {
+    dladdr_info(addr).map(|info| info.dli_fname)
 }
 
 /// True when `addr` resolves (via `dladdr`) into our own `.so`.
@@ -745,6 +851,7 @@ const fn signal_name(signo: libc::c_int) -> &'static [u8] {
         libc::SIGSEGV => b"SIGSEGV",
         libc::SIGBUS => b"SIGBUS",
         libc::SIGABRT => b"SIGABRT",
+        libc::SIGILL => b"SIGILL",
         _ => b"SIG?",
     }
 }

--- a/unix/unix/src/crash.rs
+++ b/unix/unix/src/crash.rs
@@ -428,6 +428,13 @@ fn report_foreign_fault(signo: c_int, ctx: *mut c_void) {
     push_hex(&mut b, &mut p, thread_id());
     push(&mut b, &mut p, b" pc=");
     push_hex(&mut b, &mut p, pc);
+    // The native first argument: for a fault in `objc_release` or
+    // `objc_msgSend` it is the object that was gone.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    {
+        push(&mut b, &mut p, b" arg0=");
+        push_hex(&mut b, &mut p, mcontext_u64(ctx, NATIVE_ARG0_OFFSET));
+    }
     push(&mut b, &mut p, b" image=");
     // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
     unsafe {
@@ -472,28 +479,20 @@ fn report_foreign_fault(signo: c_int, ctx: *mut c_void) {
         let _ = libc::write(fd, b.as_ptr().cast::<c_void>(), p);
     }
 
-    // The faulting stack, bounded by the thread's own stack top: the fault
-    // may be one Wine recovers, and a read past the top would re-fault into
-    // the re-entrancy guard and end a process that would have lived.
+    // The faulting stack. The fault may be one Wine recovers, so the scan
+    // must not fault itself: it probes each page before reading it rather
+    // than trusting a stack bound, since a Wine thread runs its unix calls
+    // on a stack Wine allocated, not the one its pthread record names.
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     {
         let sp = mcontext_u64(ctx, SP_OFFSET);
-        let words = stack_words_above(sp);
-        if words > 0 {
-            let mut b = [0u8; 192];
-            let mut p = 0;
-            push(
-                &mut b,
-                &mut p,
-                b"[mtld3d::unix] mtld3d.so return addrs on stack (",
-            );
-            push_decimal(&mut b, &mut p, u32::try_from(words).unwrap_or(u32::MAX));
-            push(&mut b, &mut p, b" words scanned):\n");
+        if sp != 0 {
+            const HDR: &[u8] = b"[mtld3d::unix] mtld3d.so return addrs on stack:\n";
             // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
             unsafe {
-                let _ = libc::write(fd, b.as_ptr().cast::<c_void>(), p);
+                let _ = libc::write(fd, HDR.as_ptr().cast::<c_void>(), HDR.len());
             }
-            our_frames_on_stack(sp, words);
+            our_frames_on_stack(sp, STACK_SCAN_WORDS);
         }
     }
 }
@@ -507,22 +506,6 @@ fn thread_id() -> u64 {
         libc::pthread_threadid_np(0, &raw mut id);
     }
     id
-}
-
-/// How many 4-byte words lie between `sp` and the calling thread's stack top.
-///
-/// Capped at [`STACK_SCAN_WORDS`]. Zero when the top is unknown or below
-/// `sp`, which skips the scan rather than guessing.
-fn stack_words_above(sp: u64) -> usize {
-    // SAFETY: `pthread_self` is always safe to call; reads the current TLS.
-    let me = unsafe { libc::pthread_self() };
-    // SAFETY: `pthread_get_stackaddr_np` on the calling thread reads its
-    // pthread record; it is the documented way to the stack's high end.
-    let top = unsafe { libc::pthread_get_stackaddr_np(me) } as usize as u64;
-    if top <= sp {
-        return 0;
-    }
-    usize::try_from((top - sp) / 4).map_or(STACK_SCAN_WORDS, |w| w.min(STACK_SCAN_WORDS))
 }
 
 /// Append the calling thread's name.
@@ -619,10 +602,20 @@ fn our_frames_on_stack(sp: u64, words: usize) {
     let base = sp as *const u8;
     let mut printed = 0u32;
     let mut slot = 0usize;
+    let mut probed_page = 0u64;
     while slot < words && printed < OURS_CAP {
-        // SAFETY: an offset into stack memory near `sp`; an unmapped read below
-        // re-faults into the re-entrancy guard (terminating), which bounds the
-        // walk.
+        // The word plus the seven bytes after it; a read that would cross
+        // into a page nobody mapped ends the walk instead of faulting.
+        let end = sp.wrapping_add((slot * 4) as u64 + 7);
+        let page = page_of(end);
+        if page != probed_page {
+            if !page_is_mapped(page) {
+                break;
+            }
+            probed_page = page;
+        }
+        // SAFETY: an offset into stack memory near `sp`, on a page the probe
+        // above found mapped.
         let word = unsafe { base.add(slot * 4) };
         // SAFETY: as above; `read_unaligned` tolerates a 4-byte-aligned 32-bit
         // stack.
@@ -636,6 +629,26 @@ fn our_frames_on_stack(sp: u64, words: usize) {
         }
         slot += 1;
     }
+}
+
+/// The page `addr` lies on.
+fn page_of(addr: u64) -> u64 {
+    // SAFETY: `sysconf` reads a constant.
+    let page = u64::try_from(unsafe { libc::sysconf(libc::_SC_PAGESIZE) })
+        .unwrap_or(4096)
+        .max(1);
+    addr & !(page - 1)
+}
+
+/// Whether the page at `page` is mapped, asked of the kernel rather than found out by a fault.
+///
+/// `mincore` answers `ENOMEM` for an address no mapping covers and is a
+/// plain system call, which is what a signal handler can afford.
+fn page_is_mapped(page: u64) -> bool {
+    let mut vec = [0i8; 1];
+    // SAFETY: `mincore` reads no user memory but the one-byte out vector.
+    let rc = unsafe { libc::mincore(page as *const c_void, 1, vec.as_mut_ptr()) };
+    rc == 0
 }
 
 /// What dyld knows about `addr`: its image, and the nearest symbol below it.
@@ -717,6 +730,15 @@ const SP_OFFSET: usize = 264;
 const ARG0_OFFSET: usize = 32;
 #[cfg(target_arch = "aarch64")]
 const ARG0_OFFSET: usize = 16;
+
+/// Byte offset of the register carrying a native call's first argument.
+///
+/// `x86_64` `__rdi`, the System V first argument, which is what a framework
+/// or the Objective-C runtime was handed; `arm64` `__x0`, the same role.
+#[cfg(target_arch = "x86_64")]
+const NATIVE_ARG0_OFFSET: usize = 48;
+#[cfg(target_arch = "aarch64")]
+const NATIVE_ARG0_OFFSET: usize = 16;
 
 /// Byte offset of `__rax`, which holds the vtable pointer a `CALL` loaded.
 #[cfg(target_arch = "x86_64")]

--- a/unix/unix/src/crash.rs
+++ b/unix/unix/src/crash.rs
@@ -26,6 +26,17 @@
 //! at startup on `CrossOver`'s arm64 Wine, and on any host it would have eaten
 //! the guest's own exception handling.
 //!
+//! One line is still written before such a fault is forwarded when its PC
+//! lies in a native image (a framework, libobjc, libsystem, Wine's own
+//! `.so`): `fault outside mtld3d.so:` with the signal number, the PC, the
+//! image and the thread. A fault there on a thread Wine does not own (ours,
+//! or a Metal completion thread) ends the process inside Wine's handler with
+//! nothing else said, and the game's log then has to name the image and the
+//! thread at least. Guest code and translated code resolve to no image and
+//! stay silent: those faults are Wine's ordinary work. The line is capped at
+//! a few per process and carries no signal name, since a fault Wine recovers
+//! must not read as a crash to anything that scans the log for one.
+//!
 //! `RUST_BACKTRACE=1` is also set here (if unset) so the default Rust
 //! panic hook prints message + backtrace before `abort()` flows through
 //! to the SIGABRT branch.
@@ -34,7 +45,7 @@ use core::{
     ffi::{c_int, c_void},
     mem, ptr,
 };
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicUsize, Ordering};
 
 use mtld3d_shared::crumb;
 
@@ -190,6 +201,7 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
     // SIGABRT is not shared this way: an abort is always terminal, and its PC
     // is inside libsystem rather than our code, so it stays ours to report.
     if signo != libc::SIGABRT && !fault_is_ours(ctx) {
+        report_foreign_fault(signo, ctx);
         forward_to_previous(signo, info, ctx);
         return;
     }
@@ -235,25 +247,11 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
 
     // Faulting thread name. For a teardown race the *which thread* (API vs
     // `mtld3d-encoder` / `mtld3d-submit` / `mtld3d-prewarm`) is the first clue.
-    // `pthread_getname_np` only reads thread-local storage — signal-safe enough
-    // for a terminating handler.
     {
-        let mut name = [0u8; 64];
-        // SAFETY: `pthread_self` is always safe to call; reads the current TLS.
-        let tid = unsafe { libc::pthread_self() };
-        // SAFETY: writes a NUL-terminated name (≤ len) into the buffer.
-        unsafe {
-            pthread_getname_np(
-                tid,
-                name.as_mut_ptr().cast::<core::ffi::c_char>(),
-                name.len(),
-            );
-        }
-        let nlen = name.iter().position(|&b| b == 0).unwrap_or(name.len());
         let mut b = [0u8; 192];
         let mut p = 0;
         push(&mut b, &mut p, b"[mtld3d::unix] thread=");
-        push(&mut b, &mut p, &name[..nlen.min(96)]);
+        push_thread_name(&mut b, &mut p);
         push(&mut b, &mut p, b"\n");
         // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
         unsafe {
@@ -387,6 +385,80 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
     unsafe { libc::_exit(1) };
 }
 
+/// Name a fault in someone else's native code before it is handed back.
+///
+/// Only when the PC resolves to an image: guest and translated code do not,
+/// and a fault there is Wine's ordinary work. Three writes rather than one
+/// buffer, because an image path can be longer than the line buffer. Stops
+/// after [`FOREIGN_REPORT_LIMIT`] lines, since a game may probe with faults
+/// of its own and every one would cost a lookup.
+fn report_foreign_fault(signo: c_int, ctx: *mut c_void) {
+    /// How many faults outside our image get a line.
+    const FOREIGN_REPORT_LIMIT: u32 = 4;
+    static REPORTS: AtomicU32 = AtomicU32::new(0);
+
+    let pc = fault_pc(ctx);
+    let Some(image) = dladdr_image(pc) else {
+        return;
+    };
+    if REPORTS.fetch_add(1, Ordering::AcqRel) >= FOREIGN_REPORT_LIMIT {
+        return;
+    }
+    let fd = crate::log_file::raw_fd();
+    let mut b = [0u8; 192];
+    let mut p = 0;
+    push(
+        &mut b,
+        &mut p,
+        b"[mtld3d::unix] fault outside mtld3d.so: signo=",
+    );
+    push_decimal(&mut b, &mut p, signo.cast_unsigned());
+    push(&mut b, &mut p, b" pc=");
+    push_hex(&mut b, &mut p, pc);
+    push(&mut b, &mut p, b" image=");
+    // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
+    unsafe {
+        let _ = libc::write(fd, b.as_ptr().cast::<c_void>(), p);
+    }
+    // SAFETY: `image` is the NUL-terminated path dyld owns for a loaded
+    // image; `strlen` is async-signal-safe.
+    let image_len = unsafe { libc::strlen(image) };
+    // SAFETY: write(2) is async-signal-safe; `image_len` bytes at `image` are
+    // the path just measured.
+    unsafe {
+        let _ = libc::write(fd, image.cast::<c_void>(), image_len);
+    }
+    let mut b = [0u8; 192];
+    let mut p = 0;
+    push(&mut b, &mut p, b" thread=");
+    push_thread_name(&mut b, &mut p);
+    push(&mut b, &mut p, b"\n");
+    // SAFETY: as above.
+    unsafe {
+        let _ = libc::write(fd, b.as_ptr().cast::<c_void>(), p);
+    }
+}
+
+/// Append the calling thread's name.
+///
+/// `pthread_getname_np` only reads thread-local storage, which is
+/// signal-safe enough for a terminating handler.
+fn push_thread_name(buf: &mut [u8; 192], pos: &mut usize) {
+    let mut name = [0u8; 64];
+    // SAFETY: `pthread_self` is always safe to call; reads the current TLS.
+    let tid = unsafe { libc::pthread_self() };
+    // SAFETY: writes a NUL-terminated name (≤ len) into the buffer.
+    unsafe {
+        pthread_getname_np(
+            tid,
+            name.as_mut_ptr().cast::<core::ffi::c_char>(),
+            name.len(),
+        );
+    }
+    let nlen = name.iter().position(|&b| b == 0).unwrap_or(name.len());
+    push(buf, pos, &name[..nlen.min(96)]);
+}
+
 /// Scan the raw stack for return addresses into our own dylib and print them.
 ///
 /// Walks up to 4096 words from `sp` and `backtrace_symbols_fd`-prints each
@@ -465,6 +537,22 @@ fn scan_stack_for_our_frames(sp: u64) {
     }
 }
 
+/// The path of the loaded image `addr` lies in, or `None` outside every image.
+///
+/// Guest (PE) pages and translated code are not images dyld knows, so they
+/// resolve to nothing. `dladdr` allocates nothing, which is what lets a
+/// signal handler ask.
+fn dladdr_image(addr: u64) -> Option<*const core::ffi::c_char> {
+    // SAFETY: zeroed `Dl_info` is a valid out-param for `dladdr`.
+    let mut info: libc::Dl_info = unsafe { mem::zeroed() };
+    // SAFETY: `dladdr` reads `addr` only as an opaque value and fills `info`.
+    let ok = unsafe { libc::dladdr(addr as *const c_void, &raw mut info) };
+    if ok == 0 || info.dli_fname.is_null() {
+        return None;
+    }
+    Some(info.dli_fname)
+}
+
 /// True when `addr` resolves (via `dladdr`) into our own `.so`.
 ///
 /// The match is on a loaded image whose filename contains the bytes `mtld3d`.
@@ -476,14 +564,10 @@ fn dladdr_is_ours(addr: u64) -> bool {
     /// Bound on the path scan, so a corrupt `dli_fname` can't spin.
     const PATH_MAX_SCAN: usize = 4096;
 
-    // SAFETY: zeroed `Dl_info` is a valid out-param for `dladdr`.
-    let mut info: libc::Dl_info = unsafe { mem::zeroed() };
-    // SAFETY: `dladdr` reads `addr` only as an opaque value and fills `info`.
-    let ok = unsafe { libc::dladdr(addr as *const c_void, &raw mut info) };
-    if ok == 0 || info.dli_fname.is_null() {
+    let Some(path) = dladdr_image(addr) else {
         return false;
-    }
-    let path = info.dli_fname.cast::<u8>();
+    };
+    let path = path.cast::<u8>();
     let mut idx = 0usize;
     let mut matched = 0usize;
     while idx < PATH_MAX_SCAN {
@@ -670,6 +754,22 @@ fn push(buf: &mut [u8; 192], pos: &mut usize, bytes: &[u8]) {
     let take = bytes.len().min(avail);
     buf[*pos..*pos + take].copy_from_slice(&bytes[..take]);
     *pos += take;
+}
+
+/// Append `v` in decimal, the form a signal number is read in.
+fn push_decimal(buf: &mut [u8; 192], pos: &mut usize, v: u32) {
+    let mut digits = [0u8; 10];
+    let mut n = digits.len();
+    let mut v = v;
+    loop {
+        n -= 1;
+        digits[n] = b'0' + u8::try_from(v % 10).expect("a digit fits u8");
+        v /= 10;
+        if v == 0 {
+            break;
+        }
+    }
+    push(buf, pos, &digits[n..]);
 }
 
 fn push_hex(buf: &mut [u8; 192], pos: &mut usize, v: u64) {

--- a/unix/unix/src/crash/tests.rs
+++ b/unix/unix/src/crash/tests.rs
@@ -154,6 +154,8 @@ fn foreign_fault_is_named_then_forwarded() {
         .unwrap_or_else(|| panic!("no foreign-fault line:\n{report}"));
     assert!(line.contains("signo=11"), "{line}");
     assert!(line.contains(" tid=0x"), "{line}");
+    // The released or messaged object, for a fault inside the runtime.
+    assert!(line.contains(" arg0=0x"), "{line}");
     // The image as path plus offset: the load address alone names nothing
     // once the process is gone.
     assert!(line.contains("image=/"), "{line}");
@@ -162,7 +164,7 @@ fn foreign_fault_is_named_then_forwarded() {
     // The faulting stack was scanned for our frames: this test binary is
     // one of ours by path, so the caller of `strlen` is on the list.
     assert!(
-        report.contains("mtld3d.so return addrs on stack ("),
+        report.contains("mtld3d.so return addrs on stack:"),
         "{report}"
     );
 }

--- a/unix/unix/src/crash/tests.rs
+++ b/unix/unix/src/crash/tests.rs
@@ -8,8 +8,10 @@
 //! own exit path with a decodable banner, PC, stack pointer and argument labels.
 //!
 //! The second test faults inside libsystem instead: a fault the handler does
-//! not own is handed back to the signal's default action, and the one line it
-//! writes first has to name the image and the thread.
+//! not own is handed back to the signal's default action, and the report it
+//! writes first has to name the image with an offset, the thread, and our
+//! frames on the faulting stack. The third traps in our own code, which is
+//! fatal like a fault.
 
 use std::os::unix::process::ExitStatusExt as _;
 
@@ -21,6 +23,9 @@ const SELFTEST_ENV: &str = "MTLD3D_CRASH_SELFTEST";
 
 /// Set in the re-executed child so it faults in someone else's code.
 const FOREIGN_SELFTEST_ENV: &str = "MTLD3D_CRASH_FOREIGN_SELFTEST";
+
+/// Set in the re-executed child so it executes a trap instruction.
+const ILL_SELFTEST_ENV: &str = "MTLD3D_CRASH_ILL_SELFTEST";
 
 /// The bad pointer the child dereferences.
 ///
@@ -148,6 +153,54 @@ fn foreign_fault_is_named_then_forwarded() {
         .find(|l| l.contains("fault outside mtld3d.so"))
         .unwrap_or_else(|| panic!("no foreign-fault line:\n{report}"));
     assert!(line.contains("signo=11"), "{line}");
+    assert!(line.contains(" tid=0x"), "{line}");
+    // The image as path plus offset: the load address alone names nothing
+    // once the process is gone.
     assert!(line.contains("image=/"), "{line}");
+    assert!(line.contains(".dylib+0x"), "{line}");
     assert!(line.contains("thread="), "{line}");
+    // The faulting stack was scanned for our frames: this test binary is
+    // one of ours by path, so the caller of `strlen` is on the list.
+    assert!(
+        report.contains("mtld3d.so return addrs on stack ("),
+        "{report}"
+    );
+}
+
+/// A trap instruction in our own code is fatal and named like a fault.
+///
+/// A framework's assertion ends a process with the same signal, so the
+/// handler has to own it: the child dies through the handler's `_exit(1)`
+/// with the banner, not by the signal's default action.
+#[test]
+fn illegal_instruction_in_our_code_is_fatal() {
+    if std::env::var_os(ILL_SELFTEST_ENV).is_some() {
+        super::install();
+        // SAFETY: deliberately traps; this is the signal under test, taken
+        // in a child process that never returns from the handler.
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            std::arch::asm!("ud2");
+        }
+        // SAFETY: as above, the permanently undefined encoding.
+        #[cfg(target_arch = "aarch64")]
+        unsafe {
+            std::arch::asm!("udf #0");
+        }
+        unreachable!("the trap above must not return");
+    }
+
+    let exe = std::env::current_exe().expect("test binary path");
+    let out = std::process::Command::new(exe)
+        .args([
+            "--exact",
+            "crash::tests::illegal_instruction_in_our_code_is_fatal",
+            "--nocapture",
+        ])
+        .env(ILL_SELFTEST_ENV, "1")
+        .output()
+        .expect("re-exec the test binary");
+    let report = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(out.status.code(), Some(1), "{report}");
+    assert!(report.contains("FATAL: SIGILL"), "{report}");
 }

--- a/unix/unix/src/crash/tests.rs
+++ b/unix/unix/src/crash/tests.rs
@@ -6,12 +6,21 @@
 //! only be exercised by taking the signal, so the test re-executes the binary,
 //! faults on a known address, and asserts the child died through the handler's
 //! own exit path with a decodable banner, PC, stack pointer and argument labels.
+//!
+//! The second test faults inside libsystem instead: a fault the handler does
+//! not own is handed back to the signal's default action, and the one line it
+//! writes first has to name the image and the thread.
+
+use std::os::unix::process::ExitStatusExt as _;
 
 /// Set in the re-executed child so it faults instead of asserting.
 ///
 /// A signal handler can only be exercised by actually taking the signal,
 /// which terminates the process, so the test spawns itself.
 const SELFTEST_ENV: &str = "MTLD3D_CRASH_SELFTEST";
+
+/// Set in the re-executed child so it faults in someone else's code.
+const FOREIGN_SELFTEST_ENV: &str = "MTLD3D_CRASH_FOREIGN_SELFTEST";
 
 /// The bad pointer the child dereferences.
 ///
@@ -102,4 +111,43 @@ fn fault_report_decodes_registers() {
         );
         assert_ne!(value_after(caller_label), zero, "{report}");
     }
+}
+
+/// A fault outside our image is named, then handed back.
+///
+/// `strlen` on the bad address faults inside libsystem, which the handler
+/// does not own: the child dies by the signal's default action rather than
+/// the handler's `_exit(1)`, and the report before that names the image and
+/// the calling thread.
+#[test]
+fn foreign_fault_is_named_then_forwarded() {
+    if std::env::var_os(FOREIGN_SELFTEST_ENV).is_some() {
+        super::install();
+        // SAFETY: deliberately unsound; this is the fault under test, taken
+        // in a child process that dies on it.
+        let len = unsafe { libc::strlen(std::hint::black_box(BAD_ADDR as *const libc::c_char)) };
+        unreachable!("the strlen above must fault, not return {len}");
+    }
+
+    let exe = std::env::current_exe().expect("test binary path");
+    let out = std::process::Command::new(exe)
+        .args([
+            "--exact",
+            "crash::tests::foreign_fault_is_named_then_forwarded",
+            "--nocapture",
+        ])
+        .env(FOREIGN_SELFTEST_ENV, "1")
+        .output()
+        .expect("re-exec the test binary");
+    let report = String::from_utf8_lossy(&out.stderr);
+
+    assert_eq!(out.status.signal(), Some(libc::SIGSEGV), "{report}");
+    assert!(!report.contains("FATAL"), "{report}");
+    let line = report
+        .lines()
+        .find(|l| l.contains("fault outside mtld3d.so"))
+        .unwrap_or_else(|| panic!("no foreign-fault line:\n{report}"));
+    assert!(line.contains("signo=11"), "{line}");
+    assert!(line.contains("image=/"), "{line}");
+    assert!(line.contains("thread="), "{line}");
 }

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -405,8 +405,14 @@ pub extern "C" fn create_backbuffer_handler(args: *mut c_void) -> i32 {
     // lines already cover the boot-time milestone.
     debug!(
         target: LOG_TARGET,
-        "created backbuffer {}x{} samples={}",
-        params.width, params.height, params.sample_count
+        "created backbuffer {}x{} samples={}: texture {:#x} srgb {:#x} msaa {:#x} msaa_srgb {:#x}",
+        params.width,
+        params.height,
+        params.sample_count,
+        params.texture_handle.raw(),
+        params.srgb_texture_handle.raw(),
+        params.msaa_texture_handle.raw(),
+        params.msaa_srgb_texture_handle.raw(),
     );
     STATUS_SUCCESS
 }
@@ -604,6 +610,14 @@ pub extern "C" fn create_depth_texture_handler(args: *mut c_void) -> i32 {
         params.sample_count,
     ) {
         params.texture_handle = handle;
+        debug!(
+            target: LOG_TARGET,
+            "created depth texture {}x{} samples={}: {:#x}",
+            params.width,
+            params.height,
+            params.sample_count,
+            handle.raw(),
+        );
         STATUS_SUCCESS
     } else {
         error!(target: LOG_TARGET, "failed to create depth texture");
@@ -819,6 +833,14 @@ pub extern "C" fn destroy_resources_bulk_handler(args: *mut c_void) -> i32 {
     let slice = unsafe {
         core::slice::from_raw_parts(params.handles_ptr as *const u64, params.count as usize)
     };
+    // The handles by value, so a later fault or ledger warning on one of
+    // them can be matched to the destroy that carried it.
+    debug!(
+        target: LOG_TARGET,
+        "DestroyResourcesBulk {:?} x{}: {slice:#x?}",
+        params.kind,
+        params.count,
+    );
     match params.kind {
         DestroyKind::Buffer => {
             for &h in slice {

--- a/unix/unix/src/metal/device.rs
+++ b/unix/unix/src/metal/device.rs
@@ -220,9 +220,8 @@ pub fn destroy_command_queue(
     // `release_retain` calls below.)
     unsafe { pipeline_handle.release_retain() };
     // SAFETY: as above.
-    unsafe { depth_texture_handle.release_retain() };
-    // SAFETY: as above.
-    unsafe { backbuffer_handle.release_retain() };
+    crate::metal::destroy_texture(depth_texture_handle.raw());
+    crate::metal::destroy_texture(backbuffer_handle.raw());
     // SAFETY: as above.
     unsafe { queue_handle.release_retain() };
     // SAFETY: as above.

--- a/unix/unix/src/metal/texture.rs
+++ b/unix/unix/src/metal/texture.rs
@@ -18,6 +18,31 @@ use objc2_metal::{
 
 use crate::metal::handle::{IntoRetained, ReleaseRetain};
 
+/// The texture handles this side has minted and not yet destroyed.
+///
+/// A handle enters at [`mint`] and leaves at [`destroy_texture`], so a
+/// destroy of a handle that is not here is a second destroy of one that was,
+/// or a value that never was one: the release it asks for would hand the
+/// Objective-C runtime an object that is gone, which ends the process where
+/// the memory has been reused and corrupts a live object where it has not.
+/// The check costs one hash per create and per destroy, both rare next to
+/// what they do.
+static LIVE_TEXTURES: std::sync::LazyLock<std::sync::Mutex<rustc_hash::FxHashSet<u64>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(rustc_hash::FxHashSet::default()));
+
+/// Hand a texture's retain to a raw handle, recording it as live.
+///
+/// Every texture handle that reaches the PE side is minted here, so the
+/// ledger and [`destroy_texture`]'s check agree on what is live.
+fn mint<T: objc2::Message>(texture: Retained<T>) -> u64 {
+    let raw = Retained::into_raw(texture).cast::<core::ffi::c_void>() as usize as u64;
+    LIVE_TEXTURES
+        .lock()
+        .expect("live-texture ledger poisoned")
+        .insert(raw);
+    raw
+}
+
 /// Creates a persistent `BGRA8Unorm` render target texture for use as a backbuffer.
 ///
 /// The new texture is cleared to opaque black before it is returned. A
@@ -64,7 +89,7 @@ pub fn create_backbuffer(
     // SAFETY: `Retained::into_raw` transfers the retain into a raw
     // pointer; `MetalHandle::new` adopts it as the canonical retain.
     Some((
-        unsafe { MetalHandle::<MTLTextureKind>::new(Retained::into_raw(texture) as u64) },
+        unsafe { MetalHandle::<MTLTextureKind>::new(mint(texture)) },
         srgb_handle,
     ))
 }
@@ -135,7 +160,7 @@ fn srgb_twin_view(
     view.map_or(0, |view| {
         let srgb_label = objc2_foundation::NSString::from_str(&format!("{label}-srgb"));
         view.setLabel(Some(&srgb_label));
-        Retained::into_raw(view) as u64
+        mint(view)
     })
 }
 
@@ -227,7 +252,7 @@ pub fn create_depth_texture(
     texture.setLabel(Some(&label));
     // SAFETY: `Retained::into_raw` transfers the retain; `MetalHandle::new`
     // adopts it as canonical.
-    Some(unsafe { MetalHandle::<MTLTextureKind>::new(Retained::into_raw(texture) as u64) })
+    Some(unsafe { MetalHandle::<MTLTextureKind>::new(mint(texture)) })
 }
 
 /// Creates a standalone color render-target texture.
@@ -263,7 +288,7 @@ pub fn create_color_target(
     // SAFETY: `Retained::into_raw` transfers the retain; `MetalHandle::new`
     // adopts it as canonical.
     Some((
-        unsafe { MetalHandle::<MTLTextureKind>::new(Retained::into_raw(texture) as u64) },
+        unsafe { MetalHandle::<MTLTextureKind>::new(mint(texture)) },
         srgb_handle,
     ))
 }
@@ -293,7 +318,7 @@ pub fn create_upscale_target(
     )?;
     // SAFETY: `Retained::into_raw` transfers the retain; `MetalHandle::new`
     // adopts it as canonical.
-    Some(unsafe { MetalHandle::<MTLTextureKind>::new(Retained::into_raw(texture) as u64) })
+    Some(unsafe { MetalHandle::<MTLTextureKind>::new(mint(texture)) })
 }
 
 /// Shared body of the colour-texture creators.
@@ -385,7 +410,7 @@ pub fn create_msaa_companion(
     // SAFETY: `Retained::into_raw` transfers the retain; `MetalHandle::new`
     // adopts it as canonical.
     Some((
-        unsafe { MetalHandle::<MTLTextureKind>::new(Retained::into_raw(texture) as u64) },
+        unsafe { MetalHandle::<MTLTextureKind>::new(mint(texture)) },
         srgb_handle,
     ))
 }
@@ -658,13 +683,13 @@ pub fn create_texture(
         };
         if let Some(view) = view {
             view.setLabel(Some(&label));
-            return Some((Retained::into_raw(view) as u64, srgb_handle));
+            return Some((mint(view), srgb_handle));
         }
     }
 
     texture.setLabel(Some(&label));
 
-    Some((Retained::into_raw(texture) as u64, srgb_handle))
+    Some((mint(texture), srgb_handle))
 }
 
 /// Create a single-slice, 2D view of one array slice of a texture.
@@ -702,11 +727,28 @@ pub fn create_texture_slice_view(
     view.setLabel(Some(&label));
     // SAFETY: `Retained::into_raw` hands over the view's only retain, which
     // the typed handle carries to the PE side.
-    Some(unsafe { MetalHandle::<MTLTextureKind>::new(Retained::into_raw(view) as u64) })
+    Some(unsafe { MetalHandle::<MTLTextureKind>::new(mint(view)) })
 }
 
 /// Release a Metal texture handle.
 pub fn destroy_texture(texture_handle: u64) {
+    if texture_handle == 0 {
+        return;
+    }
+    let was_live = LIVE_TEXTURES
+        .lock()
+        .expect("live-texture ledger poisoned")
+        .remove(&texture_handle);
+    if !was_live {
+        // Not once: each occurrence names its handle, and the debug lines
+        // around it say which destroy asked twice.
+        log::warn!(
+            target: crate::LOG_TARGET,
+            "destroy_texture: {texture_handle:#x} is not a live texture handle; a second \
+             destroy of a texture already released, or a value that never was one; skipped",
+        );
+        return;
+    }
     // SAFETY: bulk-destroy thunk; PE side has dropped its only copy of `texture_handle`.
     let handle = unsafe { MetalHandle::<MTLTextureKind>::new(texture_handle) };
     // SAFETY: just wrapped the unique canonical retain.


### PR DESCRIPTION
Diagnostics for #382. The issue stays open: this is the tool that makes the next occurrence explain itself, not the fix.

## Symptom

`conformance (macos-15-intel, i686)` fails about one run in three: the `device` subtest stops after `device.c:4572 ... i=1` and the runner reports `crash 0 -> 1`. The `conformance-raw` artifact is a 73-line log whose last two lines are the process's own startup banners; nothing follows the last `ok()` on stdout and nothing at all is on stderr. The job's timing says it is a death, not a hang (2m28s for the leg against a 600 s budget, no `TIMED OUT` trailer), and nothing in the artifact narrows it further.

## Mechanism

Every crash path we own was already visible, which is what makes this death interesting. Under the runner, `RUST_LOG=off` writes no line, so the per-process log file is never created and `log_file::raw_fd()` is fd 2: the PE VEH's `[mtld3d::d3d9] FATAL:` banner, the unix handler's `[mtld3d::unix] FATAL:` banner and any panic on either side would have landed in the captured stderr. None did, so the death is not a fault our handlers claim, and Wine's test framework installs its own exception filter only on real Windows.

What stays silent today: a fault whose PC lies in a native framework on a thread Wine does not own (`mtld3d-encoder`, `mtld3d-submit`, a Metal completion thread), which our handler forwards without a word and Wine's handler then dies on, reading a TEB that is not there; a `SIGKILL`; an explicit exit. The runner recorded neither the exit code nor the signal, so the three could not be told apart.

## Changes

- The conformance runner ends every raw log with how the process ended, `[conformance] subtest exited: code N` or `signal N`. Numbers only: the scanner's crash markers are signal names, and a name here would turn a fault the process survived into a crash. When a raw dir is set, each process is handed `log.dir=Z:<raw dir>/<leg>-<subtest>` so its log file lands beside its raw output, one directory per process (the ten-file retention never prunes across runs). The test processes' `RUST_LOG` comes from a new `--log` flag (Makefile `LOG=`), default `off` as before. A repeat run keeps every run's raw output as `<leg>-<subtest>-<n>.log` instead of overwriting one file. The spawn's shared inputs move onto a `Launch` struct built once in `main.rs`, which is what lets the tests hand the runner a shell script and a scratch directory instead of the process environment.
- The unix crash handler writes one line, `[mtld3d::unix] fault outside mtld3d.so: signo=N pc=... image=<path> thread=<name>`, before forwarding a fault whose PC resolves through `dladdr` to a Mach-O image that is not ours, four per process at most. Guest and translated code resolve to nothing and stay silent, since those faults are Wine's ordinary work. The thread-name block is factored out for both paths.
- A `conformance_repeat` workflow dispatch (with `conformance_only`) runs one subtest that many times on every conformance job in place of the gate, under `LOG=debug`, and the existing artifact upload takes every run's raw output and per-process log with it. `make conformance-isolate` gains `VARIANT=` for the Intel answers.
- CONFORMANCE.md, CONTRIBUTING.md and the Makefile comments describe the trailer, the log directory, `--log` and the dispatch.

Two rounds followed the first CI runs of this branch, which caught the #382 death twice (the findings are on the issue):

- The forwarded-fault report carries the thread id, the PC as image plus offset and nearest symbol, the native first argument (for `objc_release` the released object), and the return addresses into our dylib found on the faulting stack, asked of the kernel page by page rather than bounded by the pthread stack top (a Wine thread runs its unix calls on a stack Wine allocated). SIGILL joins the handled signals.
- Texture handles are recorded when minted and checked when destroyed: a destroy of a handle that is not live is refused with a warning naming it instead of handing the runtime an object that is gone. The create and bulk-destroy handlers log their handles at debug level, so a warning or a fault can be matched to the call that carried the handle.

## Alternatives

- Retrying the leg on this signature the way the GPU hang used to be retried: rejected, it would hide the bug from the gate. A death with this artifact keeps failing the job.
- `RUST_LOG=warn` on the gating legs: deferred. There is no evidence it would name the death, and a log file that exists moves the FATAL line out of the raw log into the per-process file.
- Naming the signal in the trailer: rejected for the scanner reason above; the doc comment lists the numbers.

Found on the way and filed as #400: the device detach ends the process with exit code 0, so unix-side observers never see the code a process passed to `ExitProcess`. The trailer records that zero faithfully.

## Verification

- `make check` (fmt, clippy on every leg, audit, doc): green.
- `cargo test` in `unix/`: 61 conformance tests, four of them new (`/bin/sh` plays Wine: the trailer for an exit code and for a signal, one raw log per repeat attempt, nothing kept without a raw dir); 93 unix tests including `foreign_fault_is_named_then_forwarded`, which re-executes the test binary, faults inside libsystem through `strlen` and asserts the child died by the default action after writing the line. That test fails against main's `crash.rs` and passes here.
- `make conformance` on both arches: no regressions; every raw log ends with the trailer.
- `MTLD3D_CONFORMANCE_RAW_DIR=... make conformance-isolate ONLY=device ARCH=i686 REPEAT=20 VARIANT=intel LOG=debug` on Apple Silicon: 0/20 crashes (the death does not reproduce here, consistent with it being specific to the Intel image), twenty raw logs and twenty per-process log directories.
- `make test ISOLATED=1`: 448/448 on both arches, since `mtld3d.so` changed.
- After the third commit: `make check`, unit tests (94 unix, 61 conformance), `make conformance` on both arches with `LOG=warn` (no regressions, and the ledger raised no warning anywhere in the suite on Apple Silicon), `make test ISOLATED=1` 448/448 on both arches.

Next, after merge: dispatch `ci.yml` with `conformance_repeat=20` and read `conformance-raw-macos-15-intel-i686`.
