### PR TITLE
Pin one MTLDevice per process and reuse it for every D3D device

### DIFF
--- a/unix/unix/src/metal/device.rs
+++ b/unix/unix/src/metal/device.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use mtld3d_shared::{
     MetalHandle,
     mtl::DeviceCapsFlags,
@@ -15,14 +17,64 @@ use super::{
     handle::{IntoRetained, ReleaseRetain},
     macdrv::{detach_metal_layer, release_metal_view},
 };
+use crate::LOG_TARGET;
 
 // MTLCreateSystemDefaultDevice requires CoreGraphics to be linked.
 #[link(name = "CoreGraphics", kind = "framework")]
 unsafe extern "C" {}
 
-/// Returns (`device_name`, `registry_id`, capability bits) from the system default Metal device.
+/// The one `MTLDevice` the process uses, as a retained handle.
+///
+/// The process-wide Metal caches (the present and cursor pipelines, the
+/// readback resolve library and its pipelines, the null textures, and the
+/// upload, clear and blit quads) hold objects built on whichever device first
+/// reached them, and Metal rejects an encode that mixes objects of two
+/// devices. Resolving the system default device once and handing that same
+/// object to every D3D device is what makes their grain correct rather than
+/// assumed.
+///
+/// The retain this handle carries is never released: the device is a
+/// process-lifetime object, like the caches built on it. `MetalHandle` is a
+/// transparent `u64` newtype, so the static is trivially `Send + Sync`.
+static PINNED_DEVICE: LazyLock<MetalHandle<MTLDeviceKind>> = LazyLock::new(|| {
+    let Some(device) = MTLCreateSystemDefaultDevice() else {
+        return MetalHandle::<MTLDeviceKind>::NULL;
+    };
+    // SAFETY: `Retained::into_raw` transfers the retain into the `u64` and
+    // `MetalHandle::new` adopts it. Nothing releases this handle, so the
+    // retain stays live for the rest of the process.
+    unsafe { MetalHandle::<MTLDeviceKind>::new(Retained::into_raw(device) as u64) }
+});
+
+/// The process's Metal device, with one retain for the caller.
+///
+/// Warns once when the system default device is no longer the pinned one,
+/// which automatic graphics switching on a dual-GPU Mac can arrange between
+/// two D3D device creations. The pinned device is kept in that case, so every
+/// object in the process-wide caches keeps belonging to the device the next
+/// command buffer encodes against.
+fn pinned_device() -> Option<Retained<ProtocolObject<dyn MTLDevice>>> {
+    let device = PINNED_DEVICE.into_retained()?;
+    if let Some(current) = MTLCreateSystemDefaultDevice()
+        && current.registryID() != device.registryID()
+    {
+        mtld3d_shared::log_once_warn!(
+            target: LOG_TARGET,
+            "the system default Metal device is now {} (registry id {}), not the pinned {} \
+             (registry id {}); the pinned device is kept, since the process-wide pipeline, \
+             texture and buffer caches were built on it",
+            current.name(),
+            current.registryID(),
+            device.name(),
+            device.registryID(),
+        );
+    }
+    Some(device)
+}
+
+/// Returns (`device_name`, `registry_id`, capability bits) from the process's Metal device.
 pub fn default_device_info() -> Option<(String, u64, DeviceCapsFlags)> {
-    let device = MTLCreateSystemDefaultDevice()?;
+    let device = pinned_device()?;
     let name = device.name().to_string();
     let registry_id = device.registryID();
     let mut caps = DeviceCapsFlags::empty();
@@ -145,11 +197,13 @@ pub struct DeviceCaps {
     pub min_linear_texture_align: u32,
 }
 
-/// Creates an `MTLDevice` + `MTLCommandQueue` pair.
+/// Creates an `MTLCommandQueue` on the process's Metal device.
 ///
-/// Snapshots the device caps the PE side needs at creation time.
+/// Snapshots the device caps the PE side needs at creation time. Every D3D
+/// device is handed the same `MTLDevice`, so the process-wide Metal caches and
+/// the command buffers that bind from them always name one device.
 pub fn create_command_queue() -> Option<DeviceCaps> {
-    let device = MTLCreateSystemDefaultDevice()?;
+    let device = pinned_device()?;
     let queue = device.newCommandQueue()?;
     let queue_label = objc2_foundation::NSString::from_str("mtld3d");
     queue.setLabel(Some(&queue_label));
@@ -162,7 +216,10 @@ pub fn create_command_queue() -> Option<DeviceCaps> {
     // SAFETY: `Retained::into_raw` transfers each retain into the
     // returned `u64`; `MetalHandle::new` adopts that retain into a
     // typed handle. The PE side keeps the handle alive until the
-    // matching destroy thunk fires.
+    // matching destroy thunk fires. The device retain is the one
+    // `pinned_device` took for this caller, not the pin's own, so
+    // `destroy_command_queue` releasing it leaves the pinned device live
+    // for the next D3D device and for the process-wide caches.
     let device_handle =
         unsafe { MetalHandle::<MTLDeviceKind>::new(Retained::into_raw(device) as u64) };
     // SAFETY: as above.
@@ -235,3 +292,6 @@ pub fn destroy_command_queue(
         release_metal_view(view_handle);
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/unix/unix/src/metal/device/tests.rs
+++ b/unix/unix/src/metal/device/tests.rs
@@ -1,0 +1,75 @@
+//! Unit tests for the process-pinned Metal device.
+//!
+//! The pin is what makes the process-wide Metal caches sound: they hold
+//! pipeline states, textures and buffers built on one `MTLDevice`, and Metal
+//! rejects an encode that mixes objects of two. Every Mac these tests run on
+//! has one GPU, so the assertions pin the invariant rather than reproduce the
+//! dual-GPU divergence, which needs graphics switching to observe.
+
+use objc2_metal::MTLDevice;
+
+use super::{DeviceCaps, create_command_queue, default_device_info};
+use crate::metal::handle::{IntoRetained, ReleaseRetain};
+
+/// Drops the retains one `DeviceCaps` handed out, as the destroy thunk does.
+///
+/// The caller must be done with both handles, and no copy of either may be
+/// used afterwards.
+fn release(caps: &DeviceCaps) {
+    // SAFETY: this stands in for `destroy_command_queue`. The queue handle
+    // carries the only retain on a queue nothing else names.
+    unsafe { caps.queue_handle.release_retain() };
+    // SAFETY: the device handle carries the retain `create_command_queue`
+    // took for this D3D device, not the pin's own.
+    unsafe { caps.device_handle.release_retain() };
+}
+
+/// Two `create_command_queue` calls hand out one device, and the caps agree with it.
+///
+/// The second call must name the same `id<MTLDevice>` as the first, and
+/// `default_device_info`, which answers the PE side's `GetDeviceInfo`, must
+/// report that device's registry id rather than a second resolution's. The
+/// third call proves the pin keeps a retain of its own: the device is still
+/// live after both handed-out retains are dropped.
+#[test]
+fn create_command_queue_hands_out_the_pinned_device() {
+    let Some(first) = create_command_queue() else {
+        eprintln!("MTLCreateSystemDefaultDevice returned nil, skipping");
+        return;
+    };
+    let second = create_command_queue().expect("a second queue on the pinned device");
+    assert_eq!(
+        first.device_handle.raw(),
+        second.device_handle.raw(),
+        "every D3D device gets the same MTLDevice"
+    );
+    assert_ne!(
+        first.queue_handle.raw(),
+        second.queue_handle.raw(),
+        "each D3D device gets its own MTLCommandQueue"
+    );
+
+    let (_, registry_id, _) = default_device_info().expect("caps for the pinned device");
+    let device = first
+        .device_handle
+        .into_retained()
+        .expect("the handed-out device handle is live");
+    assert_eq!(
+        device.registryID(),
+        registry_id,
+        "the caps answer describes the device the queues were made on"
+    );
+    drop(device);
+
+    release(&first);
+    release(&second);
+
+    let third = create_command_queue().expect("a queue after both devices were destroyed");
+    let device = third
+        .device_handle
+        .into_retained()
+        .expect("the pinned device outlives the handles it was handed out through");
+    assert_eq!(device.registryID(), registry_id);
+    drop(device);
+    release(&third);
+}

--- a/unix/unix/src/metal/present.rs
+++ b/unix/unix/src/metal/present.rs
@@ -115,12 +115,13 @@ use crate::{LOG_TARGET, metal::handle::IntoRetained};
 /// (`shader.rs`) — keeps the same library working on Intel/AMD Macs.
 const PRESENT_MSL: &str = include_str!("present.msl");
 
-/// Cached present-pass resources keyed on the device.
+/// Cached present-pass resources for the process's Metal device.
 ///
-/// mtld3d has one `MTLDevice` per process so a global `OnceLock` is the
-/// right grain; the fields are raw `u64` handles so the type is trivially
-/// `Send + Sync`. Handles leak at process exit — these are process-lifetime
-/// objects, the same as the device and command queue.
+/// The unix side resolves one `MTLDevice` and hands it to every D3D device
+/// (`metal::device`), so a global `OnceLock` is the right grain; the fields
+/// are raw `u64` handles so the type is trivially `Send + Sync`. Handles leak
+/// at process exit: these are process-lifetime objects, the same as the device
+/// and command queue.
 ///
 /// Six pipeline states share one MSL library, one per fragment entry
 /// point. `copy` writes the SDR drawable format; the two HDR states write


### PR DESCRIPTION
## Symptoms

On a dual-GPU Intel Mac with automatic graphics switching, a second D3D device created after a switch encodes against a different `MTLDevice` than the one the process-wide Metal caches were built on. Metal rejects the first such bind with a `was created by a different device` validation abort, and renders undefined without validation. No local or CI machine can reproduce it: every runner and every Apple Silicon Mac has one GPU, so `MTLCreateSystemDefaultDevice` answers with the same object every time.

## Root cause

Seven process-wide statics in `unix/unix/src/metal/` hold Metal objects tied to the device that first reached them: the present and cursor pipelines, the present library and the readback resolve pipelines in `present.rs`, the null textures in `null_texture.rs`, and the pipeline-plus-vertex-buffer caches in `upload_quad.rs`, `clear_quad.rs` and `blit.rs`. Their grain rested on a comment in `present.rs` asserting one `MTLDevice` per process, which nothing enforced: `create_command_queue` called `MTLCreateSystemDefaultDevice` once per D3D device and handed each the device it got back, and `default_device_info` made a further call for the caps. The system default device follows the mux state on a dual-GPU Mac, so two calls either side of a graphics switch return two objects.

## Changes

`unix/unix/src/metal/device.rs` resolves the system default device once into `PINNED_DEVICE`, a `LazyLock<MetalHandle<MTLDeviceKind>>`. The retain the handle carries is never released, which is the same lifetime the caches built on the device already have; `MetalHandle` is a transparent `u64` newtype, so the static is `Send + Sync` without a wrapper. A private `pinned_device` returns that device with one retain for the caller through the existing safe `IntoRetained` conversion, and compares the current system default against it, logging once through `log_once_warn!` when they differ and keeping the pinned one.

`create_command_queue` and `default_device_info` both go through `pinned_device`. The wire shape is unchanged: `DeviceCaps.device_handle` still carries one retain per D3D device, taken for that device rather than transferred out of a fresh `MTLCreateSystemDefaultDevice`, so `destroy_command_queue` releasing it balances as before and leaves the pin's own retain untouched. The `SAFETY` comment at the handle construction states that.

The `present.rs` doc block that carried the assumption now states the invariant instead: the unix side resolves one device and hands it to every D3D device, which is what makes a global `OnceLock` the right grain there.

## Alternatives

Key the seven caches by device handle, as `upscale.rs` keys its scaler and scratch caches by queue. Rejected: it is seven cache rewrites plus a per-lookup device argument threaded to each, to serve a case where the layer would still be creating two of every pipeline and quad buffer, and it leaves the rest of the layer (one cursor overlay, one present library) assuming a single device anyway.

Pick the device explicitly from `MTLCopyAllDevices` rather than taking the system default. Rejected: it changes which GPU the layer runs on, which is a separate decision with its own performance and external-display consequences, not a fix for the cache grain.

Fail the second `CreateCommandQueue` when the device differs. Rejected: the game gets a working device on the pinned GPU, and refusing it would break a launcher-plus-game pair that a warn line covers.

## Verification

`make fmt`, `make check` green.

`make ISOLATED=1 test`: 475 PASS per architecture (i686 and x86_64), 0 FAIL, 0 LEAK, 0 SKIP, 4 processes per leg; host unit tests 1091 passed and the runner crates 266 passed.

`make ISOLATED=1 conformance`: no regressions on either architecture. i686 device 758 to 735, x86_64 device 756 to 733, every moved site a `ceiling` pin that reads zero in a desktop-mode session plus the known flaky 4475 and 4480; visual, stateblock and d3d9ex unchanged. No baseline re-record, since none of the movement comes from this change.

The new unit test is `metal::device::tests::create_command_queue_hands_out_the_pinned_device` in `unix/unix/src/metal/device/tests.rs`. It asserts that two `create_command_queue` calls report the same `device_handle` and different `queue_handle`s, that `default_device_info` reports that device's `registryID`, and that after both handed-out retains are released the way `destroy_command_queue` releases them, a third call still returns a live device with the same registry id, which is what proves the pin holds a retain of its own. It passes before this change as well as after: the divergence needs two GPUs and a graphics switch to observe, so the test pins the invariant rather than reproducing the failure.

Closes #459
