### PR TITLE
Name the last error when the harness cannot create its window

### DIFF
--- a/windows/tests/src/win32.rs
+++ b/windows/tests/src/win32.rs
@@ -61,6 +61,7 @@ unsafe extern "system" {
     fn GetModuleHandleA(name: *const c_char) -> usize;
     fn GetCurrentProcess() -> *mut c_void;
     fn TerminateProcess(process: *mut c_void, exit_code: u32) -> i32;
+    fn GetLastError() -> u32;
 }
 
 #[link(name = "gdi32")]
@@ -202,7 +203,8 @@ fn register_class() {
 ///
 /// # Panics
 ///
-/// Panics if `CreateWindowExA` fails.
+/// Panics if `CreateWindowExA` fails, with the thread's last error in the
+/// message.
 #[must_use]
 pub fn create_window(width: i32, height: i32, visible: bool) -> usize {
     register_class();
@@ -227,7 +229,12 @@ pub fn create_window(width: i32, height: i32, visible: bool) -> usize {
             core::ptr::null(),
         )
     };
-    assert!(hwnd != 0, "CreateWindowExA failed");
+    if hwnd == 0 {
+        // SAFETY: Win32 thunk with no preconditions; reads the calling
+        // thread's own last-error slot, which the failed call just set.
+        let err = unsafe { GetLastError() };
+        panic!("CreateWindowExA failed: GetLastError() = {err}");
+    }
     hwnd
 }
 


### PR DESCRIPTION
Symptoms: one run in twenty of `make test-e2e-x86_64 JOBS=4 FAIL_FAST=0 FILTER='samplers::'` died in the harness's window helper with nothing but `CreateWindowExA failed` (#446). The helper asserted on the null handle and never read `GetLastError`, so the report could not tell a refused creation from a resource the process could not get.

Changes: `create_window` in `windows/tests/src/win32.rs` reads the thread's last error on the failure path and panics with it in the message. One extern declaration (`GetLastError`) joins the existing kernel32 block. Nothing else changes: the class is still registered once under a `Once`, creation takes no lock, and the other Win32 wrappers keep their bare asserts.

What the one recorded failure was: not a window-path race. Its full runner log shows two threads failing `CreateWindowExA` at once before any test had completed, and the fresh process the runner started next asserting in IOSurface's client initialisation (`_iosConnectInitalize`, IOSurfaceClient.m:546) with 929 IOSurface clients listed under `wine`, then hanging for the 60 s watchdog. Apple's own `ReportMemoryException` daemon aborted in the same IOSurface assertion at 11:31:43 and 11:31:59 that morning, inside that run's window, so every process on the machine that opened an IOSurface connection then failed. A healthy machine holds about 90 IOSurface user clients in total and a samplers process adds one (`ioclasscount IOSurfaceRootUserClient`). Reading the Wine tree confirms the driver cannot make `CreateWindowExA` return null on its own, and the harness's `Once` excludes the win32u class-list race; the remaining zero-return paths of `NtUserCreateWindowEx` set no last error, which is why the code is worth having in the message.

Alternatives: serialising `CreateWindowExA` against `DestroyWindow` in the harness, like the existing `DestroyWindow` mutex; rejected because 322 process runs at `JOBS=4` and `--jobs 8` with two to four concurrent processes on one wineserver, and 8000 bare create/destroy round trips across short-lived threads, never reproduced the failure, so a guard would pin nothing. A window-only stress test was written and dropped for the same reason. The 15-line stderr tail that cut off the head of the IOSurface assertion is #452.

Verification: `make check` green (fmt, clippy, audit, doc). The samplers file 60 times at `JOBS=4` with `WINEDEBUG=warn+win`: 0 failures and no win32u warning; 60 more with a second runner process on the same wineserver: 0 failures in 122 processes; 40 more at `--jobs 8` with three other streams: 0 failures in 163 processes. `make test-unit`, `make test-e2e-i686 ISOLATED=1` and `make test-e2e-x86_64 ISOLATED=1` green at `JOBS=1`.

Closes #446.
