### PR TITLE
Keep a dead test process's whole stderr and reach past Wine's chatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ on:
       e2e_filter:
         description: >-
           Run only the end-to-end tests whose id contains one of these
-          whitespace-separated patterns (e.g. `stencil msaa::`), with their
-          log files uploaded.
+          whitespace-separated patterns (e.g. `stencil msaa::`).
         type: string
         default: ''
       conformance_repeat:
@@ -221,20 +220,33 @@ jobs:
       # hangs on the paravirtual GPU. The whole suite is reported rather than
       # the first failure, and a test that is only slow there gets four
       # minutes before it counts as a hang. A dispatch with `e2e_filter`
-      # narrows the run and collects the layer's log files, which are
-      # otherwise written beside each test binary and pruned to the ten
-      # newest.
+      # narrows the run.
+      # The layer's log of every test process, and the whole stderr of every
+      # process that died with tests unaccounted for, go under the runner's
+      # temp directory, where the step below picks them up, rather than beside
+      # the test binary. The job log carries only what reached stdout: the
+      # PASS/FAIL lines, the panic messages and the tail of stderr the runner
+      # prints. What the command buffers reported is in the layer's log, and
+      # that is what tells a runner whose GPU reads back black on every test
+      # from a regression in the commits since the last green run. The
+      # directory keeps the ten newest of each kind, so a leg that restarts
+      # more than ten processes hands back its last ten; a runner fault
+      # persists, so those carry it.
       - run: make test-e2e-${{ matrix.arch }} STAGE="$STAGE" JOBS=1 TIMEOUT=120 FAIL_FAST=0 INTEL=${{ matrix.runner == 'macos-15-intel' && '1' || '' }} SCALE="${{ matrix.scale }}" FILTER="$E2E_FILTER" LOG_DIR="$LOG_DIR"
         env:
           E2E_FILTER: ${{ inputs.e2e_filter }}
-          # The layer reads the path on the Windows side, where the unix
-          # root is drive Z.
-          LOG_DIR: ${{ inputs.e2e_filter && format('Z:{0}', runner.temp) || '' }}
+          LOG_DIR: ${{ runner.temp }}
+      # `always()`, as for the conformance output below: a diverging leg is
+      # the one whose logs are worth reading, and a leg cut off by its budget
+      # ends cancelled, not failed. A leg that dies before any process logs a
+      # line has nothing to upload, and that must not turn one red into two.
       - uses: actions/upload-artifact@v4
-        if: ${{ always() && inputs.e2e_filter }}
+        if: always()
         with:
           name: e2e-logs-${{ matrix.runner }}-${{ matrix.arch }}${{ matrix.scale && format('-scale-{0}', matrix.scale) || '' }}
