### PR TITLE
Create the shader cache file atomically so only one writer writes its header

### DIFF
--- a/windows/core/src/shader_cache.rs
+++ b/windows/core/src/shader_cache.rs
@@ -36,13 +36,21 @@
 //! Robustness comes from the plaintext `frame_len` prefix plus the xxh3:
 //! torn writes (frame runs past EOF) ⇒ `break`; xxh3 mismatch ⇒ skip;
 //! decompress failure or bad UTF-8 ⇒ skip; unknown `kind` ⇒ skip via
-//! `frame_len` (forward-compat hook).
+//! `frame_len` (forward-compat hook); a file header found where a chunk
+//! header belongs ⇒ skip its 16 bytes.
 //!
-//! This module owns the binary format only — it is pure-Rust and host-
-//! testable. Encoder-side write hooks and pre-warm-thread plumbing live in
-//! `windows/d3d9`.
+//! This module owns the binary format and the creation of the file that
+//! holds it, both pure-Rust and host-testable. Encoder-side write hooks
+//! and pre-warm-thread plumbing live in `windows/d3d9`.
 
-use std::hash::{Hash, Hasher};
+use std::{
+    fs::{self, File, OpenOptions},
+    hash::{Hash, Hasher},
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+    thread,
+    time::Duration,
+};
 
 use rustc_hash::FxHashSet;
 use xxhash_rust::xxh3::Xxh3;
