### PR TITLE
Size the CI budgets to green durations and bound the runner's stderr drain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   build:
     if: ${{ !inputs.probe_only }}
     runs-on: macos-26
-    timeout-minutes: 45
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
         with:
@@ -121,7 +121,7 @@ jobs:
   check:
     if: ${{ !inputs.probe_only }}
     runs-on: macos-26
-    timeout-minutes: 60
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
         with:
@@ -186,11 +186,17 @@ jobs:
   # all fit an existing combination is folded into it instead, and that
   # would turn the macos-26/i686 identity leg into the scaled one. The job
   # name is spelled out so the empty value does not show in it.
+  # A green leg takes two to four minutes, four Wine processes included. The
+  # budget is a multiple of that, not of the worst case the runner's watchdog
+  # can produce: a process that faults and leaves Wine's debugger holding the
+  # pipes costs the watchdog period twice over, and a leg where every process
+  # does so would run the whole hour under the old budget while saying nothing
+  # a shorter one does not.
   e2e:
     name: e2e (${{ matrix.runner }}, ${{ matrix.arch }}${{ matrix.scale && format(', scale {0}', matrix.scale) || '' }})
     needs: build
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -213,7 +219,7 @@ jobs:
       # narrows the run and collects the layer's log files, which are
       # otherwise written beside each test binary and pruned to the ten
       # newest.
-      - run: make test-e2e-${{ matrix.arch }} STAGE="$STAGE" JOBS=1 TIMEOUT=240 FAIL_FAST=0 INTEL=${{ matrix.runner == 'macos-15-intel' && '1' || '' }} SCALE="${{ matrix.scale }}" FILTER="$E2E_FILTER" LOG_DIR="$LOG_DIR"
+      - run: make test-e2e-${{ matrix.arch }} STAGE="$STAGE" JOBS=1 TIMEOUT=120 FAIL_FAST=0 INTEL=${{ matrix.runner == 'macos-15-intel' && '1' || '' }} SCALE="${{ matrix.scale }}" FILTER="$E2E_FILTER" LOG_DIR="$LOG_DIR"
         env:
           E2E_FILTER: ${{ inputs.e2e_filter }}
           # The layer reads the path on the Windows side, where the unix
@@ -252,11 +258,15 @@ jobs:
   # `include` entry becomes its own combination rather than being folded into
   # the macos-26/i686 native leg; the job name is spelled out so the empty
   # value does not show in it.
+  # A green leg takes four to six minutes; the longest single subtest on the
+  # Intel image stays under four, which is what the per-subtest budget below
+  # is sized against. A `conformance_repeat` dispatch runs one subtest twenty
+  # times and legitimately needs the old hour.
   conformance:
     name: conformance (${{ matrix.runner }}, ${{ matrix.arch }}${{ matrix.variant && format(', {0}', matrix.variant) || '' }})
     needs: build
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.conformance_repeat && 60 || 20 }}
     strategy:
       fail-fast: false
       matrix:
@@ -344,7 +354,7 @@ jobs:
       matrix:
         runner: [macos-26, macos-15, macos-15-intel]
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 20
+    timeout-minutes: 10
     steps:
       - name: Host
         run: |

--- a/Makefile
+++ b/Makefile
@@ -617,8 +617,9 @@ test-unit:
 # creation cannot overlap at all, stays at 1 either way. TIMEOUT=<secs> is
 # how long a process may go without reporting a result before the runner
 # kills it and charges the hang to the test that was running (default 60);
-# the same bound covers a process that has closed stdout but will not exit,
-# and a process tree that keeps stderr open after the process is gone.
+# the same bound covers a process that has closed stdout but will not exit.
+# A process tree that keeps stderr open after the process is gone gets a
+# one-second grace, not the bound: nothing it says after that is the test's.
 #
 # A scaled or Intel-variant run reports the whole suite instead of stopping at
 # the first failure, and FAIL_FAST=0 asks for that on any run. The point of

--- a/unix/e2e/src/run.rs
+++ b/unix/e2e/src/run.rs
@@ -4,12 +4,17 @@
 //! the whole suite run in one process and a report has to show progress
 //! while they run, and because a process that stops reporting is the only
 //! sign of a hung test: the watchdog kills it once no line has arrived for
-//! the caller's timeout. stderr is collected whole; it carries the panic
-//! reports and Wine's own diagnostics, read after the process has ended.
+//! the caller's timeout. stderr is collected as it arrives too, but handed
+//! back whole once the process has ended; it carries the panic reports and
+//! Wine's own diagnostics.
 //!
