### PR TITLE
Ignore a window resize that reaches a device being released

### DIFF
--- a/unix/unix/src/metal/texture.rs
+++ b/unix/unix/src/metal/texture.rs
@@ -740,6 +740,13 @@ pub fn destroy_texture(texture_handle: u64) {
         .expect("live-texture ledger poisoned")
         .remove(&texture_handle);
     if !was_live {
+        // A build with debug assertions stops here: the second destroy is
+        // a PE-side lifetime bug, and a test that provokes one has to fail
+        // rather than pass on a skipped release.
+        debug_assert!(
+            was_live,
+            "destroy_texture: {texture_handle:#x} is not a live texture handle"
+        );
         // Not once: each occurrence names its handle, and the debug lines
         // around it say which destroy asked twice.
         log::warn!(

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -297,6 +297,15 @@ bitflags::bitflags! {
         /// later `Reset` succeeds, which is how an app learns it must retry
         /// (after releasing the `D3DPOOL_DEFAULT` resources that blocked it).
         const NOT_RESET = 1 << 2;
+        /// Set once the last `Release` has begun tearing the device down.
+        ///
+        /// The teardown hands a fullscreen window back before the cursor
+        /// subclass comes off, and the restore's `WM_SIZE` reaches the
+        /// subclass with the device no longer fullscreen. Answering it
+        /// would rebuild a back buffer whose handles the teardown has
+        /// already captured and is about to release, so the resize path
+        /// checks this and stands down.
+        const RELEASING = 1 << 3;
     }
 }
 
@@ -2424,6 +2433,14 @@ impl DeviceInner {
         if new_width == 0 || new_height == 0 {
             return;
         }
+        if self.flags.contains(DeviceFlags::RELEASING) {
+            debug!(
+                target: LOG_TARGET,
+                "WM_SIZE ({new_width}x{new_height}) during the device's release ignored; the \
+                 back buffer is being destroyed, not resized",
+            );
+            return;
+        }
         if self.fullscreen.is_some() {
             debug!(
                 target: LOG_TARGET,
@@ -3297,6 +3314,10 @@ extern "system" fn device_release(this: *mut c_void) -> u32 {
         // otherwise race with the encoder's destroy thunks on the same
         // `MTLDevice` during `shutdown_cleanup`.
         device_inner.prewarm.cancel_and_join();
+        // From here on a window message that reaches the cursor subclass
+        // finds a device being torn down, and the resize it may ask for
+        // must not rebuild what the steps below destroy.
+        device_inner.flags.insert(DeviceFlags::RELEASING);
 
         // D3DPOOL_MANAGED textures the game still holds outlive this device.
         // Their `device_inner`/`device_handle` are about to dangle. Zero

--- a/windows/tests/src/lib.rs
+++ b/windows/tests/src/lib.rs
@@ -29,5 +29,5 @@ pub use vertex::{
 };
 pub use win32::{
     Rect, WM_ACTIVATEAPP, WS_CAPTION, WS_EX_TOPMOST, WS_POPUP, WS_VISIBLE, enumerate_display_sizes,
-    set_window_pos,
+    send_message, set_window_pos,
 };

--- a/windows/tests/src/win32.rs
+++ b/windows/tests/src/win32.rs
@@ -235,6 +235,7 @@ pub fn create_window(width: i32, height: i32, visible: bool) -> usize {
 /// The call runs straight through the window's (possibly subclassed) wndproc.
 /// Lets tests synthesize the macdrv-posted messages (e.g. `WM_SIZE`)
 /// deterministically.
+#[must_use]
 pub fn send_message(hwnd: usize, msg: u32, wparam: usize, lparam: isize) -> isize {
     // SAFETY: Win32 thunk; `hwnd` is a window this process created.
     unsafe { SendMessageA(hwnd, msg, wparam, lparam) }

--- a/windows/tests/tests/e2e/device.rs
+++ b/windows/tests/tests/e2e/device.rs
@@ -1404,6 +1404,80 @@ fn create_fullscreen_honors_the_requested_resolution() {
     );
 }
 
+/// Releasing a fullscreen device gives the window back, and a `WM_SIZE` that
+/// arrives while it does must not resize the back buffer of a device being
+/// torn down.
+///
+/// The mode restore is the first thing the release does to the window, and
+/// where the mode-set is real the window manager answers it with a `WM_SIZE`
+/// for the restored window trimmed to the visible frame, delivered inside
+/// the restore call itself, before the device's own window moves are
+/// guarded. Under the test prefix's emulated mode-set nothing answers, so a
+/// second thread stands in for the window manager: a cross-thread
+/// `SendMessage` waits until the window's thread next pumps, which is that
+/// restore. A release that answered the message would destroy the back
+/// buffer, its sRGB twin and the depth texture a second time and leak their
+/// replacements, which is what ended the process on the Intel CI image. The
+/// unix side refuses a destroy of a handle that is no longer live, and a
+/// build with debug assertions ends the process at that refusal, which is
+/// what makes this test fail without the guard.
+#[test]
+fn releasing_a_fullscreen_device_ignores_a_resize_during_the_release() {
+    const WM_SIZE: u32 = 0x0005;
+    if !display_lists_640x480() {
+        return;
+    }
+    let h = Harness::with_depth();
+    let mut pp = fullscreen_params(h.hwnd(), 640, 480);
+    pp.enable_auto_depth_stencil = 1;
+    pp.auto_depth_stencil_format = D3DFMT_D24S8;
+    assert_eq!(
+        h.reset_params(&mut pp),
+        D3D_OK,
+        "Reset to fullscreen 640x480"
+    );
+    {
+        let (bb_hr, bb) = h.back_buffer(0).desc();
+        assert_eq!(bb_hr, D3D_OK, "GetDesc on the fullscreen back buffer");
+        assert_eq!(
+            (bb.width, bb.height),
+            (640, 480),
+            "the mode is the back buffer"
+        );
+    }
+
+    // The stand-in for the window manager: a size the back buffer does not
+    // have, sent from another thread so it queues until the release pumps.
+    let hwnd = h.hwnd();
+    let armed = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let sender = {
+        let armed = std::sync::Arc::clone(&armed);
+        std::thread::spawn(move || {
+            armed.wait();
+            mtld3d_tests::send_message(hwnd, WM_SIZE, 0, (456 << 16) | 600);
+        })
+    };
+    armed.wait();
+    // Long enough for the sender to reach its `SendMessage` and block there;
+    // a message that arrives after the release is pumped harmlessly below.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    assert_eq!(
+        h.release_device(),
+        0,
+        "the harness held the only device reference"
+    );
+    assert!(h.pump(), "no WM_QUIT expected");
+    sender
+        .join()
+        .expect("the sender thread ends once its message is answered");
+    let rect = h.window_rect();
+    assert!(
+        rect.right - rect.left > 0 && rect.bottom - rect.top > 0,
+        "the window outlived the device: {rect:?}",
+    );
+}
+
 #[test]
 fn fullscreen_window_reasserts_monitor_rect_after_external_resize() {
     if !display_lists_640x480() {

--- a/windows/tests/tests/e2e/device.rs
+++ b/windows/tests/tests/e2e/device.rs
@@ -1404,22 +1404,20 @@ fn create_fullscreen_honors_the_requested_resolution() {
     );
 }
 
-/// Releasing a fullscreen device gives the window back, and a `WM_SIZE` that
-/// arrives while it does must not resize the back buffer of a device being
-/// torn down.
+/// A `WM_SIZE` that arrives during a fullscreen device's release resizes nothing.
 ///
-/// The mode restore is the first thing the release does to the window, and
-/// where the mode-set is real the window manager answers it with a `WM_SIZE`
-/// for the restored window trimmed to the visible frame, delivered inside
-/// the restore call itself, before the device's own window moves are
-/// guarded. Under the test prefix's emulated mode-set nothing answers, so a
-/// second thread stands in for the window manager: a cross-thread
-/// `SendMessage` waits until the window's thread next pumps, which is that
-/// restore. A release that answered the message would destroy the back
-/// buffer, its sRGB twin and the depth texture a second time and leak their
-/// replacements, which is what ended the process on the Intel CI image. The
-/// unix side refuses a destroy of a handle that is no longer live, and a
-/// build with debug assertions ends the process at that refusal, which is
+/// Releasing a fullscreen device gives the window back. The mode restore is the
+/// first thing the release does to the window, and where the mode-set is real
+/// the window manager answers it with a `WM_SIZE` for the restored window
+/// trimmed to the visible frame, delivered inside the restore call itself,
+/// before the device's own window moves are guarded. Under the test prefix's
+/// emulated mode-set nothing answers, so a second thread stands in for the
+/// window manager: a cross-thread `SendMessage` waits until the window's thread
+/// next pumps, which is that restore. A release that answered the message would
+/// destroy the back buffer, its sRGB twin and the depth texture a second time
+/// and leak their replacements, which is what ended the process on the Intel CI
+/// image. The unix side refuses a destroy of a handle that is no longer live,
+/// and a build with debug assertions ends the process at that refusal, which is
 /// what makes this test fail without the guard.
 #[test]
 fn releasing_a_fullscreen_device_ignores_a_resize_during_the_release() {
@@ -1454,7 +1452,7 @@ fn releasing_a_fullscreen_device_ignores_a_resize_during_the_release() {
         let armed = std::sync::Arc::clone(&armed);
         std::thread::spawn(move || {
             armed.wait();
-            mtld3d_tests::send_message(hwnd, WM_SIZE, 0, (456 << 16) | 600);
+            let _ = mtld3d_tests::send_message(hwnd, WM_SIZE, 0, (0x1C8 << 16) | 0x258);
         })
     };
     armed.wait();


### PR DESCRIPTION
Fixes #382.

## Symptom

`conformance (macos-15-intel, i686)` and, as it turned out, the x86_64 leg too, died about one run in three inside `IDirect3DDevice9_Release` at the end of `test_wndproc`, leaving a raw log that ended at `device.c:4572 ... i=1`. With the diagnostics of #402 in place the death read as `objc_release+0x22` with `destroy_resources_bulk_handler`'s `Texture` arm on the stack, and the twenty-run `device` dispatch (run 33976828442) showed the live-texture ledger refusing a second destroy in 19 of 20 runs, always for the released device's back buffer, its sRGB twin and its depth texture, always right after an `apply_auto_resize`.

## Mechanism

The last `Release` of a fullscreen device destroys the back buffer's sRGB twin, captures the back buffer and depth handles for the queue-destroy thunk, and only then gives the window back. `fullscreen::leave` restores the display mode first, and where the mode-set is real, the window manager answers the restore with a `WM_SIZE` for the restored window trimmed to the visible frame (2560x1416 on the Intel image), delivered synchronously inside `ChangeDisplaySettings`'s broadcast, before the driving guard that covers the device's own `SetWindowPos`. The cursor subclass is still installed and the device is no longer fullscreen, so `apply_auto_resize` rebuilt the back buffer: it destroyed the three textures the release had just destroyed or captured, and created replacements nobody destroyed. Each second release handed the Objective-C runtime an object that was gone, which ended the process whenever the memory had been reused, hence the one-in-three. The test prefix's emulated mode-set sends no such `WM_SIZE`, which is why no local run ever showed it.

## Changes

- `DeviceFlags::RELEASING`, set at the top of the last Release's teardown before it touches the window; `apply_auto_resize` stands down for a releasing device and says so at debug level.
- The unix side's refusal of a destroy for a handle that is no longer live (the ledger from #402) now trips a `debug_assert!` first, so a build with debug assertions ends the process at a second destroy instead of skipping it; production keeps the warning and the skip.
- An e2e test provokes the exact sequence: a windowed device is Reset to fullscreen 640x480 and released while a second thread is blocked in `SendMessage(WM_SIZE)` to its window; the cross-thread send is delivered inside the mode restore's broadcast, the same pump the window manager's own `WM_SIZE` uses on a real mode-set. Gated on the 640x480 mode like every fullscreen test, so it runs on the CI images and not on a display that does not list the mode.
- `send_message` joins the test crate's re-exports.

## Alternatives

- Uninstalling the cursor subclass before giving the window back: the release intends the game's window procedure to see the restore as any other window change, and a later message during the teardown would still reach a subclass on any other path. The flag closes every entry to the resize, whichever message carries it.
- Capturing the queue-destroy handles after the window is back: the resize would still rebuild and leak a back buffer for a device about to die.

## Verification

- `make check` green; unit tests 61 conformance, 97 unix, 26 e2e, 69 core.
- `make test ISOLATED=1`: 454/454 on both arches. `make conformance` on both arches: no regressions.
- Fail-then-pass on CI: a throwaway branch with the guard disabled (run 33980991558) died on `e2e (macos-15, x86_64)` inside the new test, exit code 1, with the fatal path under `NtUserChangeDisplaySettings` in the captured backtrace; every other test passed. The guarded branch is this PR's CI run.
- After merge, the `conformance_repeat=20` dispatch again: the expectation is 0/20 ledger warnings on the Intel legs against 19/20 on e58bc6d.
