### PR TITLE
Carry a discarded frame's GPU-capture marks onto its replacement

### DIFF
--- a/windows/core/src/present.rs
+++ b/windows/core/src/present.rs
@@ -53,5 +53,21 @@ pub const fn capture_marks(index: u32, total: u32) -> (bool, bool) {
     (index == 1, index == total)
 }
 
+/// The capture marks a swapped-out frame hands to the frame replacing it.
+///
+/// A run ends with the frame the closing `Present` submits, so a swap that
+/// does not present passes the run's stop to the continuation; left behind,
+/// the encoder never sees it and the capture ends only with the process.
+/// `submitted` says whether the outgoing frame still reaches the encoder,
+/// which is what decides the start: a mid-frame flush keeps it with the piece
+/// it sends, while a swap that drops its frame hands it on too, or the
+/// capture never opens. Marks are `(start, stop)` as `capture_marks` returns
+/// them, and the outgoing frame keeps whatever is not handed on.
+#[must_use]
+pub const fn carried_capture_marks(marks: (bool, bool), submitted: bool) -> (bool, bool) {
+    let (start, stop) = marks;
+    (start && !submitted, stop)
+}
+
 #[cfg(test)]
 mod tests;

--- a/windows/core/src/present/tests.rs
+++ b/windows/core/src/present/tests.rs
@@ -62,3 +62,26 @@ fn capture_marks_outside_the_run_carry_nothing() {
     assert_eq!(capture_marks(0, 3), (false, false));
     assert_eq!(capture_marks(4, 3), (false, false));
 }
+
+#[test]
+fn a_submitted_frame_hands_on_the_stop_and_keeps_the_start() {
+    use super::carried_capture_marks;
+    assert_eq!(carried_capture_marks((true, false), true), (false, false));
+    assert_eq!(carried_capture_marks((false, true), true), (false, true));
+    assert_eq!(carried_capture_marks((true, true), true), (false, true));
+}
+
+#[test]
+fn a_dropped_frame_hands_on_every_mark_it_holds() {
+    use super::carried_capture_marks;
+    assert_eq!(carried_capture_marks((false, true), false), (false, true));
+    assert_eq!(carried_capture_marks((true, true), false), (true, true));
+    assert_eq!(carried_capture_marks((true, false), false), (true, false));
+}
+
+#[test]
+fn an_unmarked_frame_hands_on_nothing() {
+    use super::carried_capture_marks;
+    assert_eq!(carried_capture_marks((false, false), true), (false, false));
+    assert_eq!(carried_capture_marks((false, false), false), (false, false));
+}

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -92,8 +92,8 @@ use super::{
         arena_alloc_bytes, build_alpha_ref_bytes, bump_packed_stage_bindings,
     },
     encoder::{
-        BlitSide, ColorFillTarget, EncoderThread, FrameData, FrameDataFlags, FrameEncoder,
-        FrameInit, Op, StagingWarmupEntry, SubmitFence, TextureInfo, VbibWarmupEntry,
+        BlitSide, ColorFillTarget, EncoderThread, FrameData, FrameEncoder, FrameInit, Op,
+        StagingWarmupEntry, SubmitFence, TextureInfo, VbibWarmupEntry,
     },
     index_buffer::{Direct3DIndexBuffer9, IndexBufferCreateInfo},
     null_out,
