### PR TITLE
Seed the ISOLATED=1 clones with one clonefile(2) per tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,14 +49,17 @@ overwrite each other's `d3d9.dll` and `mtld3d.so`, and a game launched from that
 tree meanwhile runs whichever build landed last. `make test ISOLATED=1` avoids
 both: it clones the SDK and the ambient prefix once into `.wine-isolated/`
 inside the checkout (APFS clones, so neither costs space or a prefix boot) and
-points the tools, the install and the prefix at the clones. Use it whenever
-another worktree may be testing or a game is running; a plain `make install`
-still targets the shared trees on purpose, since that is how the game gets a
-build. The clones and the persistent wineserver of the private prefix stay
-behind for the next run; `make clean-isolated` takes them down, and
-`make clean-isolated-all` does so for every worktree of the repository. A failing run
-whose log shows a `d3d9.dll v` stamp that is not your checkout's is that
-collision, not a regression.
+points the tools, the install and the prefix at the clones. Each clone is one
+`clonefile(2)` on the directory (the Makefile's `clone_tree`), so it costs a
+call rather than a walk of the file count, and falls back to `cp -c -R` and then
+to `cp -R` when the source sits on another volume or on a volume that is not
+APFS. Use it whenever another worktree may be testing or a game is running; a
+plain `make install` still targets the shared trees on purpose, since that is
+how the game gets a build. The clones and the persistent wineserver of the
+private prefix stay behind for the next run; `make clean-isolated` takes them
+down, and `make clean-isolated-all` does so for every worktree of the
+repository. A failing run whose log shows a `d3d9.dll v` stamp that is not your
+checkout's is that collision, not a regression.
 
 Both agent runners configured in this tree already print the conventions digest
 at session start and run `scripts/audit.sh --file` after every edit, so a

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,24 @@ ifndef WINE_SDK
 $(error WINE_SDK is not set)
 endif
 
+# Clone the directory tree $(1) to $(2), cheapest mechanism first. On one APFS
+# volume clonefile(2) takes a directory and clones the whole hierarchy in a
+# single call, so the cost is the call and not the file count, where `cp -c -R`
+# asks for a clone per file and pays for the walk: 12 GB over 88000 files is
+# under a second against eleven. No stock command line tool exposes the
+# directory form, hence python3 and ctypes. A source on another volume fails
+# with EXDEV and one on a volume that is not APFS cannot clone at all, which is
+# what the two `cp` fallbacks are for, the second of them copying the bytes.
+# Prints nothing on stdout, so `$(shell ...)` can call it.
+define clone_tree
+{ mkdir -p $$(dirname $(2)) && { python3 -c 'import ctypes, sys; lib = ctypes.CDLL("/usr/lib/libSystem.B.dylib"); lib.clonefile.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint32); sys.exit(0 if lib.clonefile(sys.argv[1].encode(), sys.argv[2].encode(), 0) == 0 else 1)' $(1) $(2) 2>/dev/null || { rm -rf $(2); cp -c -R $(1) $(2) 2>/dev/null; } || { rm -rf $(2); cp -R $(1) $(2); }; }; }
+endef
+
 # ISOLATED=1 runs every install-bearing target against a private clone of the
 # Wine SDK inside this checkout: the SDK the tools come from, the tree the
 # builds install into and the prefix the tests boot all move under
 # `.wine-isolated`, so parallel worktrees, and the game bundle a maintainer is
-# playing from, never see each other's builds. APFS clones both trees for free
+# playing from, never see each other's builds. `clone_tree` seeds both for free
 # on the same volume: the SDK from `WINE_SDK`, the prefix from the ambient
 # `WINEPREFIX` (or `~/.wine`) so no prefix boots from scratch; each clone is
 # made once and reused, and `clean-isolated` removes them. Without the knob,
@@ -15,8 +28,8 @@ endif
 ISOLATED_ROOT := $(CURDIR)/.wine-isolated
 ifeq ($(ISOLATED),1)
 ISOLATED_PREFIX_SOURCE := $(or $(WINEPREFIX),$(HOME)/.wine)
-$(shell [ -d $(ISOLATED_ROOT)/sdk ] || { mkdir -p $(ISOLATED_ROOT) && { cp -c -R $(WINE_SDK) $(ISOLATED_ROOT)/sdk 2>/dev/null || { rm -rf $(ISOLATED_ROOT)/sdk && cp -R $(WINE_SDK) $(ISOLATED_ROOT)/sdk; }; }; })
-$(shell [ -d $(ISOLATED_ROOT)/prefix ] || [ ! -d $(ISOLATED_PREFIX_SOURCE) ] || { cp -c -R $(ISOLATED_PREFIX_SOURCE) $(ISOLATED_ROOT)/prefix 2>/dev/null || { rm -rf $(ISOLATED_ROOT)/prefix && cp -R $(ISOLATED_PREFIX_SOURCE) $(ISOLATED_ROOT)/prefix; }; })
+$(shell [ -d $(ISOLATED_ROOT)/sdk ] || $(call clone_tree,$(WINE_SDK),$(ISOLATED_ROOT)/sdk))
+$(shell [ -d $(ISOLATED_ROOT)/prefix ] || [ ! -d $(ISOLATED_PREFIX_SOURCE) ] || $(call clone_tree,$(ISOLATED_PREFIX_SOURCE),$(ISOLATED_ROOT)/prefix))
 WINE_SDK := $(ISOLATED_ROOT)/sdk
 WINE_INSTALL_DIR := $(ISOLATED_ROOT)/sdk
 export WINEPREFIX := $(ISOLATED_ROOT)/prefix


### PR DESCRIPTION
## Symptoms

`ISOLATED=1` seeds `.wine-isolated/sdk` and `.wine-isolated/prefix` with `cp -c -R`, and the cost scales with the number of files rather than the number of bytes. On this machine the two trees (1.2 GB over 3753 files, 1 GB over 1795 files) take 0.54 s, and the same mechanism applied to a cargo target directory (12 GB over 88000 files) takes 11 s, which is what makes seeding a worktree slow.

## Root cause

`cp -c` asks copyfile(3) for a clone, but copyfile(3) walks the hierarchy and issues one clonefile(2) per file. clonefile(2) itself accepts a directory and clones the whole hierarchy in a single call when source and destination are on the same APFS volume, so the walk is avoidable. No stock command line tool exposes the directory form.

## Changes

Makefile: a `clone_tree` function clones a directory tree, cheapest mechanism first. It makes the directory-level clonefile(2) call through python3's ctypes against libSystem, and falls back to `cp -c -R` and then to a plain `cp -R` when the call fails, which is what happens for a source on another volume (EXDEV) or on a volume that is not APFS. It prints nothing on stdout so a `$(shell ...)` can call it, and it creates the destination's parent. The two `$(shell ...)` seeding lines under `ifeq ($(ISOLATED),1)` call it instead of carrying the fallback chain inline. Everything else about the knob is unchanged: each clone is made once and reused, and `clean-isolated` removes them.

CONTRIBUTING.md: the paragraph describing `make test ISOLATED=1` names the mechanism and its fallbacks.

## Alternatives

Keep `cp -c -R`: rejected, it is the walk that costs, and the same helper is what a worktree-seeding script outside the repository needs for the target directories.

Put the helper in `scripts/`: rejected, the Makefile is the only caller in this repository, so a make function keeps the mechanism and its one use site together.

`ditto` or `rsync`: rejected, neither exposes a directory-level clone, so both pay the same per-file walk.

## Verification

`make check` green. `make ISOLATED=1 test` green: 1053 native unit tests plus 253 unix unit tests passed, and the end-to-end suite reports 454 PASS, 0 FAIL, 0 SKIP on each of i686 and x86_64 (908 PASS lines, no SIGABRT, no TIMEOUT), 3 processes per architecture.

Build tooling carries no test in either suite, so the seeding itself was exercised by hand. `make clean-isolated` followed by `make ISOLATED=1 test-unit` re-creates both clones: the SDK clone has the same 3836 entries as `WINE_SDK` (`find | sort` diffs clean) and the prefix clone the same 1964, and make's parse plus both clones takes 0.20 s where the two `cp -c -R` calls alone take 0.54 s. Each fallback leg was forced with a shim earlier on `PATH`: with `python3` failing, `cp -c -R` seeds both trees to the same entry counts; with `python3` and `cp -c` both failing, `cp -R` does. A second `make ISOLATED=1` over existing clones leaves a marker file inside `.wine-isolated/sdk` in place, so reuse still short-circuits the clone.

Closes #412
