### PR TITLE
Resolve the watched branch ref against the common gitdir

### DIFF
--- a/unix/shared/build.rs
+++ b/unix/shared/build.rs
@@ -35,15 +35,22 @@ fn build_id() -> String {
     // without touching a single source file or moving HEAD, and a release
     // artifact stamped with the previous version is the one mistake this line
     // exists to prevent.
-    if let Some(dir) = git(&["rev-parse", "--absolute-git-dir"]) {
-        let dir = PathBuf::from(dir);
+    // `HEAD` is per-worktree, and names the ref rather than the commit, so it
+    // is the one file read from the worktree's own gitdir: it moves on a branch
+    // switch and stays put on a commit. Everything a ref names lives in the
+    // common gitdir instead, and resolving one against the worktree gitdir
+    // yields a path that does not exist, which the filter below silently drops.
+    if let (Some(git_dir), Some(common_dir)) = (
+        git(&["rev-parse", "--absolute-git-dir"]).map(PathBuf::from),
+        common_dir(),
+    ) {
         let mut watch = vec![
-            dir.join("HEAD"),
-            dir.join("packed-refs"),
-            dir.join("refs").join("tags"),
+            git_dir.join("HEAD"),
+            common_dir.join("packed-refs"),
+            common_dir.join("refs").join("tags"),
         ];
         if let Some(head_ref) = git(&["symbolic-ref", "--quiet", "HEAD"]) {
-            watch.push(dir.join(head_ref));
+            watch.push(common_dir.join(head_ref));
         }
         for path in watch.iter().filter(|p| p.exists()) {
             println!("cargo:rerun-if-changed={}", path.display());
@@ -51,6 +58,21 @@ fn build_id() -> String {
     }
     git(&["describe", "--tags", "--always"])
         .unwrap_or_else(|| format!("v{}", env!("CARGO_PKG_VERSION")))
+}
+
+/// The gitdir every worktree of a repository shares, as an absolute path.
+///
+/// Branch refs, tags and `packed-refs` all live here rather than in a
+/// worktree's own gitdir; outside a worktree the two are the same directory.
+/// `git` reports the path relative to the directory it ran in wherever that is
+/// shorter, and every `git` here runs in the manifest directory, so that is
+/// what a relative answer is anchored at.
+fn common_dir() -> Option<PathBuf> {
+    let dir = PathBuf::from(git(&["rev-parse", "--git-common-dir"])?);
+    if dir.is_absolute() {
+        return Some(dir);
+    }
+    Some(PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR")?).join(dir))
 }
 
 /// Run `git` in the manifest directory, returning trimmed stdout on success.

--- a/unix/shared/build.rs
+++ b/unix/shared/build.rs
@@ -35,6 +35,7 @@ fn build_id() -> String {
     // without touching a single source file or moving HEAD, and a release
     // artifact stamped with the previous version is the one mistake this line
     // exists to prevent.
+    //
     // `HEAD` is per-worktree, and names the ref rather than the commit, so it
     // is the one file read from the worktree's own gitdir: it moves on a branch
     // switch and stays put on a commit. Everything a ref names lives in the


### PR DESCRIPTION
## Symptoms

In a git worktree the release identity stamped into every binary stops following the checkout. After a commit or a `git commit --amend`, `make install` rebuilds nothing and the installed layer keeps reporting the previous hash, one that no branch contains: `d3d9.dll v0.7.0-196-g03ee8d7` after the amend that turned 03ee8d7 into 21ec18f. The same stamp is what the debug archive's `BUILD` file names, so a crash report pairs with the wrong symbols. Touching the build script is the only thing that refreshes it.

## Root cause

`unix/shared/build.rs` asks cargo to rerun it when the ref `HEAD` names changes, and resolves that ref against `git rev-parse --absolute-git-dir`. In a plain checkout that is `.git` and the ref is at `.git/refs/heads/<branch>`. In a worktree it is `.git/worktrees/<name>`, which holds only `HEAD` and the few per-worktree refs; branch refs, tags and `packed-refs` all live in the common gitdir. The composed path does not exist, the `exists()` filter drops it, and no ref is watched at all. What remains watched is the worktree's own `HEAD`, which names a ref rather than a commit and so only changes on a branch switch, never on a commit or an amend.

## Changes

`build_id` now takes two directories: the worktree gitdir for `HEAD`, and `git rev-parse --git-common-dir` for `packed-refs`, `refs/tags` and the branch ref `symbolic-ref` reports. Outside a worktree the two are the same directory, so the plain checkout keeps watching exactly what it watched before.

`git` reports the common dir relative to the directory it ran in wherever that is shorter (`../../.git` from `unix/shared`), so a relative answer is anchored at the manifest directory the build script runs `git` in.

## Alternatives

`git rev-parse --path-format=absolute --git-common-dir` avoids the anchoring step, but it needs git 2.31 or newer and fails silently on anything older, which would leave no ref watched and restore the bug it fixes.

Watching every source file of every crate, the `--dirty` approach the existing comment rejects, would catch this and everything else, at the cost of rebuilding all three cdylibs on each edit.

Leaving the worktree `HEAD` as the only trigger and accepting the stale stamp: `HEAD` does not move on a commit, so the identity would stay wrong for the whole of a branch's life.

## Verification

`make check` green. `make ISOLATED=1 test` green: 1053 native unit tests and 253 runner tests passed, and the end-to-end suite reports 454 tests, 454 passed, 0 failed, 3 processes on each of i686 and x86_64.

The path logic lives in a build script, which cargo compiles but never runs tests for, so there is no unit test to add. It was verified by hand in a worktree, watching the stamp `strings` finds in `unix/target/aarch64-apple-darwin/release/mtld3d.so`.

Before the change, built at e6b4c3a with the stamp reading `v0.8.0-20-ge6b4c3a`: an empty commit moved HEAD to 03746fb, `git describe` answered `v0.8.0-21-g03746fb`, and `make unix-arm64` finished in 0.02s having rebuilt nothing, with the stamp still `v0.8.0-20-ge6b4c3a`. Amending that commit to e6bf44f repeated it exactly.

After the change, the commit that carries it (29733e6) rebuilt the crate and stamped `v0.8.0-21-g29733e6`. `git commit --amend --no-edit` then moved it to e58c14c without touching a file, and the next `make unix-arm64` rebuilt and stamped `v0.8.0-21-ge58c14c`. The end-to-end run's installed `d3d9.dll` logged the same `v0.8.0-21-ge58c14c`.

Conformance was not run: the change alters only which files cargo watches, and the one value it feeds into the binaries is the identity string itself.

Closes #359