-//! The same timeout bounds the end of the process: one that closes stdout
-//! and then never exits, or leaves a descendant holding stderr open, is
-//! killed once the timeout passes with no exit or no end of stderr. The
+//! The same timeout bounds a process that closes stdout and then never
+//! exits: it is killed once the timeout passes with no exit. What comes
+//! after the process is gone gets only a short grace: a descendant that
+//! still holds stderr (Wine's debugger walking a crashed process's DWARF is
+//! one) has nothing of the test's left to say, so the run drains what has
+//! arrived, kills the group once more and moves on, rather than paying the
+//! timeout a second time for an end of stderr that may never come. The
 //! child runs in a process group of its own so the kill takes every process
 //! Wine forked under it, and never the wineserver the caller booted for the
 //! whole run, which belongs to the caller's group.
@@ -61,11 +66,19 @@ pub struct Exit {
 /// How often the bounded wait for the process's exit looks again.
 const EXIT_POLL: Duration = Duration::from_millis(20);
 
+/// How long stderr may stay open after the process has ended.
+///
+/// A pipe every holder has died on closes within milliseconds of the kill;
+/// one still open past this has a survivor on it, whose output is not the
+/// test's.
+const STDERR_GRACE: Duration = Duration::from_secs(1);
+
 /// Run `wine <exe> <args...>` in the exe's directory, streaming stdout lines to `on_line`.
 ///
 /// Killed, and reported as [`ExitKind::TimedOut`], once `timeout` passes
 /// without a stdout line; killed, and reported as [`ExitKind::Hung`], once
-/// it passes after stdout closed without the process exiting. The
+/// it passes after stdout closed without the process exiting. stderr is
+/// what arrived before the end plus [`STDERR_GRACE`] after it. The
 /// environment is inherited whole: the caller owns `MTLD3D_CONFIG` and the
 /// Wine variables.
 ///
@@ -103,11 +116,16 @@ pub fn run(
             }
         }
     });