@@ -1451,18 +1451,10 @@ impl DeviceInner {
         // An F12 run ends with the frame the closing `Present` submits. A
         // mid-frame flush sends the marked frame out early, so its stop mark
         // moves onto the continuation; the start mark stays with the first
-        // piece, the encoder keeps capturing until it sees the stop.
-        // `reseed_current_frame` (Reset) replaces the continuation without
-        // passing through here, so a Reset inside a dumped run drops the
-        // migrated stop and the capture ends with the process instead.
-        if no_present
-            && frame
-                .gpu_capture_marks()
-                .contains(FrameDataFlags::GPU_CAPTURE_STOP)
-        {
-            frame.clear_gpu_capture_stop();
-            self.current_frame
-                .mark_gpu_capture(FrameDataFlags::GPU_CAPTURE_STOP);
+        // piece, and the encoder keeps capturing until it sees the stop.
+        if no_present {
+            let carried = frame.take_carried_capture_marks(true);
+            self.current_frame.mark_gpu_capture(carried);
         }
         // Pre-reserve the new frame's ops Vec to the running peak so
         // it never reallocs in steady-state — and so that a post-burst
@@ -2415,7 +2407,14 @@ impl DeviceInner {
     /// flush baked into `current_frame` and the unix-side `submit_frame`
     /// would dereference the freed `MTLTextures`.
     pub fn reseed_current_frame(&mut self) {
+        // The replaced frame is dropped rather than submitted, so an F12 run
+        // in progress hands its marks to the fresh one: without that the
+        // encoder never sees the run's stop and the capture ends only with
+        // the process. Every reseed follows a flush, which already sent the
+        // start out with the piece it submitted, so this is the stop.
+        let carried = self.current_frame.take_carried_capture_marks(false);
         self.current_frame = self.fresh_frame();
+        self.current_frame.mark_gpu_capture(carried);
         // Reseeding restores the default RT/depth bindings, so any prior
         // explicit `SetDepthStencilSurface(NULL)` override no longer applies.
         self.flags.remove(DeviceFlags::DEPTH_EXPLICITLY_UNBOUND);

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -8188,9 +8188,9 @@ bitflags::bitflags! {
         const GPU_CAPTURE_START = 1 << 2;
         /// Last frame of an F12 run: stop the Metal GPU capture after it.
         ///
-        /// When a mid-frame flush sends the flagged frame out early,
-        /// `stamp_and_swap` moves this bit onto the fresh continuation so the
-        /// capture ends with the piece the closing `Present` submits.
+        /// A frame swap that does not present moves this bit onto the
+        /// continuation, so the capture ends with the piece the closing
+        /// `Present` submits rather than with the process.
         const GPU_CAPTURE_STOP = 1 << 3;
     }
 }
@@ -8497,9 +8497,25 @@ impl FrameData {
             .intersection(FrameDataFlags::GPU_CAPTURE_START.union(FrameDataFlags::GPU_CAPTURE_STOP))
     }
 
-    /// Drop the `GPU_CAPTURE_STOP` mark, for moving it onto a continuation frame.
-    pub const fn clear_gpu_capture_stop(&mut self) {
-        self.flags = self.flags.difference(FrameDataFlags::GPU_CAPTURE_STOP);
+    /// Take the capture marks this frame hands to the frame replacing it.
+    ///
+    /// `submitted` says whether this frame still reaches the encoder. What
+    /// the continuation inherits is cleared here, so exactly one of the two
+    /// frames carries each mark.
+    pub fn take_carried_capture_marks(&mut self, submitted: bool) -> FrameDataFlags {
+        let marks = self.gpu_capture_marks();
+        let (start, stop) = mtld3d_core::present::carried_capture_marks(
+            (
+                marks.contains(FrameDataFlags::GPU_CAPTURE_START),
+                marks.contains(FrameDataFlags::GPU_CAPTURE_STOP),
+            ),
+            submitted,
+        );
+        let mut carried = FrameDataFlags::empty();
+        carried.set(FrameDataFlags::GPU_CAPTURE_START, start);
+        carried.set(FrameDataFlags::GPU_CAPTURE_STOP, stop);
+        self.flags = self.flags.difference(carried);
+        carried
     }
 
     pub const fn set_submit_fence(&mut self, fence: &SubmitFence) {


### PR DESCRIPTION
## Symptoms

An F12 press promises a three-frame GPU trace beside the log file. A `Reset` inside that run makes the trace unbounded instead: the capture keeps recording until the process exits, so a press taken across a windowed/fullscreen toggle (the same-size `Reset` Source engine games and WoW take) produces a trace of the whole rest of the session rather than the three frames the hotkey dumps.

## Root cause

The last frame of a run carries `FrameDataFlags::GPU_CAPTURE_STOP`, and the encoder stops the capture after the frame it sees it on. A mid-frame flush submits the marked frame early, so `stamp_and_swap` moves the stop onto the continuation frame and the capture ends with the piece the closing `Present` submits. `reseed_current_frame` replaces `current_frame` with `fresh_frame()` directly and never passed through that hand-off, so the marks went with the frame it dropped. `Reset` reseeds on both the resized and the unchanged-dimensions path, and so does `apply_auto_resize`, and each of them follows a flush that has already sent the run's start out with the piece it submitted, which leaves the stop as the mark that is lost.

## Changes

`mtld3d_core::present::carried_capture_marks` states which marks a swapped-out frame hands to the frame replacing it, next to the existing `capture_marks`: the stop always travels, and the start travels only when the outgoing frame is dropped rather than submitted, since a submitted piece still opens the capture itself.

`FrameData::take_carried_capture_marks` applies that to the flags, clearing what it hands on so exactly one of the two frames carries each mark. It replaces `clear_gpu_capture_stop`, and both swap sites call it: `stamp_and_swap` for the mid-frame flush it already handled, and `reseed_current_frame` for the frame it discards. `reseed_current_frame` still clears `DEPTH_EXPLICITLY_UNBOUND`, which is the other thing the reseed owes a `Reset`.

## Alternatives

Skip the reseed when the dimensions are unchanged: does not work, `Reset` has to clear `DEPTH_EXPLICITLY_UNBOUND` and re-seed the handles the recreate produced regardless of size.

Route the reseed through `stamp_and_swap`: that function stamps a submit sequence, drains the perf payload and re-asserts the persistent bindings for a frame it hands to the encoder, none of which applies to a frame that is thrown away.

Keep the migration inline at both sites: it is the same rule stated twice, and the d3d9 crate has no unit-test target, so an inline copy is untestable by construction.

## Verification

`make check` green. `make ISOLATED=1 test` green: 1070 windows unit tests and 255 unix unit tests passed, and the end-to-end suite ran 460 tests on i686 and 460 on x86_64, all passed, 4 processes per architecture, no `FAIL`, `SIGABRT`, `TIMEOUT` or `LEAK` line.

Three unit tests in `windows/core/src/present/tests.rs` pin the hand-off: `a_submitted_frame_hands_on_the_stop_and_keeps_the_start`, `a_dropped_frame_hands_on_every_mark_it_holds` and `an_unmarked_frame_hands_on_nothing`. The device-side wiring itself has no runnable test: `make test-unit` covers `mtld3d-core`, `mtld3d-types` and the unix workspace, and a `#[test]` in `windows/d3d9` is unreachable without Wine, while the arming path is an F12 poll of `GetAsyncKeyState` with no programmatic trigger, so an end-to-end test would have to inject global key state into the process the whole suite shares and would arm a real Metal capture in every leg. The policy therefore moved to core, where it is tested, and each device site is one call.

Conformance was not run: the marks are only ever set by an F12 press, so both call sites are no-ops for every conformance and rendering path, and the change touches no render, state or shader-emission code.

Closes #414
