### PR TITLE
Release a droppable level's staging on the emitted answer

### DIFF
--- a/windows/core/src/upload_redirty.rs
+++ b/windows/core/src/upload_redirty.rs
@@ -17,6 +17,17 @@
 //! cause repeats on every attempt and an unbounded retry would schedule a
 //! failing upload on every draw that binds the texture.
 //!
+//! The queue carries the other answer too. A texture whose class releases a
+//! level's staging once the GPU holds every byte of it may only do so after
+//! an upload actually reached the command stream: released early, a declined
+//! upload has no bytes left to retry from and the level stays empty. So the
+//! encoder names every upload it did emit whose level is waiting on that
+//! answer, and the same drain performs the release. Two things hold the
+//! release back. A decline filed for the subresource cancels it, because the
+//! retry reads the staging again, and the upload number the answer carries
+//! lets the drain leave the pages alone while a later upload of the level is
+//! still waiting for an answer of its own.
+//!
 //! Pure bookkeeping: no Metal handles, no D3D9 objects, so the whole contract
 //! is host-testable.
 
@@ -63,16 +74,36 @@ pub struct RedirtyEntry {
     pub rect: DirtyRect,
 }
 
-/// Declined uploads, filled on the encoder thread and drained on the API thread.
+/// One upload the encoder emitted.
+#[derive(Debug)]
+pub struct EmittedUpload {
+    /// The subresource whose upload reached the command stream.
+    pub subresource: RedirtySubresource,
+    /// Mip level the upload targeted.
+    pub level: u32,
+    /// Which of the level's scheduled uploads this one is.
+    ///
+    /// Counted by the scheduler for the levels that release their staging,
+    /// and zero for every other level. An answer whose number is behind the
+    /// level's own belongs to an upload a later one has superseded, and the
+    /// later one's answer is the one the release waits for.
+    pub generation: u32,
+    /// Whether the level is holding its staging until this answer arrives.
+    pub releases_staging: bool,
+}
+
+/// The encoder's answers about uploads, drained on the API thread.
 ///
