### PR TITLE
Rescale occlusion counts by the render grid's actual area ratio

### DIFF
--- a/windows/core/src/visibility.rs
+++ b/windows/core/src/visibility.rs
@@ -18,7 +18,7 @@ use std::{collections::VecDeque, sync::Arc};
 
 use mtld3d_shared::{MetalHandle, mtl_handle::MTLBufferKind};
 
-use crate::{page_box::PageBox, render_scale::RenderScale};
+use crate::page_box::PageBox;
 
 /// 1024 u64 slots = 8 KiB.
 ///
@@ -73,13 +73,18 @@ pub struct VisibilityQueryCore {
     ///
     /// Atomic so `GetData` can observe transitions without locking.
     status: AtomicU64,
-    /// `render.scale` of the target the query began against, in percent.
+    /// Pixel area of the target the query began against, as D3D9 reports it.
     ///
-    /// Latched at BEGIN and applied at finalize: Metal counts the samples the
-    /// rasterizer produced, which under a reduced scale are fewer than the
-    /// pixels D3D9 reports, so the count is scaled back up into the reported
-    /// space before the game reads it.
-    scale_percent: AtomicU32,
+    /// Latched at BEGIN with [`Self::render_area`] and applied at finalize:
+    /// Metal counts the samples the rasterizer produced on the render grid,
+    /// which under a reduced `render.scale` holds fewer pixels than D3D9
+    /// reports, so the count is scaled back up by the ratio of the two areas
+    /// before the game reads it. The areas rather than the nominal scale,
+    /// because a dimension the scale does not divide rounds up on the render
+    /// grid, and only the actual ratio makes a full-frame count exact.
+    logical_area: AtomicU64,
+    /// Pixel area of the same target's render grid.
+    render_area: AtomicU64,
     /// Set the instant `Issue(D3DISSUE_END)` is recorded (API thread).
     ///
     /// Cleared on `Issue(D3DISSUE_BEGIN)`. Lets the blocking
@@ -100,7 +105,8 @@ impl VisibilityQueryCore {
             accumulated: AtomicU64::new(0),
             status: AtomicU64::new(QueryStatus::NeverIssued as u64),
             end_requested: AtomicBool::new(false),
-            scale_percent: AtomicU32::new(RenderScale::IDENTITY.percent()),
+            logical_area: AtomicU64::new(0),
+            render_area: AtomicU64::new(0),
         })
     }
 