@@ -451,9 +459,9 @@ pub fn read_header(bytes: &[u8]) -> Result<u32, CacheReadError> {
 ///   well-formed Bundle chunk with no inner duplicates and reached EOF
 ///   cleanly. `true` whenever anything else was observed: any Single
 ///   chunks, more than one Bundle, a torn / corrupt / unknown-kind chunk,
-///   trailing partial-header garbage, or duplicate keys. The pre-warm
-///   thread uses this to decide whether to rewrite the file as a single
-///   dense Bundle.
+///   a stray file header mid-file, trailing partial-header garbage, or
+///   duplicate keys. The pre-warm thread uses this to decide whether to
+///   rewrite the file as a single dense Bundle.
 ///
 /// Empty input (parsed zero entries) always returns
 /// `needs_compaction = false` — there is nothing to compact.
@@ -477,6 +485,15 @@ pub fn read_records(bytes: &[u8]) -> (Vec<CacheEntry>, bool) {
     let mut duplicates = false;
 
     while off + CHUNK_HEADER_LEN <= bytes.len() {
+        if bytes[off..off + 8] == SHADER_CACHE_MAGIC {
+            // A file header inside the file is a stray from a duplicate
+            // creation: skip its 16 bytes and keep parsing. No chunk header
+            // can be mistaken for it, since the magic's leading byte would
+            // have to be a `kind` outside `0..=7` and `RECORD_KIND_BUNDLE`.
+            other_chunk = true;
+            off += HEADER_LEN;
+            continue;
+        }
         let header_start = off;
         let kind_byte = bytes[off];
         let key = u64::from_le_bytes(bytes[off + 4..off + 12].try_into().unwrap());
@@ -611,6 +628,99 @@ pub fn write_bundle(buf: &mut Vec<u8>, entries: &[CacheEntry]) {
     let frame = zstd::encode_all(plain.as_slice(), ZSTD_BUNDLE_LEVEL)
         .expect("zstd encode_all of in-memory plain-record blob");
     push_chunk(buf, RECORD_KIND_BUNDLE, 0, &frame);
+}
+
+/// Open the cache file at `path` for append, creating it with its header when absent.
+///
+/// Creation goes through `create_new`, so when several writers reach a cold
+/// cache together the file system elects exactly one of them: that writer
+/// emits the 16-byte header, and every other one opens the file it finds and
+/// appends its chunks behind that header. Exactly one header therefore
+/// reaches the file however many writers race for it.
+///
+/// # Errors
+///
+/// Any I/O error from the create, from the header write, or from the append
+/// open taken when the file already exists.
+pub fn open_for_append(path: &Path) -> std::io::Result<File> {
+    use std::io::Write as _;
+
+    match OpenOptions::new().append(true).create_new(true).open(path) {
+        Ok(mut file) => {
+            let mut header = Vec::with_capacity(HEADER_LEN);
+            write_header(&mut header);
+            file.write_all(&header)?;
+            Ok(file)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            let file = OpenOptions::new().append(true).open(path)?;
+            await_header(&file);
+            Ok(file)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Attempts `await_header` makes before it gives up on the header appearing.
+///
+/// The elected writer's create and its header write are consecutive, so one
+/// attempt is the normal case; the bound is what keeps a file left empty by a
+/// killed process from stalling a caller.
+const HEADER_WAIT_ATTEMPTS: u32 = 25;
+
+/// Interval between `await_header` attempts.
+const HEADER_WAIT_INTERVAL: Duration = Duration::from_micros(200);
+
+// Wait for the electing writer's header before appending behind it. A writer
+// that finds the file already there has to leave the first 16 bytes to
+// whoever created it, or its chunk would land at the offset the reader skips
+// as the header.
+fn await_header(file: &File) {
+    for _ in 0..HEADER_WAIT_ATTEMPTS {
+        if file
+            .metadata()
+            .is_ok_and(|m| m.len() >= u64::try_from(HEADER_LEN).unwrap_or(u64::MAX))
+        {
+            return;
+        }
+        thread::sleep(HEADER_WAIT_INTERVAL);
+    }
+}
+
+/// Replace the file at `path` with a header plus one Bundle chunk holding `entries`.
+///
+/// The bytes go to a temporary beside `path` and the temporary is renamed
+/// over it, so a reader observes either the previous file or the whole new
+/// one. The temporary's name carries the process id and a per-call counter,
+/// so two writers compacting at once cannot interleave into one scratch file.
+///
+/// Returns the number of bytes written.
+///
+/// # Errors
+///
+/// Any I/O error from the temporary write or from the rename; the temporary
+/// is removed when the rename fails.
+pub fn replace_with_bundle(path: &Path, entries: &[CacheEntry]) -> std::io::Result<usize> {
+    let mut buf = Vec::new();
+    write_header(&mut buf);
+    write_bundle(&mut buf, entries);
+
+    let tmp = temp_sibling(path);
+    fs::write(&tmp, &buf)?;
+    if let Err(e) = fs::rename(&tmp, path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(buf.len())
+}
+
+// Name a scratch file beside `path`, unique to this process and this call.
+fn temp_sibling(path: &Path) -> PathBuf {
+    static NEXT: AtomicU64 = AtomicU64::new(0);
+    let seq = NEXT.fetch_add(1, Ordering::Relaxed);
+    let mut name = path.as_os_str().to_owned();
+    name.push(format!(".{}-{seq}.tmp", std::process::id()));
+    PathBuf::from(name)
 }
 
 /// Hash any `Hash`-implementing FF state key to a u64 disk identifier.

--- a/windows/core/src/shader_cache/tests.rs
+++ b/windows/core/src/shader_cache/tests.rs
@@ -1,9 +1,11 @@
 //! Unit tests for the on-disk shader-cache binary format.
 //!
 //! Hand-built files cover the round trips, the damage paths (torn tail, flipped chunk-header
-//! bit, scrambled zstd frame, unknown chunk kind), duplicate keys and a header-only file. Every
-//! one of those but the scrambled-frame case pins the `needs_compaction` verdict the pre-warm
-//! rewrite keys off. Further tests cover header validation, `CachedKind` mapping and
+//! bit, scrambled zstd frame, unknown chunk kind, stray file header), duplicate keys and a
+//! header-only file. Every one of those but the scrambled-frame case pins the
+//! `needs_compaction` verdict the pre-warm rewrite keys off. The file-level tests write real
+//! files under the system temp root and pin that many writers reaching a cold cache together
+//! still produce one header. Further tests cover header validation, `CachedKind` mapping and
 //! `ff_key_hash` stability.
 
 use super::*;
@@ -23,6 +25,37 @@ fn write_file(entries_per_chunk: &[Vec<CacheEntry>], bundle_last: bool) -> Vec<u
         }
     }
     buf
+}
+
+/// Count the occurrences of the file magic in `bytes`.
+///
+/// A file carrying its header once has exactly one; a duplicate creation
+/// leaves a second run of the magic further in.
+fn magic_count(bytes: &[u8]) -> usize {
+    bytes
+        .windows(SHADER_CACHE_MAGIC.len())
+        .filter(|w| **w == SHADER_CACHE_MAGIC)
+        .count()
+}
+
+/// An empty directory under the system temp root, unique to this process and this call.
+fn scratch_dir(tag: &str) -> std::path::PathBuf {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "mtld3d-shader-cache-{tag}-{}-{seq}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+/// Append one record to the cache file at `path`, creating the file when absent.
+fn append_one(path: &std::path::Path, entry: &CacheEntry) {
+    let mut file = open_for_append(path).expect("open cache file");
+    let mut buf = Vec::new();
+    write_record(&mut buf, entry);
+    std::io::Write::write_all(&mut file, &buf).expect("append record");
 }
 
 fn sample_entries() -> Vec<CacheEntry> {
@@ -305,4 +338,91 @@ fn ff_key_hash_is_stable() {
     let a = (1u32, 2u32, 3u32);
     let b = (1u32, 2u32, 3u32);
     assert_eq!(ff_key_hash(&a), ff_key_hash(&b));
+}
+
+#[test]
+fn stray_file_header_mid_file_is_skipped() {
+    let entries = sample_entries();
+    let mut buf = Vec::new();
+    write_header(&mut buf);
+    write_record(&mut buf, &entries[0]);
+    // A second creation's header, landing where a chunk header belongs.
+    write_header(&mut buf);
+    write_record(&mut buf, &entries[1]);
+    let (read, needs_compaction) = read_records(&buf);
+    assert_eq!(read, vec![entries[0].clone(), entries[1].clone()]);
+    // The stray header is a reason to rewrite the file dense.
+    assert!(needs_compaction);
+}
+
+#[test]
+fn open_for_append_writes_one_header_across_writers() {
+    let dir = scratch_dir("append");
+    let path = dir.join("mtld3d_shaders.bin");
+    let entries = sample_entries();
+    for entry in &entries {
+        append_one(&path, entry);
+    }
+    let bytes = std::fs::read(&path).expect("read cache file");
+    assert_eq!(magic_count(&bytes), 1);
+    assert_eq!(read_header(&bytes), Ok(SHADER_CACHE_SCHEMA_VERSION));
+    let (read, _) = read_records(&bytes);
+    assert_eq!(read, entries);
+    std::fs::remove_dir_all(&dir).expect("remove scratch dir");
+}
+
+#[test]
+fn concurrent_open_for_append_writes_one_header() {
+    const WRITERS: usize = 8;
+
+    let dir = scratch_dir("race");
+    let path = dir.join("mtld3d_shaders.bin");
+    // Every writer reaches the cold cache in the same instant, which is what a
+    // set of devices whose first miss-compiles coincide does.
+    let start = std::sync::Barrier::new(WRITERS);
+    std::thread::scope(|scope| {
+        for key in 0..WRITERS {
+            let path = path.as_path();
+            let start = &start;
+            scope.spawn(move || {
+                let key = u64::try_from(key).expect("writer index fits u64");
+                start.wait();
+                append_one(
+                    path,
+                    &CacheEntry {
+                        kind: CachedKind::Sm2Ps,
+                        key,
+                        msl: format!("fragment float4 ps{key}() {{ return float4({key}); }}"),
+                    },
+                );
+            });
+        }
+    });
+    let bytes = std::fs::read(&path).expect("read cache file");
+    assert_eq!(magic_count(&bytes), 1);
+    assert_eq!(read_header(&bytes), Ok(SHADER_CACHE_SCHEMA_VERSION));
+    let (read, _) = read_records(&bytes);
+    assert_eq!(read.len(), WRITERS);
+    std::fs::remove_dir_all(&dir).expect("remove scratch dir");
+}
+
+#[test]
+fn replace_with_bundle_renames_one_dense_file_into_place() {
+    let dir = scratch_dir("bundle");
+    let path = dir.join("mtld3d_shaders.bin");
+    let entries = sample_entries();
+    for entry in &entries {
+        append_one(&path, entry);
+    }
+    let len = replace_with_bundle(&path, &entries).expect("replace with bundle");
+    let bytes = std::fs::read(&path).expect("read cache file");
+    assert_eq!(bytes.len(), len);
+    assert_eq!(magic_count(&bytes), 1);
+    let (read, needs_compaction) = read_records(&bytes);
+    assert_eq!(read, entries);
+    assert!(!needs_compaction);
+    // The temporary is renamed rather than left beside the cache file.
+    let leftovers = std::fs::read_dir(&dir).expect("list scratch dir").count();
+    assert_eq!(leftovers, 1);
+    std::fs::remove_dir_all(&dir).expect("remove scratch dir");
 }

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{VecDeque, hash_map::Entry},
-    fs::{File, OpenOptions},
+    fs::File,
     io::Write as _,
     path::PathBuf,
     sync::{
@@ -9880,21 +9880,16 @@ pub fn shader_cache_path() -> Option<PathBuf> {
     Some(parent.join("mtld3d_shaders.bin"))
 }
 
-/// Open the cache file in append mode, creating it (and writing the 16-byte header) if absent.
+/// Open the cache file in append mode, creating it with its header if absent.
 ///
 /// Caller invokes lazily on first miss-compile, after the pre-warm thread
 /// has already validated the file's schema, so a non-empty file we
 /// encounter here is guaranteed to already start with a valid header.
+/// `shader_cache::open_for_append` owns the creation, so two encoders
+/// arriving at a cold cache together still produce one header.
 fn open_or_create_cache_file() -> std::io::Result<File> {
     let Some(path) = shader_cache_path() else {
         return Err(std::io::Error::other("shader_cache_path unavailable"));
     };
-    let exists = path.exists();
-    let mut f = OpenOptions::new().append(true).create(true).open(&path)?;
-    if !exists {
-        let mut hdr = Vec::with_capacity(shader_cache::HEADER_LEN);
-        shader_cache::write_header(&mut hdr);
-        f.write_all(&hdr)?;
-    }
-    Ok(f)
+    shader_cache::open_for_append(&path)
 }

--- a/windows/d3d9/src/shader_prewarm.rs
+++ b/windows/d3d9/src/shader_prewarm.rs
@@ -10,7 +10,7 @@
 
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::Path,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -222,44 +222,23 @@ fn run(
 
 /// Replace `path` with a fresh file containing one Bundle chunk holding every entry.
 ///
-/// Written to `<path>.tmp` first and then atomically renamed over the
-/// original. Best-effort: any I/O failure logs once and leaves the original
-/// file untouched (worst case is a missed size optimisation; the next launch
-/// tries again).
+/// `shader_cache::replace_with_bundle` owns the write, which goes through a
+/// temporary and a rename. Best-effort: any I/O failure logs once and leaves
+/// the original file untouched (worst case is a missed size optimisation;
+/// the next launch tries again).
 fn rewrite_as_bundle(path: &Path, entries: &[CacheEntry]) {
-    let mut buf = Vec::new();
-    shader_cache::write_header(&mut buf);
-    shader_cache::write_bundle(&mut buf, entries);
-
-    let tmp: PathBuf = {
-        let mut p = path.as_os_str().to_owned();
-        p.push(".tmp");
-        PathBuf::from(p)
-    };
-    if let Err(e) = fs::write(&tmp, &buf) {
-        mtld3d_shared::log_once_warn!(
+    match shader_cache::replace_with_bundle(path, entries) {
+        Ok(len) => info!(
             target: LOG_TARGET,
-            "shader_cache: compaction write to {} failed → leaving original: {e}",
-            tmp.display()
-        );
-        return;
-    }
-    if let Err(e) = fs::rename(&tmp, path) {
-        mtld3d_shared::log_once_warn!(
+            "shader_cache: compacted {} entries into one Bundle ({len} bytes)",
+            entries.len()
+        ),
+        Err(e) => mtld3d_shared::log_once_warn!(
             target: LOG_TARGET,
-            "shader_cache: compaction rename {} → {} failed → leaving original: {e}",
-            tmp.display(),
+            "shader_cache: compaction of {} failed → leaving original: {e}",
             path.display()
-        );
-        let _ = fs::remove_file(&tmp);
-        return;
+        ),
     }
-    info!(
-        target: LOG_TARGET,
-        "shader_cache: compacted {} entries into one Bundle ({} bytes)",
-        entries.len(),
-        buf.len()
-    );
 }
 
 const fn stage_for_kind(kind: CachedKind) -> StageTag {


### PR DESCRIPTION
## Symptoms

Two devices whose first miss-compiles coincide both write the 16-byte file header of `mtld3d_shaders.bin`, so the second header lands in the middle of the file where a chunk header belongs. The reader parses its magic byte `M` as an unknown chunk kind and its `_pad` field as a `frame_len` of zero, the xxh3 over those bytes does not match, and `read_records` stops there: every entry appended after the stray header is lost and recompiles on the next launch. The e2e suite hits this shape on every `multi_device::` test when the cache is enabled, and two processes started from one directory (a game launched twice, or a launcher and its game side by side) have the same window.

## Root cause

`open_or_create_cache_file` in `windows/d3d9/src/encoder.rs` decided whether to write the header from a `path.exists()` check taken before an `OpenOptions::new().append(true).create(true)` open, with nothing serialising the two steps. The writer is per `FrameEncoder` (`cache_writer`, opened lazily on the encoder's first miss-compile) and there is one encoder per device, so both encoders saw `!exists` and both appended a header. The pre-warm thread's compaction rewrite in `shader_prewarm.rs` wrote its own header through a second, independent copy of the same logic, and staged it through a fixed `<path>.tmp` that two concurrent rewrites share.

## Changes

`mtld3d-core`'s `shader_cache` gains `open_for_append`, which owns the creation: `create_new(true)` elects one writer, that writer emits the header, and every other writer takes the `AlreadyExists` arm and opens the file for append without writing one. A writer taking that arm waits for the header to appear before its first chunk (bounded, 25 attempts at 200 us), so a chunk cannot land at the offset the reader skips as the header.

The same module gains `replace_with_bundle`, which writes the header plus one Bundle chunk to a temporary and renames it into place. Its temporary is named per process and per call, so two devices compacting at once no longer interleave into one scratch file.

`open_or_create_cache_file` resolves the path and delegates; `rewrite_as_bundle` builds nothing itself and only logs the outcome. Neither the header bytes nor the file layout change, so no schema bump is involved and existing cache files stay readable.

`read_records` skips a file header found where a chunk header belongs and flags the file for compaction, so a cache already damaged by the race recovers its tail on the next launch instead of losing it, and the pre-warm rewrite then removes the stray. The skip is unambiguous: a chunk header's leading byte is a `kind`, and the magic's `M` is outside `0..=7` and `RECORD_KIND_BUNDLE`.

## Alternatives

Write the header to a temporary and rename it into place for the create path as well: rejected, a rename replaces the file another writer may already hold an append handle on, orphaning that writer's records for the rest of the session.

Take an advisory file lock around the create: rejected, it depends on `LockFileEx` behaving under Wine for no gain over `create_new`, which the file system already serialises.

Leave the reader alone: rejected, the skip is four lines and it is what makes an already-damaged cache recover rather than losing every entry past the stray header.

## Verification

`make check` green. `make ISOLATED=1 test` green: 475 e2e tests passed per architecture (i686 and x86_64), 0 failed, 0 ignored, 4 processes each, plus 1091 and 265 host-native unit tests.

Three new tests in `windows/core/src/shader_cache/tests.rs` pin the behaviour. `concurrent_open_for_append_writes_one_header` releases eight writers from a barrier onto one cold path and asserts one occurrence of the magic and eight readable records: against the previous creation logic it reads five headers. `stray_file_header_mid_file_is_skipped` builds a file with a header between two records and asserts both records parse with `needs_compaction` set: against the previous parser it read one. `open_for_append_writes_one_header_across_writers` and `replace_with_bundle_renames_one_dense_file_into_place` pin the sequential path and the rewrite, including that no temporary is left beside the cache file.

Conformance was not run: the change touches no render, state or shader-emission path. An e2e test was considered and rejected: the suite runs the whole process under `MTLD3D_CONFIG=shaderCache.enable=false` set once by the Makefile, so a single test cannot enable the cache, and `windows/d3d9` is a `cdylib` with no test harness of its own. Moving the creation into core is what makes the race testable at all.

Closes #457