-          path: ${{ runner.temp }}/*.log
+          path: |
+            ${{ runner.temp }}/*.log
+            ${{ runner.temp }}/*.stderr
           retention-days: 14
           if-no-files-found: ignore
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,25 @@ summary on both architectures. mtld3d's log of each test process is a file,
 `<binary>-<pid>.log` under `mtld3d-logs` next to the test executable in
 `windows/target`, one per process, so one file carries the whole suite's log.
 
+A process that ends with tests unaccounted for leaves its whole stderr in the
+same directory as `<binary>-<pid>.stderr`, and every line the runner prints
+about that process names the file. What it prints inline is the last fifteen
+lines the process itself wrote: Wine's `fixme` lines and everything its
+`dbghelp` channel prints are left out, because dozens of them surround each
+backtrace and a raw tail rarely reaches back past them to the message that
+says what failed.
+
+In CI every end-to-end leg uploads both kinds of file as its
+`e2e-logs-<image>-<arch>` artifact on every run, kept fourteen days; the
+directory holds the ten newest of each, so a leg that restarted more than ten
+processes hands back its last ten. They are the layer's side of a red leg,
+which the job log lacks: when one image reads back black on test after test
+while its sibling legs are green, re-run the failed jobs first (`gh run rerun
+<run-id> --failed`, which lands on a fresh machine) and read the command
+buffer errors in the artifact's log, since a hosted runner's GPU can fail that
+way with no hang line in the job log and nothing else tells it from a
+regression.
+
 Two things are worth knowing when a test process looks wrong. `d3d9.dll`
 terminates the process from its `DLL_PROCESS_DETACH` once a device exists
 (it cannot survive the allocator's thread-local teardown on Wine's 1 MB

--- a/Makefile
+++ b/Makefile
@@ -584,13 +584,15 @@ stage: all
 # too; a test that probes a capability asks the device and asserts the answer
 # it gets, which is also what lets the suite run on real Intel hardware.
 #
-# LOG_DIR=<path> puts every test process's log file (and its GPU traces) in
-# one directory instead of beside each test binary, so a machine that is only
-# reachable through its artifacts (a CI runner) can hand the logs back. The
-# path is read on the PE side: an absolute Windows path (`Z:\...` for a unix
-# path under Wine). Ten files are kept per directory.
+# LOG_DIR=<absolute unix path> puts every test process's log file (and its GPU
+# traces) in one directory instead of beside each test binary, so a machine
+# that is only reachable through its artifacts (a CI runner) can hand the logs
+# back, which every CI end-to-end leg does. The layer reads the directory on
+# the PE side, where the unix root is drive Z, and the runner writes the whole
+# stderr of every process that died there beside those logs. Ten files of each
+# kind are kept per directory.
 INTEL_CONF := intel.expandPacked16=true;intel.denyFloat32Filtering=true;intel.managedMemory=true;intel.linearAlign256=true
-MTLD3D_CONF_TEST := shaderCache.enable=false;color.hdr.enable=false$(if $(SCALE),;render.scale=$(SCALE))$(if $(INTEL),;$(INTEL_CONF))$(if $(LOG_DIR),;log.dir=$(LOG_DIR))
+MTLD3D_CONF_TEST := shaderCache.enable=false;color.hdr.enable=false$(if $(SCALE),;render.scale=$(SCALE))$(if $(INTEL),;$(INTEL_CONF))$(if $(LOG_DIR),;log.dir=Z:$(LOG_DIR))
 # Quoted: the config separator is `;`, which the shell would otherwise read as
 # a command separator and run the rest of the line as its own command.
 MTLD3D_TEST_ENV := MTLD3D_CONFIG='$(MTLD3D_CONF_TEST)' WINEDEBUG=
@@ -691,7 +693,7 @@ test-unit:
 # with the word. A filter that selects nothing passes.
 JOBS ?= 1
 TIMEOUT ?= 60
-E2E_FLAGS := --jobs $(JOBS) --timeout $(TIMEOUT) $(if $(filter 0,$(FAIL_FAST))$(SCALE)$(INTEL),--no-fail-fast) $(if $(FILTER),--filter '$(FILTER)')
+E2E_FLAGS := --jobs $(JOBS) --timeout $(TIMEOUT) $(if $(filter 0,$(FAIL_FAST))$(SCALE)$(INTEL),--no-fail-fast) $(if $(FILTER),--filter '$(FILTER)') $(if $(LOG_DIR),--log-dir '$(LOG_DIR)')
 
 # The test binaries of one PE arch, from cargo's own account of what it built:
 # `cargo test --no-run` prints one JSON message per artifact, and the test

--- a/unix/e2e/src/attribute.rs
+++ b/unix/e2e/src/attribute.rs
@@ -15,7 +15,7 @@
 //! the exit code is then the whole assertion, since libtest never gets to
 //! report a result. A binary that carries such a test carries nothing else.
 
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, path::PathBuf};
 
 use crate::{
     binary::stderr_tail,
@@ -35,6 +35,7 @@ const ENDS_PROCESS_CODE: &str = " ends this process with exit code ";
 
 /// How a process of the binary ended, with everything it printed.
 pub struct ProcessEnd {
+    pub pid: u32,
     pub kind: ExitKind,
     pub stdout: String,
     pub stderr: String,
@@ -60,6 +61,17 @@ pub trait Launcher {
     ///
     /// Returns a message when the binary cannot list itself.
     fn list(&mut self) -> Result<Vec<String>, String>;
+
+    /// Keep the whole stderr of the process `pid`, and name the file it went to.
+    ///
+    /// A report shows only [`stderr_tail`], and a failure that starts
+    /// outside the test binary prints what it was long before that tail:
+    /// the file is where that first line survives.
+    ///
+    /// # Errors
+    ///
+    /// Returns the reason when the file cannot be written.
+    fn keep_stderr(&self, pid: u32, stderr: &str) -> Result<PathBuf, String>;
 }
 
 /// What became of one test.
@@ -225,8 +237,9 @@ pub fn run_binary(
         if in_flight.is_empty() {
             break;
         }
+        let kept = kept_stderr(launcher.keep_stderr(end.pid, &end.stderr));
         report.note(&format!(
-            "the process ended with {reason}; {} of its tests unaccounted for; its last lines:\n{}",
+            "the process ended with {reason}; {} of its tests unaccounted for; {kept}; its last lines:\n{}",
             in_flight.len(),
             stderr_tail(&end.stderr)
         ));
@@ -238,7 +251,7 @@ pub fn run_binary(
             // is broken, and running it again would only say so again.
             run.failed = true;
             let detail = format!(
-                "the process ended ({reason}) before running any test\n{}",
+                "the process ended ({reason}) before running any test; {kept}\n{}",
                 stderr_tail(&end.stderr)
             );
             for name in in_flight {
@@ -264,7 +277,7 @@ pub fn run_binary(
                 .and_then(|_| libtest::panic_report(&end.stderr, &name))
                 .unwrap_or_else(|| {
                     format!(
-                        "the process ended ({reason}) while this test ran\n{}",
+                        "the process ended ({reason}) while this test ran; {kept}\n{}",
                         stderr_tail(&end.stderr)
                     )
                 });
@@ -299,6 +312,14 @@ pub fn run_binary(
         remaining = Some(in_flight);
     }
     Ok(run)
+}
+
+/// Where a dead process's whole stderr went, or why it could not be kept.
+fn kept_stderr(kept: Result<PathBuf, String>) -> String {
+    match kept {
+        Ok(path) => format!("its full stderr is in {}", path.display()),
+        Err(why) => format!("its full stderr could not be kept ({why})"),
+    }
 }
 
 /// The test that ended its own process and the exit code it declared.

--- a/unix/e2e/src/attribute/tests.rs
+++ b/unix/e2e/src/attribute/tests.rs
@@ -7,17 +7,26 @@
 //! one thread to find its test, a hang is the test whose start line has no
 //! outcome, a binary that dies before any test fails whole, fail-fast stops
 //! after the first failure with the rest reported unrun, and a test that
-//! declares the code it ends its process with passes only on that code.
+//! declares the code it ends its process with passes only on that code,
+//! and a dead process keeps its whole stderr in a file the note names.
 
-use std::{collections::VecDeque, time::Duration};
+use std::{
+    collections::VecDeque,
+    path::PathBuf,
+    sync::atomic::{AtomicU32, Ordering},
+    time::Duration,
+};
 
 use super::{Launcher, ProcessEnd, Report, TestResult, Verdict, run_binary};
-use crate::{libtest::Parser, run::ExitKind};
+use crate::{binary::keep_stderr, libtest::Parser, run::ExitKind};
+
+/// The pid every scripted process ends under, so a test knows the file's name.
+const PID: u32 = 4242;
 
 /// One scripted process: its stdout, stderr, and how it ends.
 struct Script {
     stdout: &'static str,
-    stderr: &'static str,
+    stderr: String,
     kind: ExitKind,
 }
 
@@ -26,14 +35,23 @@ struct Scripted {
     scripts: VecDeque<Script>,
     /// `(names, threads)` of every process launched.
     launched: Vec<(Option<Vec<String>>, u32)>,
+    /// A directory of this launcher's own, so tests running at once do not share one.
+    log_dir: PathBuf,
 }
 
 impl Scripted {
     fn new(tests: &[&'static str], scripts: Vec<Script>) -> Self {
+        static NEXT: AtomicU32 = AtomicU32::new(0);
+        let log_dir = std::env::temp_dir().join(format!(
+            "mtld3d-e2e-attr-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
         Self {
             tests: tests.to_vec(),
             scripts: scripts.into(),
             launched: Vec::new(),
+            log_dir,
         }
     }
 }
@@ -54,14 +72,19 @@ impl Launcher for Scripted {
             }
         }
         Ok(ProcessEnd {
+            pid: PID,
             kind: script.kind,
             stdout: script.stdout.to_owned(),
-            stderr: script.stderr.to_owned(),
+            stderr: script.stderr,
         })
     }
 
     fn list(&mut self) -> Result<Vec<String>, String> {
         Ok(self.tests.iter().map(|t| (*t).to_owned()).collect())
+    }
+
+    fn keep_stderr(&self, pid: u32, stderr: &str) -> Result<PathBuf, String> {
+        keep_stderr(&self.log_dir, "scripted", pid, stderr)
     }
 }
 
@@ -109,7 +132,7 @@ fn a_clean_run_costs_one_process_and_never_lists() {
         &["a::one", "a::two", "b::three"],
         vec![Script {
             stdout: "running 3 tests\ntest a::one ... ok\ntest a::two ... ignored\ntest b::three ... ok\n\ntest result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
-            stderr: "",
+            stderr: String::new(),
             kind: ExitKind::Code(0),
         }],
     );
@@ -133,12 +156,12 @@ fn a_panic_names_its_test_and_the_rest_run_again() {
         vec![
             Script {
                 stdout: "running 3 tests\ntest a::one ... ok\n",
-                stderr: "thread 'a::two' panicked at x.rs:1:1:\nassertion failed: it\n",
+                stderr: "thread 'a::two' panicked at x.rs:1:1:\nassertion failed: it\n".to_owned(),
                 kind: ExitKind::Code(101),
             },
             Script {
                 stdout: "running 1 test\ntest b::three ... ok\n\ntest result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
-                stderr: "",
+                stderr: String::new(),
                 kind: ExitKind::Code(0),
             },
         ],
@@ -166,12 +189,12 @@ fn an_unnamed_crash_under_threads_is_attributed_on_one_thread() {
         vec![
             Script {
                 stdout: "running 3 tests\ntest a::one ... ok\n",
-                stderr: "wine: Unhandled page fault\n",
+                stderr: "wine: Unhandled page fault\n".to_owned(),
                 kind: ExitKind::Code(5),
             },
             Script {
                 stdout: "running 2 tests\ntest a::two ... ok\ntest b::three ... ",
-                stderr: "wine: Unhandled page fault\n",
+                stderr: "wine: Unhandled page fault\n".to_owned(),
                 kind: ExitKind::Code(5),
             },
         ],
@@ -196,12 +219,12 @@ fn a_hang_is_the_test_whose_start_line_has_no_outcome() {
         vec![
             Script {
                 stdout: "running 2 tests\ntest a::one ... ",
-                stderr: "",
+                stderr: String::new(),
                 kind: ExitKind::TimedOut(Duration::from_secs(5)),
             },
             Script {
                 stdout: "running 1 test\ntest a::two ... ok\n\ntest result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
-                stderr: "",
+                stderr: String::new(),
                 kind: ExitKind::Code(0),
             },
         ],
@@ -219,12 +242,12 @@ fn a_binary_that_dies_before_any_test_fails_whole_without_a_retry_loop() {
         vec![
             Script {
                 stdout: "",
-                stderr: "wine: could not load d3d9.dll\n",
+                stderr: "wine: could not load d3d9.dll\n".to_owned(),
                 kind: ExitKind::Code(1),
             },
             Script {
                 stdout: "",
-                stderr: "wine: could not load d3d9.dll\n",
+                stderr: "wine: could not load d3d9.dll\n".to_owned(),
                 kind: ExitKind::Code(1),
             },
         ],
@@ -243,7 +266,7 @@ fn fail_fast_stops_after_the_first_failure_and_reports_the_rest_unrun() {
         &["a::one", "a::two", "b::three"],
         vec![Script {
             stdout: "running 3 tests\ntest a::one ... ",
-            stderr: "thread 'a::one' panicked at x.rs:1:1:\nno\n",
+            stderr: "thread 'a::one' panicked at x.rs:1:1:\nno\n".to_owned(),
             kind: ExitKind::Code(101),
         }],
     );
@@ -265,7 +288,7 @@ fn a_failure_libtest_survived_is_read_from_its_report() {
         &["a::one", "a::two"],
         vec![Script {
             stdout: "running 2 tests\ntest a::one ... FAILED\ntest a::two ... ok\n\nfailures:\n\n---- a::one stdout ----\nleft != right\n\n\nfailures:\n    a::one\n\ntest result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
-            stderr: "",
+            stderr: String::new(),
             kind: ExitKind::Code(101),
         }],
     );
@@ -284,7 +307,7 @@ fn a_selected_name_the_binary_does_not_know_is_a_failure() {
         &["a::one"],
         vec![Script {
             stdout: "running 1 test\ntest a::one ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.1s\n",
-            stderr: "",
+            stderr: String::new(),
             kind: ExitKind::Code(0),
         }],
     );
@@ -304,7 +327,7 @@ fn an_unclean_exit_after_a_full_tally_costs_no_list_and_no_process() {
         &["a::one", "a::two"],
         vec![Script {
             stdout: "running 2 tests\ntest a::one ... ok\ntest a::two ... ok\n\ntest result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
-            stderr: "",
+            stderr: String::new(),
             kind: ExitKind::Code(3),
         }],
     );
@@ -326,7 +349,7 @@ fn a_declared_exit_code_the_process_ends_with_passes_its_test() {
         &["a::ends"],
         vec![Script {
             stdout: "running 1 test\ntest a::ends ... \n[e2e] test a::ends ends this process with exit code 42\n",
-            stderr: "",
+            stderr: String::new(),
             kind: ExitKind::Code(42),
         }],
     );
@@ -344,7 +367,7 @@ fn a_declared_exit_code_the_process_misses_fails_its_test() {
         &["a::ends"],
         vec![Script {
             stdout: "running 1 test\ntest a::ends ... [e2e] test a::ends ends this process with exit code 42\n",
-            stderr: "",
+            stderr: String::new(),
             kind: ExitKind::Code(0),
         }],
     );
@@ -353,4 +376,34 @@ fn a_declared_exit_code_the_process_misses_fails_its_test() {
     assert_eq!(run.processes, 1);
     assert!(run.failed);
     assert_eq!(verdicts(&log.results), [("a::ends", "fail")]);
+}
+
+#[test]
+fn a_dead_process_keeps_its_whole_stderr_and_the_note_names_the_file() {
+    let chatter: String = (0..40)
+        .map(|i| format!("fixme:dbghelp:elf_search_auxv can't find symbol {i}\n"))
+        .collect::<Vec<_>>()
+        .concat();
+    let stderr = format!("IOSurfaceClientCreate failed\n{chatter}wine = 929;\n");
+    let mut launcher = Scripted::new(
+        &["a::one", "a::two"],
+        vec![Script {
+            stdout: "running 2 tests\ntest a::one ... ok\n",
+            stderr: stderr.clone(),
+            kind: ExitKind::Signal(11),
+        }],
+    );
+    let mut log = Log::default();
+    let run = run_binary(&mut launcher, None, 1, true, &mut log).unwrap();
+    assert_eq!(run.processes, 1);
+    let path = launcher.log_dir.join(format!("scripted-{PID}.stderr"));
+    let note = log.notes.first().expect("a note about the dead process");
+    assert!(note.contains(&path.display().to_string()), "{note}");
+    assert!(note.contains("IOSurfaceClientCreate failed"), "{note}");
+    assert!(note.contains("wine = 929;"), "{note}");
+    assert!(!note.contains("fixme:dbghelp"), "{note}");
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("the kept stderr"),
+        stderr
+    );
 }

--- a/unix/e2e/src/binary.rs
+++ b/unix/e2e/src/binary.rs
@@ -1,8 +1,9 @@
-//! A test binary on disk: its name, and the launcher that runs it under Wine.
+//! A test binary on disk: its name, the launcher that runs it under Wine, and its stderr.
 
 use std::{
+    fs,
     path::{Path, PathBuf},
-    time::Duration,
+    time::{Duration, SystemTime},
 };
 
 use crate::{
@@ -10,6 +11,15 @@ use crate::{
     libtest::{self, Event, Parser},
     run::{self, ExitKind},
 };
+
+/// How many kept stderr files a directory holds, as many as the layer keeps logs.
+const KEEP: usize = 10;
+
+/// How many of the process's own stderr lines a report shows.
+const TAIL_LINES: usize = 15;
+
+/// The classes Wine's debug channels print, the first field of every line they emit.
+const WINE_CLASSES: [&str; 4] = ["err", "warn", "fixme", "trace"];
 
 /// The name a test binary is reported under: its file stem without cargo's `-<hash>`.
 #[must_use]
@@ -30,16 +40,38 @@ pub fn binary_name(exe: &Path) -> String {
 pub struct WineLauncher {
     wine: PathBuf,
     exe: PathBuf,
+    /// Where a dead process's whole stderr goes, beside the layer's own logs.
+    log_dir: PathBuf,
     timeout: Duration,
     /// A line as the process printed it, for the progress a caller shows.
     on_line: Box<dyn FnMut(&str)>,
 }
 
 impl WineLauncher {
-    pub fn new(wine: &Path, exe: &Path, timeout: Duration, on_line: Box<dyn FnMut(&str)>) -> Self {
+    /// A launcher for `exe`, keeping dead processes' stderr in `log_dir`.
+    ///
+    /// `log_dir` is where the layer writes its own per-process logs, so the
+    /// two accounts of one process sit together; `None` means the layer's
+    /// default, `mtld3d-logs` beside the executable.
+    pub fn new(
+        wine: &Path,
+        exe: &Path,
+        log_dir: Option<&Path>,
+        timeout: Duration,
+        on_line: Box<dyn FnMut(&str)>,
+    ) -> Self {
+        let log_dir = log_dir.map_or_else(
+            || {
+                exe.parent()
+                    .unwrap_or_else(|| Path::new("."))
+                    .join("mtld3d-logs")
+            },
+            Path::to_path_buf,
+        );
         Self {
             wine: wine.to_path_buf(),
             exe: exe.to_path_buf(),
+            log_dir,
             timeout,
             on_line,
         }
@@ -72,6 +104,7 @@ impl Launcher for WineLauncher {
             }
         })?;
         Ok(ProcessEnd {
+            pid: exit.pid,
             kind: exit.kind,
             stdout,
             stderr: exit.stderr,
@@ -104,15 +137,86 @@ impl Launcher for WineLauncher {
         }
         Ok(names)
     }
+
+    fn keep_stderr(&self, pid: u32, stderr: &str) -> Result<PathBuf, String> {
+        keep_stderr(&self.log_dir, &binary_name(&self.exe), pid, stderr)
+    }
 }
 
-/// The last lines of a process's stderr, for a report of how it died.
+/// Write one dead process's whole stderr into `dir`, and name the file.
+///
+/// The file is `<binary>-<pid>.stderr` beside the layer's per-process logs,
+/// under the pid the runner spawned. The extension is not `log`, so the
+/// layer's own retention (which keeps the newest ten of those) never
+/// removes an account of how a process died; the newest ten of these stay in
+/// the directory instead.
+///
+/// # Errors
+///
+/// Returns the reason when the directory or the file cannot be written.
+pub fn keep_stderr(dir: &Path, binary: &str, pid: u32, stderr: &str) -> Result<PathBuf, String> {
+    fs::create_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
+    prune(dir, KEEP - 1);
+    let path = dir.join(format!("{binary}-{pid}.stderr"));
+    fs::write(&path, stderr).map_err(|e| format!("{}: {e}", path.display()))?;
+    Ok(path)
+}
+
+/// The last lines of a process's stderr that the process itself printed.
+///
+/// Wine's own chatter is dropped first: dozens of `fixme:dbghelp` lines
+/// surround every backtrace, so a fixed count of raw lines rarely reaches
+/// back to the message that says what failed. Nothing is lost by it, since
+/// the whole stderr goes to the file [`Launcher::keep_stderr`] names.
 #[must_use]
 pub fn stderr_tail(stderr: &str) -> String {
-    const LINES: usize = 15;
-    let lines: Vec<&str> = stderr.lines().collect();
-    let start = lines.len().saturating_sub(LINES);
+    let lines: Vec<&str> = stderr
+        .lines()
+        .filter(|line| !is_wine_chatter(line))
+        .collect();
+    let start = lines.len().saturating_sub(TAIL_LINES);
     lines[start..].join("\n")
+}
+
+/// Whether Wine printed the line rather than the process running under it.
+///
+/// A channel line is `<class>:<channel>:<function> <message>`. Every
+/// `fixme` is an unimplemented notice, and `dbghelp` fills the lines around
+/// a backtrace whatever its class; neither ever carries the failure.
+fn is_wine_chatter(line: &str) -> bool {
+    let mut fields = line.splitn(3, ':');
+    let (Some(class), Some(channel), Some(_)) = (fields.next(), fields.next(), fields.next())
+    else {
+        return false;
+    };
+    WINE_CLASSES.contains(&class) && (class == "fixme" || channel == "dbghelp")
+}
+
+/// Remove the oldest kept stderr files in `dir` beyond the newest `keep`.
+///
+/// Age is the modification time; an entry whose metadata cannot be read is
+/// left alone, and so is one whose removal fails, which the next process to
+/// die tries again. Nothing here reports, because a directory that cannot
+/// be tidied is not a reason to say less about the process that died.
+fn prune(dir: &Path, keep: usize) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut aged: Vec<(SystemTime, PathBuf)> = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "stderr"))
+        .filter_map(|path| Some((fs::metadata(&path).ok()?.modified().ok()?, path)))
+        .collect();
+    if aged.len() <= keep {
+        return;
+    }
+    // Newest last; a tie keeps the order stable by name.
+    aged.sort();
+    let doomed = aged.len() - keep;
+    for (_, path) in aged.into_iter().take(doomed) {
+        let _ = fs::remove_file(path);
+    }
 }
 
 #[cfg(test)]

--- a/unix/e2e/src/binary/tests.rs
+++ b/unix/e2e/src/binary/tests.rs
@@ -1,8 +1,24 @@
-//! Unit tests for the binary naming.
+//! Unit tests for the binary naming and for what a dead process's stderr leaves behind.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use super::{binary_name, stderr_tail};
+use super::{KEEP, binary_name, keep_stderr, stderr_tail};
+
+/// A fresh directory under the temp dir, named after the test using it.
+fn dir(tag: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!("mtld3d-e2e-stderr-{}-{tag}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&path);
+    std::fs::create_dir_all(&path).expect("temp dir");
+    path
+}
+
+/// Dozens of the `fixme:dbghelp` lines Wine prints around a backtrace.
+fn chatter(count: usize) -> String {
+    (0..count)
+        .map(|i| format!("fixme:dbghelp:elf_search_auxv can't find symbol {i}\n"))
+        .collect::<Vec<_>>()
+        .concat()
+}
 
 #[test]
 fn the_name_drops_cargos_hash_and_nothing_else() {
@@ -32,4 +48,50 @@ fn the_tail_keeps_the_last_lines() {
     assert!(tail.starts_with("line 5\n"));
     assert!(tail.ends_with("line 19"));
     assert_eq!(stderr_tail("a\nb"), "a\nb");
+}
+
+#[test]
+fn the_tail_reaches_past_wines_chatter_to_the_failure() {
+    let stderr = format!(
+        "IOSurfaceClientCreate failed\n{}wine = 929;\nerr:dbghelp:elf_map_file cannot read\n",
+        chatter(40)
+    );
+    let tail = stderr_tail(&stderr);
+    assert_eq!(tail, "IOSurfaceClientCreate failed\nwine = 929;");
+}
+
+#[test]
+fn a_wine_channel_line_is_chatter_only_for_fixme_and_dbghelp() {
+    let stderr = "err:module:import_dll library not found\nfixme:d3d:unimplemented\ntrace:dbghelp:noise\nplain: text: line\n";
+    assert_eq!(
+        stderr_tail(stderr),
+        "err:module:import_dll library not found\nplain: text: line"
+    );
+}
+
+#[test]
+fn the_whole_stderr_lands_in_a_file_the_report_can_name() {
+    let dir = dir("kept");
+    let stderr = format!("IOSurfaceClientCreate failed\n{}", chatter(40));
+    let path = keep_stderr(&dir, "e2e", 4242, &stderr).expect("kept");
+    assert_eq!(path, dir.join("e2e-4242.stderr"));
+    assert_eq!(std::fs::read_to_string(&path).expect("read"), stderr);
+}
+
+#[test]
+fn the_kept_files_are_capped_and_never_touch_the_layers_logs() {
+    let dir = dir("capped");
+    std::fs::write(dir.join("e2e-1.log"), "the layer's own").expect("log");
+    for pid in 0..u32::try_from(KEEP).expect("small") + 5 {
+        keep_stderr(&dir, "e2e", pid, "stderr").expect("kept");
+    }
+    let kept = |ext: &str| {
+        std::fs::read_dir(&dir)
+            .expect("read dir")
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension().is_some_and(|x| x == ext))
+            .count()
+    };
+    assert_eq!(kept("stderr"), KEEP);
+    assert_eq!(kept("log"), 1);
 }

--- a/unix/e2e/src/cli.rs
+++ b/unix/e2e/src/cli.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub fail_fast: bool,
     /// `--filter`: substrings a test id has to contain one of; empty = every test.
     pub filter: Vec<String>,
+    /// `--log-dir`: where a dead process's stderr is kept; `None` = beside the test binary.
+    pub log_dir: Option<PathBuf>,
     /// The test binaries, after `--`.
     pub exes: Vec<PathBuf>,
 }
@@ -22,9 +24,11 @@ pub struct Config {
 /// Parse CLI args (excluding `argv[0]`).
 ///
 /// Recognised: `--wine <path>`, `--jobs <N>`, `--timeout <secs>`,
-/// `--no-fail-fast`, `--filter <patterns>` (whitespace-separated), then
-/// `--` and the test binaries. `--wine` and at least one binary are
-/// mandatory; `--jobs` defaults to 1 and `--timeout` to 60 seconds.
+/// `--no-fail-fast`, `--filter <patterns>` (whitespace-separated),
+/// `--log-dir <path>`, then `--` and the test binaries. `--wine` and at
+/// least one binary are mandatory; `--jobs` defaults to 1, `--timeout` to
+/// 60 seconds, and the log directory to the one the layer writes its own
+/// per-process logs to, `mtld3d-logs` beside the test binary.
 ///
 /// # Errors
 ///
@@ -36,6 +40,7 @@ pub fn parse_args(mut args: impl Iterator<Item = String>) -> Result<Config, Stri
     let mut timeout = Duration::from_mins(1);
     let mut fail_fast = true;
     let mut filter = Vec::new();
+    let mut log_dir: Option<PathBuf> = None;
     let mut exes = Vec::new();
     while let Some(arg) = args.next() {
         match arg.as_str() {
@@ -73,6 +78,12 @@ pub fn parse_args(mut args: impl Iterator<Item = String>) -> Result<Config, Stri
                     .ok_or_else(|| "--filter needs patterns".to_owned())?;
                 filter.extend(value.split_whitespace().map(str::to_owned));
             }
+            "--log-dir" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| "--log-dir needs a path".to_owned())?;
+                log_dir = Some(PathBuf::from(value));
+            }
             "--" => {
                 exes.extend(args.by_ref().map(PathBuf::from));
             }
@@ -89,6 +100,7 @@ pub fn parse_args(mut args: impl Iterator<Item = String>) -> Result<Config, Stri
         timeout,
         fail_fast,
         filter,
+        log_dir,
         exes,
     })
 }

--- a/unix/e2e/src/cli/tests.rs
+++ b/unix/e2e/src/cli/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for the runner's argument parser.
 
-use std::time::Duration;
+use std::{path::Path, time::Duration};
 
 use super::parse_args;
 
@@ -20,6 +20,7 @@ fn defaults_fill_in_behind_the_mandatory_pair() {
     assert_eq!(config.timeout, Duration::from_mins(1));
     assert!(config.fail_fast);
     assert!(config.filter.is_empty());
+    assert!(config.log_dir.is_none());
     assert_eq!(config.exes.len(), 2);
 }
 
@@ -35,6 +36,8 @@ fn every_flag_is_read() {
         "--no-fail-fast",
         "--filter",
         "msaa:: stencil",
+        "--log-dir",
+        "/l",
         "--",
         "/a.exe",
     ]))
@@ -43,6 +46,7 @@ fn every_flag_is_read() {
     assert_eq!(config.timeout, Duration::from_mins(4));
     assert!(!config.fail_fast);
     assert_eq!(config.filter, ["msaa::", "stencil"]);
+    assert_eq!(config.log_dir.as_deref(), Some(Path::new("/l")));
 }
 
 #[test]
@@ -52,5 +56,6 @@ fn missing_and_malformed_inputs_name_themselves() {
     assert!(err(&["--wine", "/w"]).contains("no test binary"));
     assert!(err(&["--wine", "/w", "--jobs", "0", "--", "/a"]).contains("--jobs"));
     assert!(err(&["--wine", "/w", "--timeout", "x", "--", "/a"]).contains("--timeout"));
+    assert!(err(&["--wine", "/w", "--log-dir"]).contains("--log-dir"));
     assert!(err(&["--wine", "/w", "--bogus", "--", "/a"]).contains("--bogus"));
 }

--- a/unix/e2e/src/main.rs
+++ b/unix/e2e/src/main.rs
@@ -46,7 +46,13 @@ fn real_main() -> Result<ExitCode, String> {
             println!("SKIP {name}:: (not run after a failure)");
             continue;
         }
-        let mut launcher = WineLauncher::new(&config.wine, exe, config.timeout, Box::new(|_| {}));
+        let mut launcher = WineLauncher::new(
+            &config.wine,
+            exe,
+            config.log_dir.as_deref(),
+            config.timeout,
+            Box::new(|_| {}),
+        );
         let selection = if config.filter.is_empty() {
             None
         } else {

--- a/unix/e2e/src/run.rs
+++ b/unix/e2e/src/run.rs
@@ -57,8 +57,9 @@ impl ExitKind {
     }
 }
 
-/// A process's end: how, and everything it wrote to stderr.
+/// A process's end: its pid, how it ended, and everything it wrote to stderr.
 pub struct Exit {
+    pub pid: u32,
     pub kind: ExitKind,
     pub stderr: String,
 }
@@ -104,6 +105,7 @@ pub fn run(
         .spawn()
         .map_err(|e| format!("failed to spawn {} {}: {e}", wine.display(), exe.display()))?;
 
+    let pid = child.id();
     let stdout = child.stdout.take().ok_or("stdout not piped")?;
     let mut stderr = child.stderr.take().ok_or("stderr not piped")?;
     let (lines, received) = mpsc::channel::<String>();
@@ -169,7 +171,7 @@ pub fn run(
     } else {
         ExitKind::Code(status.code().unwrap_or(-1))
     };
-    Ok(Exit { kind, stderr })
+    Ok(Exit { pid, kind, stderr })
 }
 
 /// Everything stderr delivered, and whether its end was seen.


### PR DESCRIPTION
## Symptoms

When an end-to-end test process ends with tests unaccounted for, the runner prints "its last lines" and the fifteen lines it kept are usually Wine's own. The one recorded #446 failure ended in IOSurface's client initialisation, and all that survived was the tail of the per-process dictionary the assertion prints (`wine = 929;` ... `_iosConnectInitalize, IOSurfaceClient.m, line 546`). The line that said what failed, printed above the dictionary, was gone, and with it the evidence of what had been exhausted.

## Root cause

`stderr_tail` in `unix/e2e/src/binary.rs` kept the last fifteen lines of `ProcessExit.stderr` and dropped the rest, while the whole stderr was in hand at that point. Wine's `dbghelp` channel prints dozens of lines around each backtrace, so a fixed count of raw lines is spent on those before it reaches anything the process itself wrote.

## Changes

The runner writes a dead process's whole stderr to `<binary>-<pid>.stderr` in the directory the layer writes its own per-process logs to, and every line it prints about that process (the note, and the report of the test the end is charged to) names the file. `Launcher` gains `keep_stderr`, `Exit` and `ProcessEnd` carry the pid, and the directory keeps the newest ten of these files. The extension is not `log`, so the layer's own retention, which keeps the newest ten of those, never removes an account of how a process died, and the runner's retention never removes a layer log.

The inline tail is now the last fifteen lines the process itself wrote: a line whose Wine class is `fixme`, or whose channel is `dbghelp` whatever the class, does not count. Nothing is lost by that, because the file has all of it.

`--log-dir <path>` names the directory; without it the runner uses the layer's default, `mtld3d-logs` beside the test binary. `LOG_DIR` in the Makefile is now an absolute unix path, which it feeds to the runner as that flag and to the layer as `log.dir=Z:<path>`, rather than a Windows path.

In the workflow, the `LOG_DIR` the e2e legs pass and the `e2e-logs-*` upload were gated on an `e2e_filter` dispatch again: #450 branched before #443 and its squash reverted #443's `ci.yml`, `CONTRIBUTING.md` and `Makefile` hunks whole. This restores them, so a push run's logs are collected, and adds `*.stderr` to the upload's glob.

`CONTRIBUTING.md` gains the file and the tail's rule in the section on reading a test run, next to the restored paragraph on the CI artifact.

## Alternatives

Raising the line count alone: fifteen raw lines rarely reach past the chatter, and a count high enough to would print a backtrace's worth of `fixme` lines into the job log on every failure.

Keeping the chatter in the tail and only counting the process's own lines toward the budget: same reach, but the console then carries the dozens of lines in between, which the file already has.

Naming the file `<binary>-<pid>.log`: the layer's retention prunes `log` files in that directory and would eventually delete the account of a process that died.

## Verification

Unit tests in `unix/e2e/src/binary/tests.rs`: `the_tail_reaches_past_wines_chatter_to_the_failure` feeds a leading failure line, forty `fixme:dbghelp` lines and a closing `wine = 929;`, and pins the tail to the two lines the process wrote; it fails against the previous `stderr_tail`, which returns thirteen `fixme` lines and the two after them. `a_wine_channel_line_is_chatter_only_for_fixme_and_dbghelp` pins that an `err:module:` line stays. `the_whole_stderr_lands_in_a_file_the_report_can_name` and `the_kept_files_are_capped_and_never_touch_the_layers_logs` pin the file's name, its content and the two retentions. In `unix/e2e/src/attribute/tests.rs`, `a_dead_process_keeps_its_whole_stderr_and_the_note_names_the_file` pins that the note names the file, carries the failure line and no `fixme:dbghelp`, and that the file holds all forty-two lines.

Hand-run against a script that prints one passing test, the same synthetic stderr, and then takes SIGSEGV: the note reads `its full stderr is in <dir>/fakebin-3544.stderr; its last lines:` followed by `IOSurfaceClientCreate failed` and `wine = 929;`, and the file holds the whole 1511 bytes.

`make test-e2e-x86_64 ISOLATED=1 FILTER='msaa::' LOG_DIR=<dir>` with the variable set the way CI sets it now: 15 of 15 passed and the layer's `e2e-<hash>-<pid>.log` landed in `<dir>`, where the upload step globs.

Gates: `make check` green (`audit: clean (299 files)`, zero warnings) and `make ISOLATED=1 test` green, 474 of 474 on i686 and 474 of 474 on x86_64, four processes each, plus 1086 and 263 unit tests. No new static, config key, wire field, dependency, derive or lint suppression; no new environment variable, the directory being a runner flag and an existing Makefile variable.

Closes #452.
