### PR TITLE
Read the environment-isolation pin's MTLD3D_CONFIG under the harness lock

### DIFF
--- a/windows/tests/src/harness.rs
+++ b/windows/tests/src/harness.rs
@@ -143,6 +143,17 @@ pub struct DrawIndexedUpParams {
     pub index_format: u32,
 }
 
+/// The suite-wide `MTLD3D_CONFIG`, read under the shared environment lock.
+///
+/// `None` when the variable is unset. The lock keeps a harness that is
+/// publishing entries of its own out of the read, so the value is always
+/// the suite-wide one, never a merged window in flight on another thread.
+#[must_use]
+pub fn config_var() -> Option<String> {
+    let _shared = ENVIRONMENT.read().unwrap_or_else(PoisonError::into_inner);
+    std::env::var(CONFIG_VAR).ok()
+}
+
 /// True when the suite rasterizes at the resolution D3D9 reports.
 ///
 /// `make test SCALE=<n>` puts `render.scale` in `MTLD3D_CONFIG` for every test
@@ -159,11 +170,7 @@ pub struct DrawIndexedUpParams {
 /// [`HarnessConfig::config_entries`] knows what it asked for.
 #[must_use]
 pub fn render_scale_is_identity() -> bool {
-    let config = {
-        let _shared = ENVIRONMENT.read().unwrap_or_else(PoisonError::into_inner);
-        std::env::var(CONFIG_VAR)
-    };
-    let Ok(config) = config else {
+    let Some(config) = config_var() else {
         return true;
     };
     let Some(value) = config

--- a/windows/tests/src/lib.rs
+++ b/windows/tests/src/lib.rs
@@ -16,7 +16,9 @@ mod vertex;
 mod vtbl;
 mod win32;
 
-pub use harness::{DrawIndexedUpParams, Harness, HarnessConfig, render_scale_is_identity};
+pub use harness::{
+    DrawIndexedUpParams, Harness, HarnessConfig, config_var, render_scale_is_identity,
+};
 pub use pixel::{Rgba8, assert_pixel_approx, assert_pixel_eq};
 pub use resource::{
     BufferLock, CubeTexture, IndexBuffer, LockedRect, PixelShader, Query, StateBlock, Surface,

--- a/windows/tests/tests/e2e/device.rs
+++ b/windows/tests/tests/e2e/device.rs
@@ -6,8 +6,8 @@
 use mtld3d_core::display_mode::MAX_SERVED_SIZES;
 use mtld3d_tests::{
     Harness, HarnessConfig, TexturedVertex, WM_ACTIVATEAPP, WS_CAPTION, WS_EX_TOPMOST, WS_POPUP,
-    WS_VISIBLE, assert_pixel_eq, create_window, destroy_window, enumerate_display_sizes,
-    window_rect,
+    WS_VISIBLE, assert_pixel_eq, config_var, create_window, destroy_window,
+    enumerate_display_sizes, window_rect,
 };
 use mtld3d_types::{
     D3D_OK, D3DCLEAR_TARGET, D3DCREATE_HARDWARE_VERTEXPROCESSING, D3DCREATE_NOWINDOWCHANGES,
@@ -2284,11 +2284,13 @@ fn a_second_device_renders_after_the_first_is_destroyed() {
 fn a_harness_with_its_own_configuration_leaves_the_environment_alone() {
     // The entries a harness carries are resolved by its own `Direct3DCreate9`
     // and never stay in `MTLD3D_CONFIG`, where every later interface in the
-    // process would read them.
-    let before = std::env::var("MTLD3D_CONFIG").ok();
+    // process would read them. Both reads go through the shared lock, so a
+    // window another test holds open on its own thread cannot be mistaken
+    // for a leak.
+    let before = config_var();
     let own = Harness::factory_only_with_config("caps.dfFormats=false");
     assert_eq!(
-        std::env::var("MTLD3D_CONFIG").ok(),
+        config_var(),
         before,
         "the variable is back before the constructor returns"
     );


### PR DESCRIPTION
Fixes #444.

At `JOBS>1` the pin that proves a harness's own configuration entries never stay in the environment fails on a suite that is behaving as designed:

```
FAIL e2e::device::a_harness_with_its_own_configuration_leaves_the_environment_alone
  assertion `left == right` failed: the variable is back before the constructor returns
    left: Some("shaderCache.enable=false;color.hdr.enable=false;intel.expandPacked16=true")
   right: Some("shaderCache.enable=false;color.hdr.enable=false")
```

`create_factory` publishes a harness's entries into the real `MTLD3D_CONFIG` for the duration of its `Direct3DCreate9` under `ENVIRONMENT.write()`, and every other reader in the suite takes `ENVIRONMENT.read()` first, which is what keeps that window invisible. The pin read the variable bare, twice, so either read could land inside another test's exclusive window and see that test's merged entries (the `intel.expandPacked16` above belongs to `expand16.rs`). At `JOBS=1` nothing else runs, so it never showed.

## Changes

`harness.rs` gains `config_var()`, which reads the suite-wide value under the shared lock. The pin uses it for both reads, and `render_scale_is_identity` calls it instead of carrying the same lock-plus-read inline. The lock stays private to `harness.rs`.

## Alternatives

Exposing the lock itself: rejected, because a reader outside `harness.rs` could then hold it wrong or take it exclusively. The harness's invariant is that every creation and every read of the suite-wide value goes through the same two guards in one file.

## Verification

`make check` green (fmt, clippy, audit, doc), which covers the doc-shape, derive and test-placement rules; nothing new is introduced beyond one `pub fn`.

Reproduced with the pin next to every test that opens an exclusive window:

```
make test-e2e-i686 ISOLATED=1 JOBS=4 FAIL_FAST=0 FILTER='device::a_harness_with_its_own render_scale:: non_uma:: expand16:: float_filter:: implicit_surface::'
```

Before: 4 of 5 runs fail on the pin. After: 0 of 20 runs fail on the pin. One of those 20 runs failed on `render_scale`'s vPos test instead, a separate `JOBS>1` crossing filed as #447. Both full legs are 473/473 at the default `JOBS=1`.