-/// Both counters exist so the two hot callers stay off the lock. The API
-/// thread's drain reads `pending` once a frame and returns on a clear flag;
-/// the encoder's acknowledgement of an emitted upload reads `tracked` and
-/// returns while no subresource carries a decline record, which is the whole
-/// of a run that never declines an upload.
+/// The flags exist so the two hot callers stay off the lock. The API thread's
+/// drain reads them once a frame and returns while both are clear; the
+/// encoder's acknowledgement of an emitted upload whose staging stays reads
+/// `tracked` and returns while no subresource carries a decline record, which
+/// is the whole of a run that never declines an upload.
 pub struct RedirtyQueue {
-    /// Set while `pending` holds an entry.
-    pending: AtomicBool,
+    /// Set while a declined upload waits to be marked dirty again.
+    declined_pending: AtomicBool,
+    /// Set while an emitted upload waits for its staging to be released.
+    released_pending: AtomicBool,
     /// Subresources currently carrying an attempt count.
     tracked: AtomicUsize,
     inner: Mutex<RedirtyInner>,
@@ -80,6 +111,7 @@ pub struct RedirtyQueue {
 
 struct RedirtyInner {
     pending: Vec<RedirtyEntry>,
+    released: Vec<EmittedUpload>,
     attempts: FxHashMap<RedirtySubresource, u32>,
 }
 
@@ -87,10 +119,12 @@ impl RedirtyQueue {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            pending: AtomicBool::new(false),
+            declined_pending: AtomicBool::new(false),
+            released_pending: AtomicBool::new(false),
             tracked: AtomicUsize::new(0),
             inner: Mutex::new(RedirtyInner {
                 pending: Vec::new(),
+                released: Vec::new(),
                 attempts: FxHashMap::default(),
             }),
         }
@@ -109,7 +143,12 @@ impl RedirtyQueue {
     pub fn decline(&self, entry: RedirtyEntry) -> bool {
         let (retry, tracked) = {
             let mut inner = self.inner.lock().expect("redirty queue mutex poisoned");
-            let attempts = inner.attempts.entry(entry.subresource).or_insert(0);
+            let subresource = entry.subresource;
+            // An earlier upload of this subresource was emitted and asked for
+            // the staging to go. The retry this decline schedules reads those
+            // pages, so the release is cancelled and the level keeps them.
+            inner.released.retain(|r| r.subresource != subresource);
+            let attempts = inner.attempts.entry(subresource).or_insert(0);
             *attempts += 1;
             let retry = *attempts <= MAX_REDIRTY_ATTEMPTS;
             if retry {
@@ -119,7 +158,7 @@ impl RedirtyQueue {
         };
         self.tracked.store(tracked, Ordering::Relaxed);
         if retry {
-            self.pending.store(true, Ordering::Release);
+            self.declined_pending.store(true, Ordering::Release);
         }
         retry
     }
@@ -131,21 +170,33 @@ impl RedirtyQueue {
     /// under transient memory pressure must not spend a texture's retries for
     /// the rest of the run.
     ///
+    /// An upload whose level is waiting on this answer is queued for the drain
+    /// as well; every other one only settles the budget, which is the whole of
+    /// a run that never declines an upload.
+    ///
     /// # Panics
     ///
     /// If a previous caller panicked while holding the queue's lock.
-    pub fn note_emitted(&self, subresource: RedirtySubresource) {
-        if self.tracked.load(Ordering::Relaxed) == 0 {
+    pub fn note_emitted(&self, emitted: EmittedUpload) {
+        if !emitted.releases_staging && self.tracked.load(Ordering::Relaxed) == 0 {
             return;
         }
+        let releases_staging = emitted.releases_staging;
         let tracked = {
             let mut inner = self.inner.lock().expect("redirty queue mutex poisoned");
-            if inner.attempts.remove(&subresource).is_none() {
+            let had_record = inner.attempts.remove(&emitted.subresource).is_some();
+            if !releases_staging && !had_record {
                 return;
+            }
+            if releases_staging {
+                inner.released.push(emitted);
             }
             inner.attempts.len()
         };
         self.tracked.store(tracked, Ordering::Relaxed);
+        if releases_staging {
+            self.released_pending.store(true, Ordering::Release);
+        }
     }
 
     /// Take every upload waiting to be marked dirty again.
@@ -155,17 +206,32 @@ impl RedirtyQueue {
     /// If a previous caller panicked while holding the queue's lock.
     #[must_use]
     pub fn take_pending(&self) -> Vec<RedirtyEntry> {
-        if !self.pending.swap(false, Ordering::Acquire) {
+        if !self.declined_pending.swap(false, Ordering::Acquire) {
             return Vec::new();
         }
         let mut inner = self.inner.lock().expect("redirty queue mutex poisoned");
         core::mem::take(&mut inner.pending)
     }
 
+    /// Take every emitted upload whose staging may now be released.
+    ///
+    /// # Panics
+    ///
+    /// If a previous caller panicked while holding the queue's lock.
+    #[must_use]
+    pub fn take_released(&self) -> Vec<EmittedUpload> {
+        if !self.released_pending.swap(false, Ordering::Acquire) {
+            return Vec::new();
+        }
+        let mut inner = self.inner.lock().expect("redirty queue mutex poisoned");
+        core::mem::take(&mut inner.released)
+    }
+
     /// Whether a drain would find anything.
     #[must_use]
     pub fn has_pending(&self) -> bool {
-        self.pending.load(Ordering::Acquire)
+        self.declined_pending.load(Ordering::Acquire)
+            || self.released_pending.load(Ordering::Acquire)
     }
 }
 

--- a/windows/core/src/upload_redirty/tests.rs
+++ b/windows/core/src/upload_redirty/tests.rs
@@ -1,10 +1,27 @@
-use super::{MAX_REDIRTY_ATTEMPTS, RedirtyEntry, RedirtyQueue, RedirtySubresource};
+use super::{EmittedUpload, MAX_REDIRTY_ATTEMPTS, RedirtyEntry, RedirtyQueue, RedirtySubresource};
 use crate::{dirty_rect::DirtyRect, ids::TextureId};
 
 fn subresource(index: u32) -> RedirtySubresource {
     RedirtySubresource {
         texture_id: TextureId::new_unique(),
         index,
+    }
+}
+
+fn emitted(subresource: RedirtySubresource) -> EmittedUpload {
+    EmittedUpload {
+        subresource,
+        level: subresource.index,
+        generation: 0,
+        releases_staging: false,
+    }
+}
+
+fn releasing(subresource: RedirtySubresource, generation: u32) -> EmittedUpload {
+    EmittedUpload {
+        generation,
+        releases_staging: true,
+        ..emitted(subresource)
     }
 }
 
@@ -22,6 +39,7 @@ fn a_fresh_queue_has_nothing_to_drain() {
     let queue = RedirtyQueue::new();
     assert!(!queue.has_pending());
     assert!(queue.take_pending().is_empty());
+    assert!(queue.take_released().is_empty());
 }
 
 #[test]
@@ -97,7 +115,7 @@ fn an_emitted_upload_gives_the_subresource_its_budget_back() {
     }
     assert!(!queue.decline(entry(sub, rect)));
 
-    queue.note_emitted(sub);
+    queue.note_emitted(emitted(sub));
     assert!(queue.decline(entry(sub, rect)));
 }
 
@@ -105,7 +123,71 @@ fn an_emitted_upload_gives_the_subresource_its_budget_back() {
 fn acknowledging_an_untouched_subresource_changes_nothing() {
     let queue = RedirtyQueue::new();
     let sub = subresource(0);
-    queue.note_emitted(sub);
+    queue.note_emitted(emitted(sub));
     assert!(!queue.has_pending());
     assert!(queue.decline(entry(sub, DirtyRect::full(2, 2))));
+}
+
+#[test]
+fn an_emitted_upload_that_asked_for_it_reports_its_staging_released() {
+    let queue = RedirtyQueue::new();
+    let sub = subresource(3);
+    queue.note_emitted(releasing(sub, 7));
+    assert!(queue.has_pending());
+
+    let released = queue.take_released();
+    assert_eq!(released.len(), 1);
+    assert_eq!(released[0].subresource, sub);
+    assert_eq!(released[0].level, 3);
+    assert_eq!(released[0].generation, 7);
+    assert!(queue.take_pending().is_empty());
+    assert!(!queue.has_pending());
+    assert!(queue.take_released().is_empty());
+}
+
+#[test]
+fn an_emitted_upload_that_keeps_its_staging_releases_nothing() {
+    let queue = RedirtyQueue::new();
+    queue.note_emitted(emitted(subresource(0)));
+    assert!(!queue.has_pending());
+    assert!(queue.take_released().is_empty());
+}
+
+#[test]
+fn a_decline_cancels_a_release_the_same_subresource_is_waiting_for() {
+    let queue = RedirtyQueue::new();
+    let sub = subresource(1);
+    queue.note_emitted(releasing(sub, 1));
+    assert!(queue.decline(entry(sub, DirtyRect::full(8, 8))));
+
+    assert!(queue.take_released().is_empty());
+    assert_eq!(queue.take_pending().len(), 1);
+}
+
+#[test]
+fn a_decline_leaves_another_subresources_release_alone() {
+    let queue = RedirtyQueue::new();
+    let released = subresource(0);
+    let declined = subresource(1);
+    queue.note_emitted(releasing(released, 1));
+    assert!(queue.decline(entry(declined, DirtyRect::full(8, 8))));
+
+    let drained = queue.take_released();
+    assert_eq!(drained.len(), 1);
+    assert_eq!(drained[0].subresource, released);
+    assert_eq!(queue.take_pending().len(), 1);
+}
+
+#[test]
+fn an_emitted_upload_that_releases_its_staging_also_gives_the_budget_back() {
+    let queue = RedirtyQueue::new();
+    let sub = subresource(0);
+    let rect = DirtyRect::full(16, 16);
+    for _ in 0..MAX_REDIRTY_ATTEMPTS {
+        assert!(queue.decline(entry(sub, rect)));
+    }
+    assert!(!queue.decline(entry(sub, rect)));
+
+    queue.note_emitted(releasing(sub, 1));
+    assert!(queue.decline(entry(sub, rect)));
 }

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -670,15 +670,17 @@ pub struct DeviceInner {
     /// create, release and Evict run one at a time, on the API thread or
     /// serialised by the device `ApiLock` under `D3DCREATE_MULTITHREADED`.
     live_textures: Mutex<Vec<*mut TextureInner>>,
-    /// Uploads the encoder emitted nothing for, waiting to be marked dirty again.
+    /// What the encoder made of each upload, waiting to be acted on.
     ///
     /// The bind-time flush clears a level's dirty bit and takes its pending
     /// rectangle before the job crosses to the encoder thread, and
     /// `UnlockRect` publishes only the rectangle the game locked, so a
     /// decline downstream of the hand-off would otherwise leave the region
     /// unannounced for the rest of the run. The encoder files the
-    /// subresource and its rectangle here; [`Self::apply_upload_redirty`]
-    /// drains the queue once a frame and marks them dirty again.
+    /// subresource and its rectangle here, along with the subresources whose
+    /// upload it did emit and whose staging is waiting on that answer;
+    /// [`Self::apply_upload_answers`] drains the queue once a frame, marks
+    /// the declined ones dirty again and releases the staging of the rest.
     upload_redirty: Arc<RedirtyQueue>,
     /// Per-draw snapshot dirty-bitmask.
     ///
@@ -1820,7 +1822,7 @@ impl DeviceInner {
         // Both `IDirect3DDevice9::Present` and the swap chain's land here, so
         // the diagnostics that run once per frame poll from this point.
         crate::capture::poll();
-        self.apply_upload_redirty();
+        self.apply_upload_answers();
         let (frame, seq) = self.stamp_and_swap(new_frame, false);
 
         // The block we measure belongs to the frame that will next be
@@ -2054,37 +2056,50 @@ impl DeviceInner {
         Arc::clone(&self.upload_redirty)
     }
 
-    /// Mark every upload the encoder emitted nothing for dirty again.
+    /// Act on what the encoder made of the uploads of the frame just ended.
     ///
-    /// Runs once per `Present`, before the frame is stamped, so the next
-    /// frame's bind-time flush re-schedules the region. A texture released
-    /// between the decline and this drain has left the registry, and its
-    /// entries are dropped with it.
-    fn apply_upload_redirty(&self) {
+    /// Runs once per `Present`, before the frame is stamped: a declined
+    /// upload is marked dirty again so the next frame's bind-time flush
+    /// re-schedules the region, and a level that was holding its staging for
+    /// the emitted answer releases it. The declines are applied first, so a
+    /// level whose later upload was declined is dirty by the time its earlier
+    /// release is considered and keeps the pages the retry reads. A texture
+    /// released between the answer and this drain has left the registry, and
+    /// its entries are dropped with it.
+    fn apply_upload_answers(&self) {
         if !self.upload_redirty.has_pending() {
             return;
         }
-        let entries = self.upload_redirty.take_pending();
-        if entries.is_empty() {
+        let declined = self.upload_redirty.take_pending();
+        let released = self.upload_redirty.take_released();
+        if declined.is_empty() && released.is_empty() {
             return;
         }
+        let wanted: rustc_hash::FxHashSet<TextureId> = declined
+            .iter()
+            .map(|entry| entry.subresource.texture_id)
+            .chain(released.iter().map(|ack| ack.subresource.texture_id))
+            .collect();
         let live: Vec<*mut TextureInner> = self
             .live_textures
             .lock()
             .expect("live_textures mutex poisoned")
             .clone();
+        // Only the textures an answer names go in the map: a drain runs on
+        // every frame that uploads a static texture, and a game holds far
+        // more textures than one frame uploads.
         let by_id: rustc_hash::FxHashMap<TextureId, *mut TextureInner> = live
             .into_iter()
-            .map(|ptr| {
+            .filter_map(|ptr| {
                 // SAFETY: `ptr` is a snapshot from `live_textures`; entries
                 // are removed before the `TextureInner` Box is freed, and
                 // nothing frees one while the API thread runs this.
                 let id = unsafe { &*ptr }.texture_id();
-                (id, ptr)
+                wanted.contains(&id).then_some((id, ptr))
             })
             .collect();
         let mut restored = 0u32;
-        for entry in &entries {
+        for entry in &declined {
             let Some(&ptr) = by_id.get(&entry.subresource.texture_id) else {
                 continue;
             };
@@ -2098,11 +2113,21 @@ impl DeviceInner {
             );
             restored += 1;
         }
-        mtld3d_shared::log_once_info!(
-            target: TEX_TRACE_TARGET,
-            "upload redirty: {restored} of {} declined uploads marked dirty again",
-            entries.len()
-        );
+        for ack in &released {
+            let Some(&ptr) = by_id.get(&ack.subresource.texture_id) else {
+                continue;
+            };
+            // SAFETY: same contract as the map build above.
+            let ti = unsafe { &mut *ptr };
+            crate::texture::release_emitted_staging(ti, ack.level as usize, ack.generation);
+        }
+        if !declined.is_empty() {
+            mtld3d_shared::log_once_info!(
+                target: TEX_TRACE_TARGET,
+                "upload redirty: {restored} of {} declined uploads marked dirty again",
+                declined.len()
+            );
+        }
     }
 
     /// Finalize the visibility query whose END frame retires at `target_seq`.

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -47,7 +47,7 @@ use mtld3d_core::{
     stretch_rect::StretchRegion,
     upload_pass::UploadDecode,
     upload_recovery::{UploadFate, UploadRecoveryQueue},
-    upload_redirty::{RedirtyEntry, RedirtyQueue, RedirtySubresource},
+    upload_redirty::{EmittedUpload, RedirtyEntry, RedirtyQueue, RedirtySubresource},
     visibility::{
         MAX_SLOTS, RetiredVisibilityBuffer, SLOT_BYTES, VisibilityQueryCore, VisibilityQueryState,
     },
@@ -354,15 +354,29 @@ pub struct TextureUploadJob {
     /// single-slice `bytes_per_image` from the region's block-row count
     /// instead.
     pub slice_pitch: u32,
-    /// Where a job that emits nothing reports itself.
+    /// Where a job reports what became of it.
     ///
     /// The dirty state this upload was built from is already cleared when
     /// the encoder thread sees the job, so a decline that stayed on this
     /// thread would lose the region: `UnlockRect` publishes only the
     /// rectangle the game locked and nothing re-announces the rest. The
     /// queue carries the subresource and the rectangle back to the API
-    /// thread, which marks them dirty again for the next bind.
+    /// thread, which marks them dirty again for the next bind, and carries
+    /// the emitted answer back for the levels waiting to release their
+    /// staging.
     pub redirty: Arc<RedirtyQueue>,
+    /// Whether the level releases its staging once this upload is emitted.
+    ///
+    /// Set for a level of the staging-droppable class whose every texel this
+    /// upload puts on the GPU. The release waits for the emitted answer: a
+    /// level released at schedule time has no bytes left to retry from when
+    /// the upload is declined downstream of the hand-off.
+    pub release_staging: bool,
+    /// Which of the level's scheduled uploads this one is.
+    ///
+    /// Travels back with the emitted answer so the release can tell whether a
+    /// later upload of the level is still waiting for an answer of its own.
+    pub upload_generation: u32,
 }
 
 impl TextureUploadJob {
@@ -371,6 +385,16 @@ impl TextureUploadJob {
         RedirtySubresource {
             texture_id: self.info.texture_id,
             index: u32::try_from(self.staging_index).unwrap_or(u32::MAX),
+        }
+    }
+
+    /// The answer this job reports once its upload reaches the command stream.
+    fn emitted_answer(&self) -> EmittedUpload {
+        EmittedUpload {
+            subresource: self.redirty_subresource(),
+            level: self.level,
+            generation: self.upload_generation,
+            releases_staging: self.release_staging,
         }
     }
 
@@ -6740,8 +6764,9 @@ impl FrameEncoder {
         if emitted {
             // The subresource reached the command stream, so its decline
             // record (if it had one) has served its purpose and its retry
-            // budget goes back.
-            job.redirty.note_emitted(job.redirty_subresource());
+            // budget goes back, and a level that was holding its staging for
+            // this answer may let it go.
+            job.redirty.note_emitted(job.emitted_answer());
             // Keep the job so an aborted upload command buffer can replay
             // it. It only holds a clone of the texture's own persistent
             // staging Arc, so the memory cost is the clone.

--- a/windows/d3d9/src/texture.rs
+++ b/windows/d3d9/src/texture.rs
@@ -274,6 +274,15 @@ pub struct TextureInner {
     /// staging ([`TextureInner::staging_droppable_class`]), which pays neither
     /// the memory nor the bookkeeping.
     staging_coverage: Vec<StagingCoverage>,
+    /// Per-level count of the uploads scheduled for it (empty when untracked).
+    ///
+    /// A level releases its staging when the encoder answers that an upload of
+    /// it was emitted, and the answer arrives a frame later, by which time the
+    /// level may have scheduled another upload the encoder has not answered
+    /// yet. The count tells the two apart, so the pages a pending upload may
+    /// still have to be retried from stay put. Only the class that can release
+    /// its staging counts, next to its coverage.
+    upload_generation: Vec<u32>,
     /// Levels a device context currently maps (bit N = level N).
     ///
     /// A `GetDC` hands GDI a DIB over the level's staging pages, and
@@ -532,6 +541,23 @@ impl TextureInner {
             && self.dropped_staging & (1u32 << level) == 0
             && !self.locked[level]
             && !self.level_dc_open(level)
+    }
+
+    /// Number this level's next upload and hand the number back.
+    ///
+    /// Zero for a level whose class never releases its staging, which counts
+    /// nothing: the number only serves the release.
+    fn next_upload_generation(&mut self, level: usize) -> u32 {
+        let Some(slot) = self.upload_generation.get_mut(level) else {
+            return 0;
+        };
+        *slot = slot.wrapping_add(1);
+        *slot
+    }
+
+    /// Whether `generation` is the number of the last upload scheduled for `level`.
+    fn is_latest_upload(&self, level: usize, generation: u32) -> bool {
+        self.upload_generation.get(level) == Some(&generation)
     }
 
     /// Whether a device context currently maps `level`.
@@ -2885,6 +2911,7 @@ fn build_texture_inner(info: TextureCreateInfo) -> *mut TextureInner {
         staging,
         dropped_staging: 0,
         staging_coverage: Vec::new(),
+        upload_generation: Vec::new(),
         dc_open: 0,
         level_authority: LevelAuthorityMask::new(),
         mip_widths: info.mip_widths,
@@ -2914,6 +2941,7 @@ fn build_texture_inner(info: TextureCreateInfo) -> *mut TextureInner {
         boxed.staging_coverage = core::iter::repeat_with(StagingCoverage::new)
             .take(boxed.staging.len())
             .collect();
+        boxed.upload_generation = vec![0; boxed.staging.len()];
     }
     // A default-pool static texture's staging only carries writes to the
     // GPU, and a streaming engine creates far more textures than it ever
@@ -4048,6 +4076,13 @@ pub fn schedule_upload(ti: &mut TextureInner, dev: &mut DeviceInner, level: u32,
     // consulted by the volume blit path.
     let block_rows = ti.mip_height(level_u).div_ceil(ti.block_h.max(1));
     let slice_pitch = ti.mip_bytes_per_row(level_u).saturating_mul(block_rows);
+    // Every byte of a level the game cannot lock again is on the GPU once this
+    // upload is emitted: each write since the staging was allocated was
+    // uploaded by the flush that followed it, this one included, and together
+    // they cover the level. The release waits for the encoder's answer, since
+    // a declined upload is retried from the staging this would have released.
+    let release_staging = ti.staging_droppable(level_u) && ti.staging_fully_written(level_u);
+    let upload_generation = ti.next_upload_generation(level_u);
     let job = TextureUploadJob {
         info: ti.texture_info(),
         arc: ti.staging_arc(level_u),
@@ -4064,6 +4099,8 @@ pub fn schedule_upload(ti: &mut TextureInner, dev: &mut DeviceInner, level: u32,
         depth: (ti.depth >> level).max(1),
         slice_pitch,
         redirty: dev.upload_redirty(),
+        release_staging,
+        upload_generation,
     };
     let texture_id = ti.texture_id;
     let regen_mipmaps = ti.autogen_mipmap() && level == 0;
@@ -4081,13 +4118,6 @@ pub fn schedule_upload(ti: &mut TextureInner, dev: &mut DeviceInner, level: u32,
         rect.w,
         rect.h
     );
-    // Every byte of a level the game cannot lock again is now on the GPU: each
-    // write since the staging was allocated was uploaded by the flush that
-    // followed it, this one included, and together they cover the level. The
-    // job holds its own `Arc` of the staging, so the texture's copy can go now.
-    if ti.staging_droppable(level_u) && ti.staging_fully_written(level_u) {
-        ti.drop_staging(level_u);
-    }
     dev.push_op(Box::new(move |enc: &mut FrameEncoder| {
         enc.run_texture_upload(job);
         if regen_mipmaps {
@@ -4140,6 +4170,10 @@ fn schedule_cube_upload(
         depth: 1,
         slice_pitch,
         redirty: dev.upload_redirty(),
+        // A cube is outside the staging-droppable class: its faces are
+        // written and uploaded by paths that expect the level to be there.
+        release_staging: false,
+        upload_generation: 0,
     };
     dev.push_op(Box::new(move |enc: &mut FrameEncoder| {
         enc.run_texture_upload(job);
@@ -4162,6 +4196,36 @@ pub fn redirty_declined_upload(ti: &mut TextureInner, face: u32, level: usize, r
     } else {
         ti.mark_written_region(level, rect);
     }
+}
+
+/// Release the staging of a level whose upload the encoder emitted.
+///
+/// The scheduler asked for the release when it built the job and the GPU now
+/// holds every texel of the level, so the pages are redundant: this is the
+/// half of the 32-bit footprint saving that has to wait for an answer, since
+/// a declined upload is retried from exactly these pages. The job carries its
+/// own `Arc` of them, so an upload the encoder still holds for replay keeps
+/// reading what it was built from.
+///
+/// The conditions are re-read here because the level's state moves while the
+/// answer is in flight. A later upload of the level may still be waiting for
+/// an answer of its own, and would be retried from these pages; a write that
+/// landed after the upload was scheduled marks the level dirty and its bytes
+/// have reached no command buffer yet; a lock or a device context maps the
+/// pages; a rename or a release of its own leaves the coverage short of the
+/// whole level. Each of them keeps the staging, and the level is offered
+/// again by the answer or the upload that follows.
+pub fn release_emitted_staging(ti: &mut TextureInner, level: usize, generation: u32) {
+    if level >= (ti.levels as usize).min(32) {
+        return;
+    }
+    if !ti.is_latest_upload(level, generation) || ti.dirty_mask & (1u32 << level) != 0 {
+        return;
+    }
+    if !ti.staging_droppable(level) || !ti.staging_fully_written(level) {
+        return;
+    }
+    ti.drop_staging(level);
 }
 
 /// Mark every previously-uploaded mip dirty for the next bind-time `flush_dirty_mips`.

--- a/windows/tests/tests/e2e/textures.rs
+++ b/windows/tests/tests/e2e/textures.rs
@@ -1093,11 +1093,21 @@ fn update_surface_uploads_the_selected_cube_face() {
     );
 }
 
+/// Run the frame that releases the staging of the levels uploaded so far.
+///
+/// A level of the class that releases its staging after an upload keeps it
+/// until the encoder answers that the upload reached the command stream, and
+/// the answer is acted on at the next `Present`. A test that wants a released
+/// level takes one more frame after the draw that uploaded it.
+fn release_uploaded_staging(h: &Harness) {
+    assert_eq!(h.present(), 0, "the Present that releases uploaded staging");
+}
+
 /// A default-pool texture the game cannot lock takes a second `UpdateTexture`.
 ///
-/// Its staging goes away once the first upload has been submitted (the GPU
-/// holds the only copy, as on real D3D9); the second update re-creates it,
-/// and what samples back is the second fill.
+/// Its staging goes away once the first upload has been emitted (the GPU holds
+/// the only copy, as on real D3D9); the second update re-creates it, and what
+/// samples back is the second fill.
 #[test]
 fn default_pool_texture_takes_a_second_update_after_its_upload() {
     const RED: u32 = 0xFFFF_0000;
@@ -1108,6 +1118,7 @@ fn default_pool_texture_takes_a_second_update_after_its_upload() {
     src.lock_rect(0, 0).write::<u32>(&[RED; 4]);
     assert_eq!(h.update_texture_hr(&src, &dst), 0, "first UpdateTexture");
     assert_pixel_eq(sample_center(&h, &dst).to_pixel(), RED, "first fill");
+    release_uploaded_staging(&h);
 
     src.lock_rect(0, 0).write::<u32>(&[GREEN; 4]);
     assert_eq!(h.update_texture_hr(&src, &dst), 0, "second UpdateTexture");
@@ -1242,6 +1253,8 @@ fn partial_updates_covering_a_default_pool_level_keep_its_pixels() {
         assert_pixel_eq(sampled[i], color, name);
     }
 
+    release_uploaded_staging(&h);
+
     // The four writes covered the level, so its staging is gone. A fifth
     // partial update re-creates it and must upload only its own rect: the
     // pixels the GPU already holds are the only copy of the other three.
@@ -1262,7 +1275,7 @@ fn partial_updates_covering_a_default_pool_level_keep_its_pixels() {
 /// A sub-rectangle `UpdateSurface` leaves the rest of the destination level alone.
 ///
 /// The destination is a default-pool texture whose staging is released once
-/// its first whole-level upload has been submitted, so the partial update
+/// its first whole-level upload has been emitted, so the partial update
 /// re-creates a staging buffer holding only the copied rectangle. Uploading
 /// the whole mip from it would push uninitialised pages over the GPU content
 /// the copy never touched.
@@ -1281,13 +1294,14 @@ fn update_surface_sub_rect_keeps_the_rest_of_the_level() {
         0,
         "whole-level UpdateSurface"
     );
-    // The sampling draw submits the whole-level upload, which releases the
-    // destination's staging.
+    // The sampling draw submits the whole-level upload; the frame after it
+    // releases the destination's staging.
     assert_pixel_eq(
         sample_center(&h, &dst).to_pixel(),
         GREEN,
         "whole-level fill",
     );
+    release_uploaded_staging(&h);
 
     let patch = h.create_offscreen_plain_surface(4, 4, D3DFMT_A8R8G8B8, D3DPOOL_SYSTEMMEM);
     patch.lock_rect(0).write_u32(&[RED; 16]);
@@ -1315,7 +1329,8 @@ fn update_surface_sub_rect_keeps_the_rest_of_the_level() {
 /// A plain lock of a released default-pool level hands back the level's texels.
 ///
 /// The whole-level write reaches the GPU at the next draw and the staging goes
-/// with it, so a second lock has nothing left in system memory. D3D9 promises
+/// once that upload is answered, so a second lock has nothing left in system
+/// memory. D3D9 promises
 /// that lock the level's current contents, which leaves reading them back from
 /// the GPU as the only honest answer; the pages alone read as garbage.
 #[test]
@@ -1331,9 +1346,10 @@ fn lock_of_a_released_default_pool_level_reads_the_level_back() {
         assert_eq!(locked.pitch(), 256, "64 texels * 4 bytes/texel row pitch");
         locked.write_u32(&written);
     }
-    // The draw is what uploads the level and releases its staging; which texel
-    // the centre sample lands on is not what this pins.
+    // The draw is what uploads the level; which texel the centre sample lands
+    // on is not what this pins.
     let _sampled = sample_center(&h, &tex);
+    release_uploaded_staging(&h);
 
     let locked = tex.lock_rect(0, 0);
     assert_eq!(
@@ -1345,8 +1361,8 @@ fn lock_of_a_released_default_pool_level_reads_the_level_back() {
 
 /// `GetDC` on a released default-pool level maps the level's own texels.
 ///
-/// The draw uploads the level and the staging goes with the upload, so the
-/// pixels live on the GPU alone and the level's staging slot points at the one
+/// The draw uploads the level and the staging goes once that upload is
+/// answered, so the pixels live on the GPU alone and the slot points at the one
 /// page every released level shares. A DIB over that page reads whatever it
 /// holds and its writes reach every other released level, so the DC reads the
 /// level back first, the way a `LockRect` of it does.
@@ -1363,8 +1379,9 @@ fn get_dc_on_a_released_default_pool_level_reads_the_level_back() {
         let mut locked = tex.lock_rect(0, 0);
         locked.write_u32(&[GREEN; TEXELS]);
     }
-    // The draw is what uploads the level and releases its staging.
+    // The draw is what uploads the level.
     assert_pixel_eq(sample_center(&h, &tex).to_pixel(), GREEN, "upload");
+    release_uploaded_staging(&h);
 
     let surface = tex.surface_level(0);
     let dc = surface.dc();
@@ -1592,6 +1609,7 @@ fn discard_lock_of_a_released_default_pool_level_rewrites_it() {
         locked.write_u32(&[FIRST; TEXELS]);
     }
     assert_pixel_eq(sample_center(&h, &tex).to_pixel(), FIRST, "first fill");
+    release_uploaded_staging(&h);
 
     {
         let mut locked = tex.lock_rect(0, D3DLOCK_DISCARD);
@@ -2666,8 +2684,8 @@ fn get_dc_on_an_odd_width_16_bit_texture_level_round_trips_a_texel() {
 /// nothing but the creation call tells it apart from an ordinary 2D texture,
 /// and the class that releases its staging after an upload must still exclude
 /// it: the volume paths write and upload a level whole and re-create it as a
-/// single 2D slice. The first update is drawn (the point a released level would
-/// go), then a second update has to reach the GPU.
+/// single 2D slice. The first update is drawn and its frame answered (the
+/// point a released level would go), then a second update has to reach the GPU.
 #[test]
 fn single_slice_default_volume_takes_a_second_update_after_its_upload() {
     const RED: u32 = 0xFFFF_0000;
@@ -2696,6 +2714,7 @@ fn single_slice_default_volume_takes_a_second_update_after_its_upload() {
         "SetFVF"
     );
     assert_pixel_eq(sample_volume_depth(&h, 0.5), RED, "first fill");
+    release_uploaded_staging(&h);
 
     src.write_u32(0, &[GREEN; 4]);
     assert_eq!(


### PR DESCRIPTION
## Symptoms

A `D3DPOOL_DEFAULT` texture without `D3DUSAGE_DYNAMIC` whose upload the encoder declines loses the level for the rest of the run. The redirty queue marks the level dirty again, the next bind schedules the upload, and it lands on `texture 0x...: upload of level 0 requested after its staging was released; the GPU copy stands`. There is no GPU copy: the upload the warn assumes happened is the one that was declined, so the level stays as it was, and nothing announces it again until the game writes those texels a second time. Every other pool keeps its staging and heals from the redirty; this class is the one that cannot.

## Root cause

`schedule_upload` released the staging of a staging-droppable level (`staging_droppable_class`: default pool, not dynamic, not a render target, depth, cube or volume) in the same call that pushed the upload op. Every step past that hand-off can still emit nothing: the destination texture may fail to create, the sampled-texture rename may find no destination, the staging wrapper or the padded repack may fail, and a texel-widening expansion has no blit that could stand in for the pass it needs. By then the only copy of the level's bytes is gone.

## Changes

`mtld3d-core`'s upload queue carries the encoder's positive answer as well as its declines. `note_emitted` takes an `EmittedUpload`, which names the subresource, the level, the number of the upload among the level's scheduled uploads, and whether the level is holding its staging for that answer; the ones that are queue for the drain. A decline filed for a subresource drops a release still waiting for it, because the retry reads exactly those pages.

`schedule_upload` no longer releases anything. It works out whether the level qualifies, stamps the upload with the level's next number and hands both to the job; the encoder reports them back once the upload reaches the command stream. `TextureInner` counts the uploads scheduled per level for the class that can release, next to the coverage tracking it already keeps for it.

`DeviceInner::apply_upload_answers` (the `Present` drain, formerly `apply_upload_redirty`) marks the declined uploads dirty again first, then releases the staging of each acknowledged level. The release re-reads the level's state, because the answer arrives a frame after the upload was scheduled: it stands down when a later upload of the level is still unanswered, when a write has marked the level dirty since, when a lock or a device context maps the pages, or when the coverage no longer says the GPU holds every texel. The drain's texture lookup now only maps the textures an answer names, since it runs on ordinary frames rather than only on the frames that declined something.

The end-to-end tests that want a released level take the frame the release happens in (`release_uploaded_staging`), so they keep exercising the path they were written for rather than passing on staging that is still resident.

## Alternatives

Hand the staging back on a decline: the job already holds an `Arc` of the pages, so the queue could carry it to the API thread and restore the level's slot. Rejected: it keeps the pages alive across the same window anyway, and it has to prove nothing re-created the level in the meantime, where the answer-driven release simply does not release yet.

Release on frame retirement instead of on the answer: retirement says the GPU consumed the frame, not that this upload was emitted into it, so a declined upload would still release.

Drop the release for this class: it is the change that took in-game texture staging from 501 MiB to 187 MiB inside a 32-bit address space, so it stays. The cost of the fix is one frame of latency on the release, bounded by what a single frame uploads.

## Verification

`make check`, `make ISOLATED=1 test` and `make ISOLATED=1 conformance` are green. The end-to-end suite is 460 passed, 0 failed on each of i686 and x86_64 (920 test results, 4 processes per architecture). Conformance reports no regressions against the baseline on both architectures; the device suite reads below its pinned ceilings on both, which the ceiling class tolerates, so the baseline is not re-recorded.

New unit tests in `windows/core/src/upload_redirty/tests.rs`: `an_emitted_upload_that_asked_for_it_reports_its_staging_released`, `an_emitted_upload_that_keeps_its_staging_releases_nothing`, `a_decline_cancels_a_release_the_same_subresource_is_waiting_for`, `a_decline_leaves_another_subresources_release_alone`, and `an_emitted_upload_that_releases_its_staging_also_gives_the_budget_back`. They pin the acknowledgement bookkeeping the release rests on; being tests of an interface this change introduces, they do not compile against the code before it.

No end-to-end test can fail before and pass after. Reaching the bug needs a declined upload, and every decline path is an allocation or a pipeline creation that failed, none of which an application can provoke through the D3D9 API. The release itself is deliberately invisible through that API as well: a released level is re-materialised before any lock, device context or upload reads it, so a test can only observe that the pixels are right, which they were before this change too. What the existing tests do pin, with the extra frame, is that the level survives the release when it happens at its new point: `default_pool_texture_takes_a_second_update_after_its_upload`, `partial_updates_covering_a_default_pool_level_keep_its_pixels`, `update_surface_sub_rect_keeps_the_rest_of_the_level`, `lock_of_a_released_default_pool_level_reads_the_level_back`, `get_dc_on_a_released_default_pool_level_reads_the_level_back`, `discard_lock_of_a_released_default_pool_level_rewrites_it` and `single_slice_default_volume_takes_a_second_update_after_its_upload`.

Rules check: no new config key, environment variable, static, wire field, dependency or lint suppression. The one new type (`EmittedUpload`) derives only `Debug`, so the derive inventory is unchanged. Pure bookkeeping stays in `mtld3d-core`; the `windows/d3d9` side is the scheduler, the encoder answer and the drain. Unit tests live in the existing `upload_redirty/tests.rs` child module.

Closes #419
