### PR TITLE
Mark a texture upload dirty again when the encoder emits nothing

### DIFF
--- a/scripts/derive_inventory.txt
+++ b/scripts/derive_inventory.txt
@@ -170,6 +170,7 @@ windows/core/src/texture_staging.rs MipShape Debug,Clone,Copy,PartialEq,Eq
 windows/core/src/texture_staging.rs PreserveKind Debug,Clone,Copy,PartialEq,Eq
 windows/core/src/upload_pass.rs UploadDecode Clone,Copy,Debug,PartialEq,Eq
 windows/core/src/upload_recovery.rs UploadFate Clone,Copy,Debug,PartialEq,Eq
+windows/core/src/upload_redirty.rs RedirtySubresource Clone,Copy,PartialEq,Eq,Hash,Debug
 windows/core/src/visibility.rs QueryStatus Clone,Copy,Debug,PartialEq,Eq
 windows/d3d9/src/cursor.rs CursorFlags Clone,Copy,Debug,Default,PartialEq,Eq
 windows/d3d9/src/device.rs DepthBinding Clone

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -1356,6 +1356,17 @@ impl CopyRejectReason {
         self as u64
     }
 
+    /// Per-destination key so the warn fires once per reason and destination.
+    ///
+    /// A texture upload that this rejects is one texture's pixels, and a
+    /// single key for the whole process names the first texture to hit the
+    /// reason and hides every other one. Metal object addresses are at least
+    /// 8-byte aligned and the discriminant is under 8, so the low bits carry
+    /// it without ever colliding with another destination.
+    const fn key_at(self, destination: u64) -> u64 {
+        destination ^ (self as u64)
+    }
+
     const fn as_str(self) -> &'static str {
         match self {
             Self::FormatMismatch => "source and destination pixel formats are incompatible",
@@ -1782,7 +1793,7 @@ fn encode_leading_blits(
                     let dst_handle = cmd.dst_handle;
                     mtld3d_shared::log_once_warn_by!(
                         target: crate::LOG_TARGET,
-                        key: reason.key(),
+                        key: reason.key_at(dst_handle),
                         "encode_leading_blits: {reason_text}, upload skipped. \
                          src handle={src_handle:#x} {source}, \
                          dst handle={dst_handle:#x} {destination}, \

--- a/windows/core/src/lib.rs
+++ b/windows/core/src/lib.rs
@@ -57,5 +57,6 @@ pub mod texture_flags;
 pub mod texture_staging;
 pub mod upload_pass;
 pub mod upload_recovery;
+pub mod upload_redirty;
 pub mod visibility;
 pub mod vs_draw;

--- a/windows/core/src/upload_redirty.rs
+++ b/windows/core/src/upload_redirty.rs
@@ -1,0 +1,179 @@
+//! Uploads the encoder never emitted, on their way back into the dirty state.
+//!
+//! A texture upload is scheduled on the API thread: the flush takes the
+//! level's dirty bit and its pending rect, builds a job and hands it to the
+//! encoder thread. Every step past that hand-off can still decline to emit
+//! anything: the destination texture may fail to create, the staging wrapper
+//! may fail, a padded repack may fail, and a texel-widening expansion has no
+//! blit that could stand in for the pass it needs. The dirty state is already
+//! gone by then, and `UnlockRect` publishes only the rectangle the game
+//! locked, so nothing re-announces the region: the mip keeps whatever it held
+//! until the game happens to write those texels again.
+//!
+//! This queue closes that gap. The encoder records the subresource and the
+//! rectangle of every upload it did not emit; the API thread drains the queue
+//! once a frame and marks each one dirty again, so the next bind retries.
+//! Retries are bounded per subresource, because a decline with a permanent
+//! cause repeats on every attempt and an unbounded retry would schedule a
+//! failing upload on every draw that binds the texture.
+//!
+//! Pure bookkeeping: no Metal handles, no D3D9 objects, so the whole contract
+//! is host-testable.
+
+use std::sync::{
+    Mutex,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+use rustc_hash::FxHashMap;
+
+use crate::{dirty_rect::DirtyRect, ids::TextureId};
+
+/// Times one subresource is re-marked dirty before the layer stops retrying.
+///
+/// A transient decline (an allocation that failed under memory pressure)
+/// clears well inside this; a permanent one (a pipeline the device will
+/// never compile) does not, and retrying it forever would cost a scheduled
+/// upload on every draw that binds the texture for the rest of the run.
+pub const MAX_REDIRTY_ATTEMPTS: u32 = 4;
+
+/// The subresource an upload writes.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct RedirtySubresource {
+    /// The texture the upload belongs to.
+    pub texture_id: TextureId,
+    /// Index into the texture's per-subresource storage.
+    ///
+    /// The mip level for a 2D or volume texture, the cube subresource index
+    /// for a cube face level. It is the index the scheduler already carries
+    /// on the job, so no side table has to agree with it.
+    pub index: u32,
+}
+
+/// One upload that reached no command buffer.
+#[derive(Debug)]
+pub struct RedirtyEntry {
+    /// What the upload was writing.
+    pub subresource: RedirtySubresource,
+    /// Cube face the upload targeted; zero for every other texture kind.
+    pub face: u32,
+    /// Mip level the upload targeted.
+    pub level: u32,
+    /// Region of the level the upload was carrying.
+    pub rect: DirtyRect,
+}
+
+/// Declined uploads, filled on the encoder thread and drained on the API thread.
+///
+/// Both counters exist so the two hot callers stay off the lock. The API
+/// thread's drain reads `pending` once a frame and returns on a clear flag;
+/// the encoder's acknowledgement of an emitted upload reads `tracked` and
+/// returns while no subresource carries a decline record, which is the whole
+/// of a run that never declines an upload.
+pub struct RedirtyQueue {
+    /// Set while `pending` holds an entry.
+    pending: AtomicBool,
+    /// Subresources currently carrying an attempt count.
+    tracked: AtomicUsize,
+    inner: Mutex<RedirtyInner>,
+}
+
+struct RedirtyInner {
+    pending: Vec<RedirtyEntry>,
+    attempts: FxHashMap<RedirtySubresource, u32>,
+}
+
+impl RedirtyQueue {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            pending: AtomicBool::new(false),
+            tracked: AtomicUsize::new(0),
+            inner: Mutex::new(RedirtyInner {
+                pending: Vec::new(),
+                attempts: FxHashMap::default(),
+            }),
+        }
+    }
+
+    /// Record an upload the encoder did not emit; report whether it will be retried.
+    ///
+    /// `false` means the subresource has spent its budget: the caller warns
+    /// and the region stays as the texture holds it. The entry is not queued
+    /// in that case, so a spent subresource costs nothing per attempt beyond
+    /// the lookup.
+    ///
+    /// # Panics
+    ///
+    /// If a previous caller panicked while holding the queue's lock.
+    pub fn decline(&self, entry: RedirtyEntry) -> bool {
+        let (retry, tracked) = {
+            let mut inner = self.inner.lock().expect("redirty queue mutex poisoned");
+            let attempts = inner.attempts.entry(entry.subresource).or_insert(0);
+            *attempts += 1;
+            let retry = *attempts <= MAX_REDIRTY_ATTEMPTS;
+            if retry {
+                inner.pending.push(entry);
+            }
+            (retry, inner.attempts.len())
+        };
+        self.tracked.store(tracked, Ordering::Relaxed);
+        if retry {
+            self.pending.store(true, Ordering::Release);
+        }
+        retry
+    }
+
+    /// Forget a subresource's attempt count after an upload of it was emitted.
+    ///
+    /// The budget counts consecutive declines, so an upload that reached the
+    /// command stream gives the subresource its full budget back: a decline
+    /// under transient memory pressure must not spend a texture's retries for
+    /// the rest of the run.
+    ///
+    /// # Panics
+    ///
+    /// If a previous caller panicked while holding the queue's lock.
+    pub fn note_emitted(&self, subresource: RedirtySubresource) {
+        if self.tracked.load(Ordering::Relaxed) == 0 {
+            return;
+        }
+        let tracked = {
+            let mut inner = self.inner.lock().expect("redirty queue mutex poisoned");
+            if inner.attempts.remove(&subresource).is_none() {
+                return;
+            }
+            inner.attempts.len()
+        };
+        self.tracked.store(tracked, Ordering::Relaxed);
+    }
+
+    /// Take every upload waiting to be marked dirty again.
+    ///
+    /// # Panics
+    ///
+    /// If a previous caller panicked while holding the queue's lock.
+    #[must_use]
+    pub fn take_pending(&self) -> Vec<RedirtyEntry> {
+        if !self.pending.swap(false, Ordering::Acquire) {
+            return Vec::new();
+        }
+        let mut inner = self.inner.lock().expect("redirty queue mutex poisoned");
+        core::mem::take(&mut inner.pending)
+    }
+
+    /// Whether a drain would find anything.
+    #[must_use]
+    pub fn has_pending(&self) -> bool {
+        self.pending.load(Ordering::Acquire)
+    }
+}
+
+impl Default for RedirtyQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/windows/core/src/upload_redirty/tests.rs
+++ b/windows/core/src/upload_redirty/tests.rs
@@ -1,0 +1,111 @@
+use super::{MAX_REDIRTY_ATTEMPTS, RedirtyEntry, RedirtyQueue, RedirtySubresource};
+use crate::{dirty_rect::DirtyRect, ids::TextureId};
+
+fn subresource(index: u32) -> RedirtySubresource {
+    RedirtySubresource {
+        texture_id: TextureId::new_unique(),
+        index,
+    }
+}
+
+fn entry(subresource: RedirtySubresource, rect: DirtyRect) -> RedirtyEntry {
+    RedirtyEntry {
+        subresource,
+        face: 0,
+        level: subresource.index,
+        rect,
+    }
+}
+
+#[test]
+fn a_fresh_queue_has_nothing_to_drain() {
+    let queue = RedirtyQueue::new();
+    assert!(!queue.has_pending());
+    assert!(queue.take_pending().is_empty());
+}
+
+#[test]
+fn a_declined_upload_comes_back_with_its_rect() {
+    let queue = RedirtyQueue::new();
+    let sub = subresource(2);
+    let rect = DirtyRect {
+        x: 16,
+        y: 8,
+        w: 32,
+        h: 4,
+    };
+    assert!(queue.decline(entry(sub, rect)));
+    assert!(queue.has_pending());
+
+    let drained = queue.take_pending();
+    assert_eq!(drained.len(), 1);
+    assert_eq!(drained[0].subresource, sub);
+    assert_eq!(drained[0].level, 2);
+    assert_eq!(drained[0].rect, rect);
+    assert!(!queue.has_pending());
+    assert!(queue.take_pending().is_empty());
+}
+
+#[test]
+fn every_declined_subresource_is_reported_separately() {
+    let queue = RedirtyQueue::new();
+    let first = subresource(0);
+    let second = subresource(1);
+    assert!(queue.decline(entry(first, DirtyRect::full(8, 8))));
+    assert!(queue.decline(entry(second, DirtyRect::full(4, 4))));
+
+    let drained = queue.take_pending();
+    assert_eq!(drained.len(), 2);
+    assert_eq!(drained[0].subresource, first);
+    assert_eq!(drained[1].subresource, second);
+}
+
+#[test]
+fn a_subresource_that_keeps_declining_stops_being_retried() {
+    let queue = RedirtyQueue::new();
+    let sub = subresource(0);
+    let rect = DirtyRect::full(16, 16);
+    for _ in 0..MAX_REDIRTY_ATTEMPTS {
+        assert!(queue.decline(entry(sub, rect)));
+    }
+    assert!(!queue.decline(entry(sub, rect)));
+
+    let drained = queue.take_pending();
+    assert_eq!(drained.len(), MAX_REDIRTY_ATTEMPTS as usize);
+}
+
+#[test]
+fn the_budget_is_per_subresource() {
+    let queue = RedirtyQueue::new();
+    let spent = subresource(0);
+    let fresh = subresource(1);
+    let rect = DirtyRect::full(16, 16);
+    for _ in 0..=MAX_REDIRTY_ATTEMPTS {
+        queue.decline(entry(spent, rect));
+    }
+    assert!(!queue.decline(entry(spent, rect)));
+    assert!(queue.decline(entry(fresh, rect)));
+}
+
+#[test]
+fn an_emitted_upload_gives_the_subresource_its_budget_back() {
+    let queue = RedirtyQueue::new();
+    let sub = subresource(0);
+    let rect = DirtyRect::full(16, 16);
+    for _ in 0..MAX_REDIRTY_ATTEMPTS {
+        assert!(queue.decline(entry(sub, rect)));
+    }
+    assert!(!queue.decline(entry(sub, rect)));
+
+    queue.note_emitted(sub);
+    assert!(queue.decline(entry(sub, rect)));
+}
+
+#[test]
+fn acknowledging_an_untouched_subresource_changes_nothing() {
+    let queue = RedirtyQueue::new();
+    let sub = subresource(0);
+    queue.note_emitted(sub);
+    assert!(!queue.has_pending());
+    assert!(queue.decline(entry(sub, DirtyRect::full(2, 2))));
+}

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -33,6 +33,7 @@ use mtld3d_core::{
     readback::{ReadbackDestination, ReadbackReject, ReadbackSource},
     streams::validate_stream_freq,
     texture_flags::TextureFlags,
+    upload_redirty::RedirtyQueue,
 };
 use mtld3d_shared::{
     BlitTextureToBufferParams, CreateColorTargetParams, CreateDepthTextureParams,
@@ -667,6 +668,16 @@ pub struct DeviceInner {
     /// create, release and Evict run one at a time, on the API thread or
     /// serialised by the device `ApiLock` under `D3DCREATE_MULTITHREADED`.
     live_textures: Mutex<Vec<*mut TextureInner>>,
+    /// Uploads the encoder emitted nothing for, waiting to be marked dirty again.
+    ///
+    /// The bind-time flush clears a level's dirty bit and takes its pending
+    /// rectangle before the job crosses to the encoder thread, and
+    /// `UnlockRect` publishes only the rectangle the game locked, so a
+    /// decline downstream of the hand-off would otherwise leave the region
+    /// unannounced for the rest of the run. The encoder files the
+    /// subresource and its rectangle here; [`Self::apply_upload_redirty`]
+    /// drains the queue once a frame and marks them dirty again.
+    upload_redirty: Arc<RedirtyQueue>,
     /// Per-draw snapshot dirty-bitmask.
     ///
     /// Each bit marks one `CurrentSnapshot` piece as needing rebuild on the
@@ -1814,6 +1825,7 @@ impl DeviceInner {
         // Both `IDirect3DDevice9::Present` and the swap chain's land here, so
         // the diagnostics that run once per frame poll from this point.
         crate::capture::poll();
+        self.apply_upload_redirty();
         let (frame, seq) = self.stamp_and_swap(new_frame, false);
 
         // The block we measure belongs to the frame that will next be
@@ -2033,6 +2045,66 @@ impl DeviceInner {
         mtld3d_shared::log_once_info!(
             target: TEX_TRACE_TARGET,
             "EvictManagedResources: marked {evicted_count} textures dirty (cache eviction queued)"
+        );
+    }
+
+    /// The queue an upload job reports a failed emission to.
+    ///
+    /// Cloned onto every `TextureUploadJob`, so a job that emits nothing
+    /// names the device whose textures it belongs to without the encoder
+    /// having to track which device it is draining for.
+    pub fn upload_redirty(&self) -> Arc<RedirtyQueue> {
+        Arc::clone(&self.upload_redirty)
+    }
+
+    /// Mark every upload the encoder emitted nothing for dirty again.
+    ///
+    /// Runs once per `Present`, before the frame is stamped, so the next
+    /// frame's bind-time flush re-schedules the region. A texture released
+    /// between the decline and this drain has left the registry, and its
+    /// entries are dropped with it.
+    fn apply_upload_redirty(&self) {
+        if !self.upload_redirty.has_pending() {
+            return;
+        }
+        let entries = self.upload_redirty.take_pending();
+        if entries.is_empty() {
+            return;
+        }
+        let live: Vec<*mut TextureInner> = self
+            .live_textures
+            .lock()
+            .expect("live_textures mutex poisoned")
+            .clone();
+        let by_id: rustc_hash::FxHashMap<TextureId, *mut TextureInner> = live
+            .into_iter()
+            .map(|ptr| {
+                // SAFETY: `ptr` is a snapshot from `live_textures`; entries
+                // are removed before the `TextureInner` Box is freed, and
+                // nothing frees one while the API thread runs this.
+                let id = unsafe { &*ptr }.texture_id();
+                (id, ptr)
+            })
+            .collect();
+        let mut restored = 0u32;
+        for entry in &entries {
+            let Some(&ptr) = by_id.get(&entry.subresource.texture_id) else {
+                continue;
+            };
+            // SAFETY: same contract as the map build above.
+            let ti = unsafe { &mut *ptr };
+            crate::texture::redirty_declined_upload(
+                ti,
+                entry.face,
+                entry.level as usize,
+                entry.rect,
+            );
+            restored += 1;
+        }
+        mtld3d_shared::log_once_info!(
+            target: TEX_TRACE_TARGET,
+            "upload redirty: {restored} of {} declined uploads marked dirty again",
+            entries.len()
         );
     }
 
@@ -2736,6 +2808,7 @@ impl Direct3DDevice9 {
             cur_autogen_rt_ids: [None; RENDER_TARGET_SLOTS],
             last_depth_binding: None,
             live_textures: Mutex::new(Vec::new()),
+            upload_redirty: Arc::new(RedirtyQueue::new()),
             snapshot_dirty: SnapshotDirty::all(),
             snapshot_cache: CurrentSnapshot::EMPTY,
             frame_dump: frame_dump::FrameDump::IDLE,

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -18,6 +18,7 @@ use mtld3d_core::{
     config::Mtld3dConfig,
     convert::{FAN_PATTERN_MAX_TRIANGLES, fan_pattern_bytes, fill_fan_pattern_u16},
     depth_stencil_state::{DepthStencilSnapshot, key_from_snapshot, params_from_snapshot},
+    dirty_rect::DirtyRect,
     dxso::{
         DxsoProgram, FfPsKey, FfVsKey, LOG_TARGET as MSL_TRACE_TARGET, VariantKey, VsSamplerKinds,
         declared_ps_samplers, emit_ps_ff_named, emit_ps_programmable_named, emit_vs_ff_named,
@@ -46,6 +47,7 @@ use mtld3d_core::{
     stretch_rect::StretchRegion,
     upload_pass::UploadDecode,
     upload_recovery::{UploadFate, UploadRecoveryQueue},
+    upload_redirty::{RedirtyEntry, RedirtyQueue, RedirtySubresource},
     visibility::{
         MAX_SLOTS, RetiredVisibilityBuffer, SLOT_BYTES, VisibilityQueryCore, VisibilityQueryState,
     },
@@ -350,6 +352,66 @@ pub struct TextureUploadJob {
     /// single-slice `bytes_per_image` from the region's block-row count
     /// instead.
     pub slice_pitch: u32,
+    /// Where a job that emits nothing reports itself.
+    ///
+    /// The dirty state this upload was built from is already cleared when
+    /// the encoder thread sees the job, so a decline that stayed on this
+    /// thread would lose the region: `UnlockRect` publishes only the
+    /// rectangle the game locked and nothing re-announces the rest. The
+    /// queue carries the subresource and the rectangle back to the API
+    /// thread, which marks them dirty again for the next bind.
+    pub redirty: Arc<RedirtyQueue>,
+}
+
+impl TextureUploadJob {
+    /// The subresource key this job's decline record is filed under.
+    fn redirty_subresource(&self) -> RedirtySubresource {
+        RedirtySubresource {
+            texture_id: self.info.texture_id,
+            index: u32::try_from(self.staging_index).unwrap_or(u32::MAX),
+        }
+    }
+
+    /// The region this job was carrying, as a dirty rectangle.
+    const fn redirty_rect(&self) -> DirtyRect {
+        DirtyRect {
+            x: self.origin_x,
+            y: self.origin_y,
+            w: self.region_w,
+            h: self.region_h,
+        }
+    }
+}
+
+/// Hand an upload the encoder emitted nothing for back to the API thread.
+///
+/// The scheduler cleared the subresource's dirty bit and took its pending
+/// rectangle before the job crossed to this thread, so without this the
+/// region is lost: `UnlockRect` publishes only the rectangle the game
+/// locked, and nothing re-announces the rest until the game writes those
+/// texels again. The queue carries the rectangle back and the next bind
+/// retries. `reason` names the emit path that produced nothing, so a
+/// subresource that spends its retry budget says which one on the way out.
+fn decline_texture_upload(job: &TextureUploadJob, reason: &str) {
+    let subresource = job.redirty_subresource();
+    let entry = RedirtyEntry {
+        subresource,
+        face: job.destination_slice,
+        level: job.level,
+        rect: job.redirty_rect(),
+    };
+    if job.redirty.decline(entry) {
+        return;
+    }
+    mtld3d_shared::log_once_warn_by!(
+        target: LOG_TARGET,
+        key: subresource.texture_id.raw(),
+        "run_texture_upload: texture {:#x} subresource {} has declined its upload \
+         {} times ({reason}); the region keeps whatever the texture holds",
+        subresource.texture_id.raw(),
+        subresource.index,
+        mtld3d_core::upload_redirty::MAX_REDIRTY_ATTEMPTS,
+    );
 }
 
 /// Per-mip `MTLBuffer` wrapper for texture staging.
@@ -6315,10 +6377,20 @@ impl FrameEncoder {
                         entry.attempts(),
                     );
                 }
-                // Acknowledged, or the game released the texture so the
-                // replay had no destination: dropping the job releases the
-                // staging Arc clone, which is all the entry owns.
-                UploadFate::Released | UploadFate::Reissue => {}
+                // The replay emitted nothing: the game released the
+                // texture, or the blit path declined it. Report it so the
+                // API thread restores the mip's dirty state and the next
+                // bind schedules the upload again; an entry naming a
+                // texture that is gone is dropped at the drain.
+                UploadFate::Reissue => {
+                    decline_texture_upload(
+                        entry.payload(),
+                        "the aborted-submit replay emitted nothing",
+                    );
+                }
+                // Acknowledged: dropping the job releases the staging Arc
+                // clone, which is all the entry owns.
+                UploadFate::Released => {}
             }
         }
     }
@@ -6604,7 +6676,13 @@ impl FrameEncoder {
     pub fn run_texture_upload(&mut self, job: TextureUploadJob) {
         let mut handle = self.get_or_create_texture(&job.info);
         if handle == 0 {
-            error!(target: LOG_TARGET, "run_texture_upload: texture handle creation failed");
+            mtld3d_shared::log_once_warn_by!(
+                target: LOG_TARGET,
+                key: job.info.texture_id.raw(),
+                "run_texture_upload: texture {:#x} handle creation failed",
+                job.info.texture_id.raw(),
+            );
+            decline_texture_upload(&job, "no destination texture");
             return;
         }
         // Per-draw texture versioning: this blit lands in the frame-head
@@ -6643,6 +6721,7 @@ impl FrameEncoder {
             } else {
                 handle = self.rename_sampled_texture(&job, handle);
                 if handle == 0 {
+                    decline_texture_upload(&job, "the sampled-texture rename found no destination");
                     return;
                 }
             }
@@ -6655,6 +6734,10 @@ impl FrameEncoder {
             self.run_texture_upload_blit(&job, handle)
         };
         if emitted {
+            // The subresource reached the command stream, so its decline
+            // record (if it had one) has served its purpose and its retry
+            // budget goes back.
+            job.redirty.note_emitted(job.redirty_subresource());
             // Keep the job so an aborted upload command buffer can replay
             // it. It only holds a clone of the texture's own persistent
             // staging Arc, so the memory cost is the clone.
@@ -6663,6 +6746,8 @@ impl FrameEncoder {
                 self.current_submit_seq,
                 job,
             );
+        } else {
+            decline_texture_upload(&job, "the blit path emitted nothing");
         }
     }
 
@@ -7097,10 +7182,13 @@ impl FrameEncoder {
             return Some(true);
         }
         if mtld3d_core::upload_pass::is_expansion(decode) {
-            mtld3d_shared::log_once_warn!(
+            mtld3d_shared::log_once_warn_by!(
                 target: LOG_TARGET,
-                "run_texture_upload: the upload pass declined a texel-widening expansion; no \
-                 blit can widen those texels, so the mip keeps its previous contents",
+                key: job.info.texture_id.raw(),
+                "run_texture_upload: the upload pass declined a texel-widening expansion for \
+                 texture {:#x}; no blit can widen those texels, so the mip keeps its previous \
+                 contents until the upload is retried",
+                job.info.texture_id.raw(),
             );
             return Some(false);
         }

--- a/windows/d3d9/src/texture.rs
+++ b/windows/d3d9/src/texture.rs
@@ -423,6 +423,11 @@ pub fn is_dropped_staging_page(bits: *const u8) -> bool {
 }
 
 impl TextureInner {
+    /// Process-unique id of the texture this inner belongs to.
+    pub const fn texture_id(&self) -> TextureId {
+        self.texture_id
+    }
+
     /// D3DPOOL_* the texture was created in.
     pub const fn d3d_pool(&self) -> u32 {
         self.d3d_pool
@@ -4058,6 +4063,7 @@ pub fn schedule_upload(ti: &mut TextureInner, dev: &mut DeviceInner, level: u32,
         bytes_per_pixel: ti.bytes_per_pixel,
         depth: (ti.depth >> level).max(1),
         slice_pitch,
+        redirty: dev.upload_redirty(),
     };
     let texture_id = ti.texture_id;
     let regen_mipmaps = ti.autogen_mipmap() && level == 0;
@@ -4133,10 +4139,29 @@ fn schedule_cube_upload(
         bytes_per_pixel: ti.bytes_per_pixel,
         depth: 1,
         slice_pitch,
+        redirty: dev.upload_redirty(),
     };
     dev.push_op(Box::new(move |enc: &mut FrameEncoder| {
         enc.run_texture_upload(job);
     }));
+}
+
+/// Re-mark a subresource whose upload the encoder emitted nothing for.
+///
+/// The bind-time flush takes a level's dirty bit and its pending rectangle
+/// before the job crosses to the encoder thread, so an upload that reaches no
+/// command buffer leaves the region unannounced: `UnlockRect` publishes only
+/// the rectangle the game locked, and the level is not re-announced until the
+/// game writes those texels again. Restoring the dirty state here makes the
+/// next bind retry the upload. The rectangle unions with anything the game
+/// has written since, and a write that already covers the level keeps it
+/// whole, so the retry never narrows what was going to be uploaded anyway.
+pub fn redirty_declined_upload(ti: &mut TextureInner, face: u32, level: usize, rect: DirtyRect) {
+    if ti.flags.contains(TextureFlags::CUBE) {
+        ti.mark_cube_written_region(face, level, rect);
+    } else {
+        ti.mark_written_region(level, rect);
+    }
 }
 
 /// Mark every previously-uploaded mip dirty for the next bind-time `flush_dirty_mips`.


### PR DESCRIPTION
## Symptoms

A texture region a game writes once can stay missing for the rest of the run. The layer logs one of the encoder-side declines and then never re-announces the region, so the mip keeps whatever it held: `run_texture_upload: texture handle creation failed`, `run_texture_upload: the upload pass declined a texel-widening expansion; no blit can widen those texels, so the mip keeps its previous contents`, or, from the unix side, `encode_leading_blits: the region leaves the destination mip level, upload skipped.`

The unix-side line also fired once per rejection reason for the whole process, so the second texture to hit a reason was invisible in the log.

## Root cause

`flush_dirty_mips_slow` clears the level's bit in `dirty_mask` and `take()`s `pending_upload_rects[level]` before `schedule_upload` builds the job, and the job then crosses to the encoder thread. Everything past that hand-off can still decline to emit anything: `run_texture_upload` returns on a null texture handle and on a rename that found no destination, `run_texture_upload_blit` returns false on an empty backing, a null staging wrapper or a failed padded repack, `try_texture_upload_pass` returns `Some(false)` for a declined expansion, and `settle_texture_uploads` frees a replay entry whose re-issue emitted nothing.

The dirty state is gone by then. `UnlockRect` publishes only the rectangle the game locked, so nothing re-announces the region until the game happens to write those texels again; a whole-level republish (managed eviction, device rehydrate) pushes whatever the staging holds rather than the lost write. Before the lock-semantics change that narrowed Unlock to the locked rectangle, the next non-READONLY Unlock republished the whole mip and healed every one of these.

## Changes

`mtld3d-core` gains `upload_redirty`, a queue of uploads the encoder emitted nothing for: the subresource, the cube face and level, and the rectangle the job was carrying. The encoder thread files entries, the API thread drains them. Retries are bounded per subresource (`MAX_REDIRTY_ATTEMPTS`), because a decline with a permanent cause repeats on every attempt and an unbounded retry would schedule a failing upload on every draw that binds the texture; an upload that does reach the command stream returns the subresource's budget. Both hot callers gate on an atomic, so a run that never declines an upload never takes the lock.

`TextureUploadJob` carries a clone of the queue, which is how a job names the device its texture belongs to without the encoder tracking that itself. `run_texture_upload` reports every path that emits nothing and acknowledges every path that does; `settle_texture_uploads` reports a replay that emitted nothing the same way.

`DeviceInner::present` drains the queue before it stamps the frame, resolves each entry against the live-texture registry and restores the subresource's dirty state through the same `mark_written_region` / `mark_cube_written_region` the write path uses, so the rectangle unions with anything written since and a covering write keeps the level whole. A texture released between the decline and the drain has left the registry and its entries are dropped with it.

The encoder-side failure logs are now keyed per texture rather than per call site, and the unix-side `upload skipped` warn is keyed per rejection reason and destination texture.

## Alternatives

Acknowledge every emitted upload and clear the dirty state only on the acknowledgement: correct, but a level stays dirty until the encoder catches up, so every bind in between schedules the upload again on the hot path.

Re-mark from the encoder thread directly: the API thread owns `TextureInner` and the encoder runs concurrently with it, so there is no sound `&mut` to take.

Reuse `pending_texture_uploads` for the never-emitted case: it is seq-gated on GPU retirement and replays into the encoder's own frame-leading blits, which is the wrong recovery for an upload that reached no command buffer at all.

Wire the unix-side rejection back to the API thread as well: the two reasons a buffer-to-texture copy is rejected there are an out-of-bounds region and a source buffer shorter than the copy reads, both of which are deterministic in the geometry the PE side computed, so a retry reproduces them. Per-texture logging is what makes those diagnosable; the geometry itself is a separate defect if it ever fires.

Force a decline from an end-to-end test: every decline is an internal allocation or pipeline failure with no D3D9 call that provokes it, and a fault-injection knob is a config key this change has no other need for.

## Verification

`make check` green (fmt, clippy nursery + pedantic denied on both PE targets and native, audit including the derive inventory, doc).

`make ISOLATED=1 test` green: 1060 native unit tests passed, 253 unix unit tests passed, and the end-to-end suite reported `454 tests: 454 passed, 0 failed, 0 ignored, 0 not run; 3 processes` on each of i686 and x86_64.

`make ISOLATED=1 conformance` reports no regressions against the baseline on either architecture; every site that moved is a `ceiling` or `flaky` count moving down, and no baseline re-record is needed because the change alters only failure paths the suite does not reach.

The pin is `mtld3d-core`'s `upload_redirty::tests`, seven tests over the bookkeeping this change adds: a declined upload comes back with its rectangle and its subresource, a drain empties the queue, declines from different subresources are reported separately, a subresource that keeps declining stops being retried after `MAX_REDIRTY_ATTEMPTS`, the budget is per subresource, and an emitted upload gives the subresource its budget back. All seven fail before the change (the queue that carries a declined upload back to the dirty state does not exist) and pass after.

Closes #347
