### PR TITLE
Upload the layer's e2e logs on every CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,7 @@ on:
       e2e_filter:
         description: >-
           Run only the end-to-end tests whose id contains one of these
-          whitespace-separated patterns (e.g. `stencil msaa::`), with their
-          log files uploaded.
+          whitespace-separated patterns (e.g. `stencil msaa::`).
         type: string
         default: ''
       conformance_repeat:
@@ -216,17 +215,29 @@ jobs:
       # hangs on the paravirtual GPU. The whole suite is reported rather than
       # the first failure, and a test that is only slow there gets four
       # minutes before it counts as a hang. A dispatch with `e2e_filter`
-      # narrows the run and collects the layer's log files, which are
-      # otherwise written beside each test binary and pruned to the ten
-      # newest.
+      # narrows the run.
+      # The layer's log of every test process goes under the runner's temp
+      # directory, where the step below picks it up, rather than beside the
+      # test binary. The job log carries only what reached stdout: the
+      # PASS/FAIL lines, the panic messages and a tail of stderr that Wine's
+      # debugger fills. What the command buffers reported is in the layer's
+      # log, and that is what tells a runner whose GPU reads back black on
+      # every test from a regression in the commits since the last green run.
+      # The directory keeps the ten newest logs, so a leg that restarts more
+      # than ten processes hands back its last ten; a runner fault persists,
+      # so those carry it.
       - run: make test-e2e-${{ matrix.arch }} STAGE="$STAGE" JOBS=1 TIMEOUT=120 FAIL_FAST=0 INTEL=${{ matrix.runner == 'macos-15-intel' && '1' || '' }} SCALE="${{ matrix.scale }}" FILTER="$E2E_FILTER" LOG_DIR="$LOG_DIR"
         env:
           E2E_FILTER: ${{ inputs.e2e_filter }}
           # The layer reads the path on the Windows side, where the unix
           # root is drive Z.
-          LOG_DIR: ${{ inputs.e2e_filter && format('Z:{0}', runner.temp) || '' }}
+          LOG_DIR: Z:${{ runner.temp }}
+      # `always()`, as for the conformance output below: a diverging leg is
+      # the one whose logs are worth reading, and a leg cut off by its budget
+      # ends cancelled, not failed. A leg that dies before any process logs a
+      # line has nothing to upload, and that must not turn one red into two.
       - uses: actions/upload-artifact@v4
-        if: ${{ always() && inputs.e2e_filter }}
+        if: always()
         with:
           name: e2e-logs-${{ matrix.runner }}-${{ matrix.arch }}${{ matrix.scale && format('-scale-{0}', matrix.scale) || '' }}
           path: ${{ runner.temp }}/*.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,15 @@ redirect, `make test > out.log 2>&1`, and judge the run by the runner's
 summary on both architectures. mtld3d's log of each test process is a file,
 `<binary>-<pid>.log` under `mtld3d-logs` next to the test executable in
 `windows/target`, one per process, so one file carries the whole suite's log.
+In CI every end-to-end leg uploads those files as its `e2e-logs-<image>-<arch>`
+artifact on every run, kept fourteen days; the directory holds the ten newest,
+so a leg that restarted more than ten processes hands back its last ten. They
+are the layer's side of a red leg, which the job log lacks: when one image
+reads back black on test after test while its sibling legs are green, re-run
+the failed jobs first (`gh run rerun <run-id> --failed`, which lands on a
+fresh machine) and read the command buffer errors in the artifact's log,
+since a hosted runner's GPU can fail that way with no hang line in the job
+log and nothing else tells it from a regression.
 
 Two things are worth knowing when a test process looks wrong. `d3d9.dll`
 terminates the process from its `DLL_PROCESS_DETACH` once a device exists

--- a/Makefile
+++ b/Makefile
@@ -529,7 +529,8 @@ stage: all
 #
 # LOG_DIR=<path> puts every test process's log file (and its GPU traces) in
 # one directory instead of beside each test binary, so a machine that is only
-# reachable through its artifacts (a CI runner) can hand the logs back. The
+# reachable through its artifacts (a CI runner) can hand the logs back, which
+# every CI end-to-end leg does. The
 # path is read on the PE side: an absolute Windows path (`Z:\...` for a unix
 # path under Wine). Ten files are kept per directory.
 INTEL_CONF := intel.expandPacked16=true;intel.denyFloat32Filtering=true;intel.managedMemory=true;intel.linearAlign256=true


### PR DESCRIPTION
Closes #442.

Symptom: a failing e2e leg on a push run keeps only the job log. Main run 33990530825 had the Intel x86_64 leg read back black on 124 tests with no `kIOAccelCommandBufferCallbackErrorHang` line anywhere, and the job log said "got 0,0,0,0" 124 times and nothing about why; the same job on a fresh runner passed 469/469 in three minutes. The layer's per-process logs, with the command buffer errors Metal reported, were written on the runner and discarded, because both the `LOG_DIR` the Makefile feeds into `log.dir` and the upload step were gated on an `e2e_filter` dispatch.

Changes: every e2e leg now writes the layer's logs under the runner's temp directory and uploads them as `e2e-logs-<image>-<arch>` with `if: always()` and 14-day retention, the way the conformance job uploads its raw output. `always()` rather than `failure()` because the incident's job ended cancelled at its budget, where `failure()` is false. The layer keeps the ten newest logs per directory, so a leg that restarts more than ten processes hands back its last ten; a runner fault persists, so those carry it. The `e2e_filter` input description no longer claims the upload, and CONTRIBUTING.md names the artifact and the recipe: one image reading back black while its siblings are green is re-run first, then read from the artifact.

Alternatives: `failure() || inputs.e2e_filter` would have missed the cancelled job. A runner-side scan of stderr for the driver's hang lines was left out on purpose: this failure mode left no such line, and the signature it does leave is what the uploaded logs will show next time. Raising the ten-file cap would need a config key, not wanted for this.

Verification: `make audit` and `make fmt-check` green; nothing in Rust changes, so the clippy, doc and unit legs are this run's. The workflow YAML parses with the step's `LOG_DIR` and `if` as intended. A filtered local leg with the variable set the way CI sets it (`make test-e2e-x86_64 FILTER='msaa::' LOG_DIR="Z:<dir>"`) passed 15/15 and left `e2e-<hash>-<pid>.log` where the upload step globs. On this run, each of the seven e2e jobs carries an `e2e-logs-*` artifact with the three per-process logs of the binaries that load d3d9.dll (`snmalloc_drift` never does, so it leaves none); run 34019709826, every job green.

