### PR TITLE
Gate the release tag against the workspace versions and draft the release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: ci
 on:
   push:
     branches: [main]
+    # A release is a `v*` tag, and it runs the `release` job alone: see the
+    # comment above that job for why the matrix does not run a second time.
+    tags: ['v*']
   pull_request:
   # So a branch can be run through the whole matrix before it has a PR, or
   # only through the runner probe at the bottom.
@@ -78,14 +81,16 @@ env:
 # machines that carry no toolchain, the slow Intel image included, and no
 # compile happens twice. `check` runs every lint, doc and unit leg as steps of
 # one job, then builds the distribution bundle, since each of those is short and
-# a machine per leg cost more in setup than in work.
+# a machine per leg cost more in setup than in work. A tag push runs none of
+# that and only `release`, which reads the result the same commit already got
+# on main.
 jobs:
   # Everything a test machine needs, built once on the fast image: both PE
   # arches, both unix `.so` builds, the e2e test binaries, and the e2e and
   # conformance runners for both host arches. Primes the caches the check job
   # restores too.
   build:
-    if: ${{ !inputs.probe_only }}
+    if: ${{ !inputs.probe_only && !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: macos-26
     timeout-minutes: 20
     steps:
@@ -118,7 +123,7 @@ jobs:
   # the production profile's fat LTO is exercised here rather than first
   # failing when a release is cut.
   check:
-    if: ${{ !inputs.probe_only }}
+    if: ${{ !inputs.probe_only && !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: macos-26
     timeout-minutes: 20
     steps:
@@ -350,6 +355,104 @@ jobs:
           path: unix/conformance/baseline.txt
           retention-days: 14
           if-no-files-found: error
+
+  # A `v*` tag is a release, and the tag push runs this job on its own. The
+  # matrix is not run a second time: the gate here is main's own run at this
+  # exact commit, which is the same tree, so re-running it would cost half an
+  # hour to learn what merging the commit already established. What this job
+  # adds is the work a release used to take by hand, where each step was only
+  # as reliable as whoever remembered it.
+  #
+  # The tag has to agree with the version both workspaces carry, or the shipped
+  # DLLs name a release nobody published: every binary stamps `git describe`,
+  # which is also why the bundle is built here, after the tag exists, rather
+  # than taken from the `check` job that ran before it.
+  #
+  # It drafts and stops: the body it creates is empty because the notes are
+  # written by hand, and the maintainer publishes. CONTRIBUTING.md carries the
+  # procedure around this job.
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: macos-26
+    # Long, because the step below waits for main's run when the tag was pushed
+    # on the heels of the commit.
+    timeout-minutes: 60
+    permissions:
+      # The draft, and the query for main's run.
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-tags: true
+      # First, before a toolchain is fetched: a tag that disagrees with the
+      # manifests is answered in seconds instead of after a bundle build.
+      - name: version-check
+        env:
+          TAG: ${{ github.ref_name }}
+        run: make version-check TAG="$TAG"
+      # The gate that replaces re-running the matrix. A run that has not
+      # finished is waited on, since main is pushed and tagged in one sitting;
+      # a run that never appears means the tag names a commit that never landed
+      # on main, which no amount of waiting fixes, so that gets a short grace
+      # and then a verdict.
+      - name: The ci run for this commit on main is green
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          missing=0
+          for _ in $(seq 90); do
+            read -r status conclusion url <<<"$(gh run list --workflow ci.yml \
+              --commit "$GITHUB_SHA" --event push --branch main --limit 1 \
+              --json status,conclusion,url \
+              --jq '.[] | "\(.status) \(.conclusion) \(.url)"')"
+            if [ -z "$status" ]; then
+              missing=$((missing + 1))
+              if [ "$missing" -gt 10 ]; then
+                echo "::error::no ci run on main for $GITHUB_SHA: this tag names a commit that never landed there"
+                exit 1
+              fi
+              echo "no ci run for $GITHUB_SHA on main yet"
+            elif [ "$status" = completed ]; then
+              if [ "$conclusion" != success ]; then
+                echo "::error::$url concluded $conclusion, so this commit is not a release"
+                exit 1
+              fi
+              echo "$url is green"
+              exit 0
+            else
+              echo "$url is $status"
+            fi
+            sleep 30
+          done
+          echo "::error::main's ci run for $GITHUB_SHA had not finished after 45 minutes; re-run this job once it has"
+          exit 1
+      - uses: ./.github/actions/prepare
+        with:
+          pe: 'true'
+          wine-release: ${{ env.WINE_RELEASE }}
+      # PROD=1 is this target's default, so the archives carry the production
+      # profile, and the target verifies that every binary in them is stamped
+      # with the tag before it writes either one.
+      - name: bundle
+        run: make bundle
+      # Re-running the job after a failed upload finds the draft it already
+      # made and replaces the assets, rather than failing on a tag that has a
+      # release.
+      - name: Draft the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" --clobber \
+              windows/target/mtld3d.tar.xz windows/target/mtld3d-debug.tar.xz
+          else
+            gh release create "$TAG" --draft --title "$TAG" --notes "" \
+              windows/target/mtld3d.tar.xz windows/target/mtld3d-debug.tar.xz
+          fi
+          echo "Drafted $TAG with both archives. Write the notes, then publish:" >> "$GITHUB_STEP_SUMMARY"
+          echo '`gh release edit '"$TAG"' --draft=false --latest`' >> "$GITHUB_STEP_SUMMARY"
 
   # Manual only: what a hosted macOS runner exposes to Metal, on every image
   # the matrices above use. The OS, the device, and the capability bits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,3 +316,28 @@ reproduced or root-caused locally yet.
 
 File the issue with its labels attached. When a claim in an issue body stops
 being true, edit the body rather than correcting it in a comment trail.
+
+## Cutting a release
+
+A release is a `v*` tag, and pushing one is the whole trigger: CI drafts the
+release, attaches the two archives `make bundle` produces, and leaves the body
+empty for the notes, which are written by hand.
+
+The version lives in the `[workspace.package]` table of both `Cargo.toml`s and
+in the local-crate entries of both `Cargo.lock`s, so the bump is its own commit
+touching four files. Refresh each lock with `cargo metadata --format-version 1
+--manifest-path <workspace>/Cargo.toml > /dev/null`, which rewrites the version
+lines without the dependency churn `cargo update` would bring, and check the bump
+before tagging with `make version-check TAG=vX.Y.Z`.
+
+Land that commit, wait for its run on `main` to go green, then push the tag. The
+release job refuses a tag whose version disagrees with either workspace, and
+refuses one whose commit has no green run on `main`; a tag pushed while that run
+is still going is waited on rather than rejected. It builds the bundle itself,
+after the tag exists, because every binary stamps `git describe` and one built
+before the tag names the previous release.
+
+What is left is the notes and the publish. Group the points into sections rather
+than one flat list, give the two or three headline items a section each, and end
+every point with the pull requests that did it. Then
+`gh release edit vX.Y.Z --draft=false --latest`.

--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,13 @@ DEBUG_STAGE  := $(CURDIR)/windows/target/bundle-debug
 BUILD_ID     := $(shell git describe --tags --always 2>/dev/null || \
                         sed -n 's/^version = "\(.*\)"/v\1/p' windows/Cargo.toml)
 
+# The tag a release is cut at. Defaults to the one on HEAD, so a checkout of a
+# tag needs no argument; the release job passes the ref it was triggered by, and
+# a maintainer about to cut a release passes the tag they are about to create
+# (`make version-check TAG=v0.9.0`), which is the only way to check a bump
+# before the tag exists.
+TAG          ?= $(shell git describe --tags --exact-match 2>/dev/null)
+
 # Target naming, two vocabularies with one rule each:
 #
 #   windows / unix   the two cargo workspaces, which are also the two
@@ -265,7 +272,7 @@ BUILD_ID     := $(shell git describe --tags --always 2>/dev/null || \
 # Wine install, never into a file named after the target.
 .PHONY: all windows windows-i686 windows-x86_64 unix unix-x64 unix-arm64 \
 	install install-windows-i686 install-windows-x86_64 install-unix-x64 install-unix-arm64 \
-	bundle stage configure-test-prefix clean-isolated clean-isolated-all \
+	bundle version-check stage configure-test-prefix clean-isolated clean-isolated-all \
 	test test-unit test-e2e-i686 test-e2e-x86_64 \
 	conformance conformance-i686 conformance-x86_64 \
 	conformance-baseline conformance-baseline-i686 conformance-baseline-x86_64 \
@@ -411,6 +418,43 @@ install-unix-arm64: $(if $(STAGE),,unix-arm64)
 		fi ; \
 	done
 
+# The gate a release tag has to pass. Every shipped binary stamps `git describe`
+# (BUILD_ID above), so a tag that disagrees with the version the workspaces
+# carry ships DLLs naming a release nobody published, and nothing says so until
+# a user reports a version that does not exist. The locks are read alongside the
+# manifests because they record the version of every local crate: a bump that
+# refreshed one workspace's lock and not the other leaves the tree disagreeing
+# with itself.
+#
+# A local crate is one the lock gives no `source`. Clearing the name on that
+# line is what keeps a registry crate's own version out of the comparison, since
+# every package but ours has one.
+define LOCK_VERSIONS
+function chk() {
+    if (n != "" && v != "\"" w "\"") {
+        printf "version-check: %s records %s for %s, the manifest says \"%s\"\n", \
+            FILENAME, v, n, w
+        e = 1
+    }
+    n = ""; v = ""
+}
+/^name = /    { n = $$3 }
+/^version = / { v = $$3 }
+/^source = /  { n = "" }
+/^$$/         { chk() }
+END           { chk(); exit e }
+endef
+export LOCK_VERSIONS
+
+version-check:
+	test -n "$(TAG)" || { echo "version-check: HEAD carries no tag and none was given; pass the tag you are about to create, TAG=vX.Y.Z" >&2; exit 2; }
+	for ws in windows unix; do \
+		manifest=$$(sed -n 's/^version = "\(.*\)"/v\1/p' $$ws/Cargo.toml | head -1) ; \
+		test "$$manifest" = "$(TAG)" || { echo "version-check: $$ws/Cargo.toml says $$manifest, the tag says $(TAG)" >&2; exit 1; } ; \
+		awk -v w="$${manifest#v}" "$$LOCK_VERSIONS" $$ws/Cargo.lock >&2 || exit 1 ; \
+	done
+	echo "version-check: $(TAG) matches both workspaces"
+
 # Distribution bundle, serving both install routes (see INSTALL.md, which is
 # shipped inside): wine/ mirrors a Wine installation's lib/wine/ with every
 # PE builtin-marked (drop-in for a Wine tree the user owns), while native/
@@ -452,6 +496,19 @@ bundle: all
 	cp -c $(CURDIR)/mtld3d.conf            $(BUNDLE_STAGE)/
 	cp -c $(CURDIR)/INSTALL.md             $(BUNDLE_STAGE)/
 	cp -c $(CURDIR)/LICENSE                $(BUNDLE_STAGE)/
+	# The identity every binary stamps has to be this build's: a bundle
+	# assembled from a stale target dir is how a release ships DLLs naming the
+	# previous tag, and neither the version gate nor the archive itself can see
+	# that. A binary carries exactly one of these, so finding this one is
+	# enough. The two prefix markers are winebuild placeholders holding no code,
+	# so they carry no stamp and are not swept.
+	test -n "$(BUILD_ID)" || { echo "bundle: this build has no identity to check the binaries against" >&2; exit 1; }
+	for f in $(BUNDLE_STAGE)/wine/i386-windows/*.dll \
+	         $(BUNDLE_STAGE)/wine/x86_64-windows/*.dll \
+	         $(BUNDLE_STAGE)/wine/$(UNIX_WINEDIR_x64)/mtld3d.so \
+	         $(BUNDLE_STAGE)/wine/$(UNIX_WINEDIR_arm64)/mtld3d.so ; do \
+		LC_ALL=C grep -a -q -F "$(BUILD_ID)" $$f || { echo "bundle: $$f is not stamped $(BUILD_ID); it was built at another commit, rebuild it" >&2; exit 1; } ; \
+	done
 	tar -cJf $(BUNDLE_OUT) -C $(BUNDLE_STAGE) wine native prefix-markers mtld3d.conf INSTALL.md LICENSE
 	# The symbols for exactly these binaries, as a second archive. Laid out by
 	# arch alone, with no wine/native split: debug info has no install route, and


### PR DESCRIPTION
Closes #385.

Symptom: folding the workflows into one deleted `release.yml`, and two things it did were never replaced. It drafted a release on a `v*` tag push, and it failed the push when the tag disagreed with the `version` in either `[workspace.package]` table. v0.8.0 was the first release cut without it, so both were hand work: `gh release create --draft` for the draft, then reading `BUILD` out of the debug archive and running `strings` over every shipped binary to confirm the tag and the manifests agreed. That check runs only if whoever cuts the release remembers it, and a mismatch is silent until a user reports a binary naming a version that does not exist.

Two things can drift, for the same reason: every shipped binary stamps `git describe --tags` from `unix/shared/build.rs` and the Makefile computes `BUILD_ID` from the same expression. A tag that disagrees with the manifests ships DLLs naming a release nobody published, and a bundle assembled from a build made before the tag existed stamps every DLL with the previous release.

Changes, three:

`make version-check` compares a tag against the version each workspace carries, in the manifest and in every local-crate entry of the lock, so a bump that touched one workspace or left a lock behind is caught with the manifests rather than after the tag is pushed. It defaults to the tag on HEAD and takes `TAG=vX.Y.Z`, which is how a bump is checked before the tag exists.

`make bundle` now requires every binary going into the archives to carry this build's identity before it writes either one. A binary holds exactly one, so finding this one is the whole check; the two prefix markers are `winebuild` placeholders holding no code and are not swept. That gate runs on every pull request too, since the check job already builds the bundle.

A `v*` tag push runs a new `release` job alone: `build` and `check` sit out a tag, and the test legs skip with `build`. The job runs version-check first, then requires the ci run this commit already got on main to be green, waiting for it when the tag was pushed on the heels of the commit and refusing outright when the commit never landed on main. Then it builds the bundle, after the tag exists, and drafts a release with both archives attached and an empty body. Re-running it replaces the assets instead of failing on a tag that already has a release. The notes stay hand-written, and `CONTRIBUTING.md` now carries the procedure around the job, which had no home in the tree.

Alternatives: running the whole matrix on the tag push and gating the draft on it proves the same thing about the same tree and costs another half hour of six whole-suite legs per release, so main's own run at that commit is the cheaper form of the same evidence. Restoring `release.yml` as its own file would have duplicated the toolchain and Wine pins `ci.yml` deliberately holds in one place. The lock check could have gone into `scripts/audit.sh` to run on every commit, but a release rule has no section in `docs/CONVENTIONS.md` to name, and one home for the whole gate reads better than two.

Rules check: no new static, config key, wire field, dependency, derive or lint suppression; no new script, since `version-check` is a Makefile target rather than a `scripts/` helper; no new environment variable, since `TAG` is a make variable with a default; no duplicate, since the tag gate has no implementation in the tree today and `version-check` reuses the `BUILD_ID` expression for reading the manifest version; and the tag trigger adds no job to a pull request or a main push, reorders nothing, and adds no matrix axis.

Verification: `make check` clean, with `audit: clean (299 files)` and zero warnings, and `make test ISOLATED=1` green on both architectures, 473 of 473 in four processes each. `make version-check` passes at `TAG=v0.8.0`, fails at `TAG=v0.9.0` naming `windows/Cargo.toml` and both values, names all six local crates when a manifest is bumped without its lock, and exits 2 when HEAD carries no tag and no `TAG` is given. `make bundle` passes at HEAD, fails naming the first binary under a forced `BUILD_ID` mismatch, refuses to sweep against an empty identity, and leaves no archive behind when it fails. The `gh run list` query the release job uses was run against the current main commit, where it returns that commit's green run, and against an unknown sha, where it returns nothing. The release job itself is first exercised by a tag push, so this run proves only that it stays out of a pull-request run.