@@ -118,10 +124,11 @@ impl VisibilityQueryCore {
     /// Metal encoder will write to. Moves the query from
     /// `NeverIssued`/`Issued` back into `Pending` — a second Issue on the
     /// same wrapper reuses the core.
-    pub fn begin(&self, seq: u64, offset: u32, scale: RenderScale) {
+    pub fn begin(&self, seq: u64, offset: u32, logical: (u32, u32), render: (u32, u32)) {
         self.seq_begin.store(seq, Ordering::Release);
         self.offset_begin.store(offset, Ordering::Release);
-        self.scale_percent.store(scale.percent(), Ordering::Release);
+        self.logical_area.store(area(logical), Ordering::Release);
+        self.render_area.store(area(render), Ordering::Release);
         // Reset the accumulator in case this core was previously issued
         // and the app is re-issuing.
         self.accumulated.store(0, Ordering::Release);
@@ -214,7 +221,11 @@ impl VisibilityQueryCore {
     /// Used only from `VisibilityQueryState::intake_completed` in this
     /// module.
     fn finalize(&self, summed: u64) {
-        let logical = logical_samples(summed, self.scale_percent.load(Ordering::Acquire));
+        let logical = logical_samples(
+            summed,
+            self.render_area.load(Ordering::Acquire),
+            self.logical_area.load(Ordering::Acquire),
+        );
         self.accumulated.store(logical, Ordering::Release);
         self.status
             .store(QueryStatus::Issued as u64, Ordering::Release);
@@ -229,19 +240,27 @@ impl VisibilityQueryCore {
 ///
 /// Encapsulated inside `VisibilityQueryState` — the encoder reaches it
 /// via `VisibilityQueryState::bump_slot`.
-/// Convert a sample count the rasterizer produced at `scale_percent` into reported pixels.
+/// The pixel area of an extent, for the area ratio a count is rescaled by.
+const fn area((width, height): (u32, u32)) -> u64 {
+    (width as u64) * (height as u64)
+}
+
+/// Convert a sample count produced on a `render_area` grid into `logical_area` pixels.
 ///
-/// A target rasterized at `s` percent holds `(s / 100)^2` of the pixels D3D9
-/// reports, so the counter is divided by that, rounded to nearest. The
-/// identity (and a percentage the parser never produces, `0`) passes the
-/// count through; the result saturates at `u64::MAX`.
+/// A target rasterized below the resolution D3D9 reports holds fewer pixels
+/// than the game was told, so the counter is multiplied by the ratio of the
+/// reported area to the render area, rounded to nearest. Equal areas (the
+/// identity, and every target the scale does not reach) and a zero area (a
+/// query begun before any target was bound) pass the count through; the
+/// result saturates at `u64::MAX`.
 #[must_use]
-pub fn logical_samples(render_samples: u64, scale_percent: u32) -> u64 {
-    if scale_percent == 0 || scale_percent == RenderScale::IDENTITY.percent() {
+pub fn logical_samples(render_samples: u64, render_area: u64, logical_area: u64) -> u64 {
+    if render_area == 0 || logical_area == 0 || render_area == logical_area {
         return render_samples;
     }
-    let squared = u128::from(scale_percent) * u128::from(scale_percent);
-    let scaled = (u128::from(render_samples) * 10_000 + squared / 2) / squared;
+    let scaled = (u128::from(render_samples) * u128::from(logical_area)
+        + u128::from(render_area) / 2)
+        / u128::from(render_area);
     u64::try_from(scaled).unwrap_or(u64::MAX)
 }
 

--- a/windows/core/src/visibility/tests.rs
+++ b/windows/core/src/visibility/tests.rs
@@ -12,7 +12,7 @@ use super::{
     MAX_SLOTS, QueryStatus, RetiredVisibilityBuffer, VisibilityBufferPool,
     VisibilityOffsetAllocator, VisibilityQueryCore, logical_samples, sum_slots,
 };
-use crate::{page_box::PageBox, render_scale::RenderScale};
+use crate::page_box::PageBox;
 
 fn dummy_buf(seq: u64) -> RetiredVisibilityBuffer {
     // SAFETY: tests; opaque value never dereferenced.
@@ -91,7 +91,7 @@ fn query_core_status_transitions() {
     let core = VisibilityQueryCore::new();
     assert_eq!(core.status(), QueryStatus::NeverIssued);
     assert_eq!(core.seq_end_loaded(), 0);
-    core.begin(10, 3, RenderScale::IDENTITY);
+    core.begin(10, 3, (640, 480), (640, 480));
     assert_eq!(core.status(), QueryStatus::Pending);
     assert_eq!(core.offset_begin(), 3);
     // BEGIN does not record seq_end — END drives the GetData(FLUSH)
@@ -109,12 +109,12 @@ fn query_core_status_transitions() {
 #[test]
 fn query_core_reissue_resets_accumulator() {
     let core = VisibilityQueryCore::new();
-    core.begin(1, 0, RenderScale::IDENTITY);
+    core.begin(1, 0, (640, 480), (640, 480));
     core.end(1, 1);
     core.finalize(100);
     assert_eq!(core.get_u32(), 100);
     // Re-issue with a different span: accumulator must zero out.
-    core.begin(2, 2, RenderScale::IDENTITY);
+    core.begin(2, 2, (640, 480), (640, 480));
     assert_eq!(core.status(), QueryStatus::Pending);
     core.end(2, 3);
     core.finalize(7);
@@ -124,7 +124,7 @@ fn query_core_reissue_resets_accumulator() {
 #[test]
 fn query_core_u32_clamp() {
     let core = VisibilityQueryCore::new();
-    core.begin(0, 0, RenderScale::IDENTITY);
+    core.begin(0, 0, (640, 480), (640, 480));
     core.end(0, 1);
     core.finalize(u64::MAX);
     assert_eq!(core.get_u32(), u32::MAX);
@@ -171,9 +171,9 @@ fn state_intake_completed_respects_seq() {
     let mut state = VisibilityQueryState::new();
     let c1 = VisibilityQueryCore::new();
     let c2 = VisibilityQueryCore::new();
-    c1.begin(5, 0, RenderScale::IDENTITY);
+    c1.begin(5, 0, (640, 480), (640, 480));
     c1.end(5, 1);
-    c2.begin(10, 2, RenderScale::IDENTITY);
+    c2.begin(10, 2, (640, 480), (640, 480));
     c2.end(10, 3);
     state.push_pending(5, c1.clone());
     state.push_pending(10, c2.clone());
@@ -271,39 +271,51 @@ fn scaling_smoke_hundred_queries() {
 }
 
 #[test]
-fn logical_samples_passes_the_identity_through() {
-    assert_eq!(logical_samples(0, 100), 0);
-    assert_eq!(logical_samples(307_200, 100), 307_200);
-    assert_eq!(logical_samples(u64::MAX, 100), u64::MAX);
+fn logical_samples_passes_equal_and_unknown_areas_through() {
+    assert_eq!(logical_samples(0, 307_200, 307_200), 0);
+    assert_eq!(logical_samples(307_200, 307_200, 307_200), 307_200);
+    assert_eq!(logical_samples(u64::MAX, 307_200, 307_200), u64::MAX);
     assert_eq!(
-        logical_samples(42, 0),
+        logical_samples(42, 0, 307_200),
         42,
-        "an unparsed percentage is the identity"
+        "no target bound at BEGIN"
+    );
+    assert_eq!(
+        logical_samples(42, 76_800, 0),
+        42,
+        "no target bound at BEGIN"
     );
 }
 
 #[test]
-fn logical_samples_divides_by_the_squared_scale_rounding_to_nearest() {
+fn logical_samples_scales_by_the_area_ratio_rounding_to_nearest() {
     // A 640x480 frame at 50% rasterizes 320x240 samples.
-    assert_eq!(logical_samples(76_800, 50), 307_200);
-    // At 75% a 480x360 frame; 172_800 * 16 / 9.
-    assert_eq!(logical_samples(172_800, 75), 307_200);
+    assert_eq!(logical_samples(76_800, 320 * 240, 640 * 480), 307_200);
+    // At 75% a 480x360 grid; 172_800 * 16 / 9.
+    assert_eq!(logical_samples(172_800, 480 * 360, 640 * 480), 307_200);
+    // A dimension the scale does not divide rounds up on the render grid:
+    // 3456x2234 at 75% is 2592x1676, and a full-frame count is exact only
+    // through the actual ratio, where the nominal 16/9 would give 7_723_008.
+    assert_eq!(
+        logical_samples(2592 * 1676, 2592 * 1676, 3456 * 2234),
+        3456 * 2234
+    );
     // One sample at 75% is 1.78 reported pixels, rounded to 2; at 50% it is 4.
-    assert_eq!(logical_samples(1, 75), 2);
-    assert_eq!(logical_samples(1, 50), 4);
+    assert_eq!(logical_samples(1, 480 * 360, 640 * 480), 2);
+    assert_eq!(logical_samples(1, 320 * 240, 640 * 480), 4);
     // 5 samples at 75% are 8.89, rounded to 9.
-    assert_eq!(logical_samples(5, 75), 9);
+    assert_eq!(logical_samples(5, 480 * 360, 640 * 480), 9);
 }
 
 #[test]
 fn logical_samples_saturates_instead_of_wrapping() {
-    assert_eq!(logical_samples(u64::MAX, 50), u64::MAX);
+    assert_eq!(logical_samples(u64::MAX, 320 * 240, 640 * 480), u64::MAX);
 }
 
 #[test]
-fn finalize_reports_the_count_in_reported_pixels_of_the_scale_begun_at() {
+fn finalize_reports_the_count_in_reported_pixels_of_the_target_begun_against() {
     let core = VisibilityQueryCore::new();
-    core.begin(1, 0, RenderScale::from_percent(50));
+    core.begin(1, 0, (640, 480), (320, 240));
     core.end(1, 1);
     core.finalize(76_800);
     assert_eq!(core.get_u32(), 307_200);

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -2558,23 +2558,43 @@ impl FrameEncoder {
     /// first call in the frame.
     pub fn begin_visibility_query(&mut self, core: &Arc<VisibilityQueryCore>) {
         if self.visibility.exhausted_this_frame() {
-            core.begin(self.current_submit_seq, 0, self.target_scale());
+            core.begin(
+                self.current_submit_seq,
+                0,
+                self.pass_state.current_color_logical_size(),
+                self.pass_state.current_color_size(),
+            );
             self.visibility.inc_active();
             return;
         }
         if !self.ensure_visibility_buffer() {
             self.mark_visibility_exhausted();
-            core.begin(self.current_submit_seq, 0, self.target_scale());
+            core.begin(
+                self.current_submit_seq,
+                0,
+                self.pass_state.current_color_logical_size(),
+                self.pass_state.current_color_size(),
+            );
             self.visibility.inc_active();
             return;
         }
         let Some(slot) = self.visibility.bump_slot() else {
             self.mark_visibility_exhausted();
-            core.begin(self.current_submit_seq, 0, self.target_scale());
+            core.begin(
+                self.current_submit_seq,
+                0,
+                self.pass_state.current_color_logical_size(),
+                self.pass_state.current_color_size(),
+            );
             self.visibility.inc_active();
             return;
         };
-        core.begin(self.current_submit_seq, slot, self.target_scale());
+        core.begin(
+            self.current_submit_seq,
+            slot,
+            self.pass_state.current_color_logical_size(),
+            self.pass_state.current_color_size(),
+        );
         self.visibility.inc_active();
         let cmd =
             Command::set_visibility_result_mode(VisibilityResultMode::Counting, slot * SLOT_BYTES);


### PR DESCRIPTION
Closes #408.

## Symptom

An occlusion count rescaled by the squared nominal `render.scale` is off for a target whose dimension the scale does not divide: at 0.75 a 3456x2234 fullscreen back buffer rasterizes 2592x1676 (1675.5 rounded up), so a full-screen quad's 4,344,192 samples rescale to 7,723,008 where the reported area is 7,720,704. Wine's `test_occlusion_query` compares against the registry mode's exact area and fails at device.c:6623, 6635 and 6644 under the scaled conformance run.

## Changes

The query core latches the target's reported and render pixel areas at `Issue(BEGIN)` instead of the nominal percentage, and `visibility::logical_samples` rescales by their ratio, rounded to nearest. Equal areas (the identity and every target the scale does not reach) and a zero area (a query begun before a target was bound) pass the count through; the result saturates. A full-frame count is now exact for any dimension.

## Rules check

Replaces one `AtomicU32` with two `AtomicU64` on the query core, changes `begin`'s signature to take the two extents the encoder already holds, and drops the `RenderScale` import from the module. No config key, wire field, dependency, derive, `#[allow]`, env var or unsafe. Pure logic in `mtld3d-core`.

## Verification

Unit tests pin equal and unknown areas passing through, the 50% and 75% conversions, the 3456x2234 case exact through the actual ratio, rounding, saturation, and finalize reporting in the space begun against. The occlusion e2e tests (identity and the pinned 0.5) stay green. `make check` and `make test` green on both arches. Wine's device subtest run by hand at `render.scale = 0.75` no longer fails the three sites.