-    let (stderr_tx, stderr_rx) = mpsc::channel::<String>();
+    // stderr comes over in chunks so that what the process wrote before it
+    // died is in hand the moment it is gone; the sender dropping is the EOF.
+    let (stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>();
     thread::spawn(move || {
-        let mut buf = Vec::new();
-        let _ = stderr.read_to_end(&mut buf);
-        let _ = stderr_tx.send(String::from_utf8_lossy(&buf).into_owned());
+        let mut chunk = [0u8; 4096];
+        while let Ok(n) = stderr.read(&mut chunk) {
+            if n == 0 || stderr_tx.send(chunk[..n].to_vec()).is_err() {
+                break;
+            }
+        }
     });
 
     let mut timed_out = false;
@@ -131,14 +149,17 @@ pub fn run(
             .map_err(|e| format!("wait on {} failed: {e}", exe.display()))?;
         (status, true)
     };
-    let stderr = stderr_rx.recv_timeout(timeout).unwrap_or_else(|_| {
+    let mut stderr = drain_stderr(&stderr_rx, STDERR_GRACE);
+    if !stderr.complete {
+        // Something the kill did not reach still holds the pipe: a process
+        // that put itself in another group. Say so, and try the kill once
+        // more for whatever did land in the group since.
         kill_group(&child);
-        let mut stderr = stderr_rx.recv_timeout(EXIT_POLL).unwrap_or_default();
-        stderr.push_str(
-            "[e2e] stderr not collected in full: the process tree held it open past the timeout\n",
+        stderr.text.push_str(
+            "[e2e] stderr not collected in full: the process tree held it open past the end\n",
         );
-        stderr
-    });
+    }
+    let stderr = stderr.text;
     let kind = if timed_out {
         ExitKind::TimedOut(timeout)
     } else if hung {
@@ -149,6 +170,34 @@ pub fn run(
         ExitKind::Code(status.code().unwrap_or(-1))
     };
     Ok(Exit { kind, stderr })
+}
+
+/// Everything stderr delivered, and whether its end was seen.
+struct Stderr {
+    text: String,
+    complete: bool,
+}
+
+/// Collect stderr chunks until the pipe closes or `grace` passes without one.
+fn drain_stderr(chunks: &mpsc::Receiver<Vec<u8>>, grace: Duration) -> Stderr {
+    let mut buf = Vec::new();
+    loop {
+        match chunks.recv_timeout(grace) {
+            Ok(chunk) => buf.extend_from_slice(&chunk),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Stderr {
+                    text: String::from_utf8_lossy(&buf).into_owned(),
+                    complete: true,
+                };
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                return Stderr {
+                    text: String::from_utf8_lossy(&buf).into_owned(),
+                    complete: false,
+                };
+            }
+        }
+    }
 }
 
 /// The process's exit status if it exits within `timeout`, `None` if it does not.

--- a/unix/e2e/src/run/tests.rs
+++ b/unix/e2e/src/run/tests.rs
@@ -57,6 +57,37 @@ fn a_process_that_closes_stdout_and_never_exits_is_killed_and_reported_hung() {
 }
 
 #[test]
+fn a_killed_process_whose_survivor_holds_stderr_costs_the_grace_not_the_timeout() {
+    // The script goes silent, so the watchdog kills its group; the perl
+    // child moved itself to a group of its own first and keeps stderr open
+    // past the kill, as Wine's debugger does after a crash.
+    let path = script(
+        "escaped",
+        "echo start\necho early >&2\n(perl -e 'setpgrp(0,0); sleep 30' >/dev/null) &\nsleep 30\n",
+    );
+    let timeout = Duration::from_secs(2);
+    let (exit, elapsed, lines) = run_script(&path, timeout);
+    assert_eq!(exit.kind, ExitKind::TimedOut(timeout));
+    assert_eq!(lines, ["start"]);
+    assert!(
+        exit.stderr.starts_with("early\n"),
+        "stderr: {:?}",
+        exit.stderr
+    );
+    assert!(
+        exit.stderr.contains("stderr not collected in full"),
+        "stderr: {:?}",
+        exit.stderr
+    );
+    // One timeout for the silence, the grace for stderr, and slack; the old
+    // shape paid the timeout twice.
+    assert!(
+        elapsed < timeout + Duration::from_secs(2),
+        "took {elapsed:?}"
+    );
+}
+
+#[test]
 fn a_descendant_holding_stderr_does_not_park_the_run() {
     // The script exits at once; its background child keeps stderr open.
     let path = script("holder", "echo done\n(sleep 30 >/dev/null) &\nexit 0\n");


### PR DESCRIPTION
## Symptoms

The Intel x86_64 e2e leg of main run 33990530825 ran for the full hour of its budget and was cut off with about 160 of 466 tests still to go, while every other job of that run was green inside six minutes. Its log is 124 failing tests reading back black, each ending its process, and ten of those deaths followed by `[e2e] stderr not collected in full: the process tree held it open past the timeout`, each of which cost the runner's full 240 s watchdog period: 40 of the 60 minutes were spent waiting for an end of stderr that never came, under thousands of `fixme:dbghelp_dwarf:compute_location` lines from Wine's debugger walking the crashed process's DWARF.

The job budgets were an hour for e2e and conformance, 45 minutes for the build and an hour for the check, against green durations of two to four, four to six, four to five and seven to eight minutes.

## Root cause

When a test process faults under Wine, the crashed process starts `winedbg --auto` through `CreateProcess`, and the debugger inherits the process's stderr. The runner's stdout watchdog kills the child's process group after `TIMEOUT` seconds of silence, the exit wait returns at once, and the stderr collection then waited for EOF for another full `TIMEOUT` before giving up, because the collection was a single `read_to_end` that could only finish at EOF. A debugger that outlives the kill therefore doubled the cost of every wedge, and a leg with several of them ran out the job budget saying nothing its first minutes had not said.

The job budgets were never sized against measured durations.

## Changes

- `unix/e2e/src/run.rs`: stderr is read in chunks over a channel, so what the process wrote before it died is in hand the moment it is gone. After the process has ended, the drain waits at most `STDERR_GRACE` (one second) for the pipe to close; a pipe still open past that has a survivor on it, whose output is not the test's, so the run notes `stderr not collected in full`, kills the group once more and moves on. The exit wait after stdout closes keeps the full `TIMEOUT`, since the process itself may still be finishing.
- `.github/workflows/ci.yml`: budgets sized to a multiple of the green duration: 20 minutes for build, check, e2e and conformance, 10 for the probe; the e2e runner's per-process watchdog goes from 240 s to 120 s (a green leg's longest silence is well under a minute, and four wedged processes at one period each still fit the job). A `conformance_repeat` dispatch keeps the hour, since it runs one subtest twenty times on purpose. The per-subtest conformance budget stays at 600 s: the device subtest on the Intel image is silent for up to 209 s in a green run.
- `Makefile`: the `TIMEOUT` knob's comment says what the grace covers.

## Alternatives

- Keep Wine's debugger out of the test prefix (`winedbg.exe=d`): would remove the DWARF spam as well, but its backtrace has been useful for faults inside Wine's own code, so that stays a separate decision.
- Lower the per-process watchdog to the Makefile's 60 s default: a green leg's silence is far below that, but the Intel image's first device creation and the mode-set tests have no measured worst case, so 120 s keeps a margin.

## Verification

- `cd unix && cargo nextest run -p mtld3d-e2e`: 29 passed. New `run::tests::a_killed_process_whose_survivor_holds_stderr_costs_the_grace_not_the_timeout`: a script goes silent while a `perl` child in its own process group keeps stderr open; with the old collection the run took two timeouts (4 s at `TIMEOUT=2`), now one plus the grace (3.0 s measured), and the stderr written before the kill is still delivered. The three existing deadline tests keep their bounds.
- `make check`: green.
- The runner change is exercised by every e2e leg of this PR's CI; the budgets are exercised by the jobs finishing inside them.

Closes #440
