### PR TITLE
Keep the layer's log of a lost test process and name the tests it had in flight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,10 @@ jobs:
       # The layer's log of every test process, and the whole stderr of every
       # process that died with tests unaccounted for, go under the runner's
       # temp directory, where the step below picks them up, rather than beside
-      # the test binary. The job log carries only what reached stdout: the
+      # the test binary. The layer's log of such a process is moved to
+      # `.layer-log` there, out of the layer's ten-newest retention, so the
+      # account of the death is in the artifact however many processes ran
+      # after it. The job log carries only what reached stdout: the
       # PASS/FAIL lines, the panic messages and the tail of stderr the runner
       # prints. What the command buffers reported is in the layer's log, and
       # that is what tells a runner whose GPU reads back black on every test
@@ -247,6 +250,7 @@ jobs:
           path: |
             ${{ runner.temp }}/*.log
             ${{ runner.temp }}/*.stderr
+            ${{ runner.temp }}/*.layer-log
           retention-days: 14
           if-no-files-found: ignore
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,9 +88,14 @@ about that process names the file. What it prints inline is the last fifteen
 lines the process itself wrote: Wine's `fixme` lines and everything its
 `dbghelp` channel prints are left out, because dozens of them surround each
 backtrace and a raw tail rarely reaches back past them to the message that
-says what failed.
+says what failed. The layer's own log of that process is the other account,
+and the only one of a death the layer's crash handler ended: its fatal banner,
+registers and stack go there and never to stderr. The runner moves that log
+to `<binary>-<pid>.layer-log` beside the stderr, because the layer keeps only
+its ten newest logs and the next run would remove it, and quotes it in the
+same note from the banner on when there is one.
 
-In CI every end-to-end leg uploads both kinds of file as its
+In CI every end-to-end leg uploads all three kinds of file as its
 `e2e-logs-<image>-<arch>` artifact on every run, kept fourteen days; the
 directory holds the ten newest of each, so a leg that restarted more than ten
 processes hands back its last ten. They are the layer's side of a red leg,

--- a/Makefile
+++ b/Makefile
@@ -589,8 +589,9 @@ stage: all
 # that is only reachable through its artifacts (a CI runner) can hand the logs
 # back, which every CI end-to-end leg does. The layer reads the directory on
 # the PE side, where the unix root is drive Z, and the runner writes the whole
-# stderr of every process that died there beside those logs. Ten files of each
-# kind are kept per directory.
+# stderr of every process that died there beside those logs and moves the
+# layer's log of that process next to it, out of the layer's own retention.
+# Ten files of each kind are kept per directory.
 INTEL_CONF := intel.expandPacked16=true;intel.denyFloat32Filtering=true;intel.managedMemory=true;intel.linearAlign256=true
 MTLD3D_CONF_TEST := shaderCache.enable=false;color.hdr.enable=false$(if $(SCALE),;render.scale=$(SCALE))$(if $(INTEL),;$(INTEL_CONF))$(if $(LOG_DIR),;log.dir=Z:$(LOG_DIR))
 # Quoted: the config separator is `;`, which the shell would otherwise read as

--- a/unix/Cargo.lock
+++ b/unix/Cargo.lock
@@ -246,6 +246,7 @@ name = "mtld3d-e2e"
 version = "0.8.0"
 dependencies = [
  "libc",
+ "mtld3d-shared",
 ]
 
 [[package]]

--- a/unix/e2e/Cargo.toml
+++ b/unix/e2e/Cargo.toml
@@ -9,6 +9,10 @@ authors.workspace = true
 
 [dependencies]
 libc = { workspace = true }
+# The runner reads the log the layer wrote for a process it lost, so it takes
+# the file naming and the fatal banner from the crate that defines them rather
+# than restating either.
+mtld3d-shared = { workspace = true }
 
 [lints]
 workspace = true

--- a/unix/e2e/src/attribute.rs
+++ b/unix/e2e/src/attribute.rs
@@ -20,7 +20,9 @@
 //!
 //! The layer keeps an account of its own. Its log file, not the process's
 //! stderr, is where its crash report goes, so a note about a process that
-//! ended unaccounted for quotes both.
+//! ended unaccounted for quotes both, and the runner moves that log out of
+//! the layer's retention (the newest ten logs, which the runs that follow
+//! soon exceed) so the account is still there when someone reads the note.
 //!
 //! One kind of test ends its process on purpose: it declares its name and
 //! the code it is about to exit with on stdout (see [`declared_exit`]), and
@@ -30,7 +32,7 @@
 use std::{collections::BTreeSet, mem, path::PathBuf};
 
 use crate::{
-    binary::stderr_tail,
+    binary::{LayerLog, stderr_tail},
     libtest::{self, Event, Outcome, Summary},
     run::ExitKind,
 };
@@ -92,17 +94,20 @@ pub trait Launcher {
     /// Returns the reason when the file cannot be written.
     fn keep_stderr(&self, pid: u32, stderr: &str) -> Result<PathBuf, String>;
 
-    /// The layer's own log of the process `pid`: the file, and its account of the end.
+    /// Keep the layer's own log of the process `pid`, and read its account of the end.
     ///
     /// The layer writes every line, its crash report included, into this
     /// file and never to the pipes the runner reads, so a process the layer
     /// ended says nothing on stderr and the file is the only account of it.
+    /// The layer also removes all but its newest ten logs as later processes
+    /// create theirs, so the file is moved to a name that retention never
+    /// matches, beside the kept stderr.
     ///
     /// # Errors
     ///
     /// Returns the reason when the file cannot be read, which for a process
     /// that logged nothing is that it was never created.
-    fn layer_log(&self, pid: u32) -> Result<(PathBuf, String), String>;
+    fn keep_layer_log(&self, pid: u32) -> Result<LayerLog, String>;
 }
 
 /// What became of one test.
@@ -287,7 +292,7 @@ pub fn run_binary(
                 in_flight.len(),
                 in_flight_line(&running),
                 stderr_tail(&end.stderr),
-                layer_log(launcher.layer_log(end.pid))
+                kept_layer_log(launcher.keep_layer_log(end.pid))
             ));
             let named = libtest::panicked_tests(&end.stderr)
                 .into_iter()
@@ -400,10 +405,22 @@ fn in_flight_line(running: &[String]) -> String {
     format!("in flight when it ended: {}\n", running.join(", "))
 }
 
-/// Where the layer's own log of a dead process is and what it says about the end.
-fn layer_log(read: Result<(PathBuf, String), String>) -> String {
-    match read {
-        Ok((path, tail)) => format!("the layer's own log is {}:\n{tail}", path.display()),
+/// Where the layer's own log of a dead process is kept and what it says about the end.
+fn kept_layer_log(kept: Result<LayerLog, String>) -> String {
+    match kept {
+        Ok(LayerLog {
+            path,
+            tail,
+            not_kept: None,
+        }) => format!("the layer's own log is kept as {}:\n{tail}", path.display()),
+        Ok(LayerLog {
+            path,
+            tail,
+            not_kept: Some(why),
+        }) => format!(
+            "the layer's own log is still {}, which its retention will remove ({why}):\n{tail}",
+            path.display()
+        ),
         Err(why) => format!("the layer wrote no log of it ({why})"),
     }
 }

--- a/unix/e2e/src/attribute.rs
+++ b/unix/e2e/src/attribute.rs
@@ -10,12 +10,24 @@
 //! before running it. Every round strictly shrinks what is left, so the loop
 //! ends.
 //!
+//! What was in flight is not libtest's to say once more than one test runs
+//! at a time: it names a test only when the test finishes. So a test names
+//! itself when it starts (see [`announced`]), and a process that ends with
+//! several unaccounted for is narrowed to the tests that had named
+//! themselves and not finished. Those run one at a time, where a start line
+//! names the culprit; the rest wait for a process of their own at the width
+//! the caller asked for, since nothing so far says they were involved.
+//!
+//! The layer keeps an account of its own. Its log file, not the process's
+//! stderr, is where its crash report goes, so a note about a process that
+//! ended unaccounted for quotes both.
+//!
 //! One kind of test ends its process on purpose: it declares its name and
 //! the code it is about to exit with on stdout (see [`declared_exit`]), and
 //! the exit code is then the whole assertion, since libtest never gets to
 //! report a result. A binary that carries such a test carries nothing else.
 
-use std::{collections::BTreeSet, path::PathBuf};
+use std::{collections::BTreeSet, mem, path::PathBuf};
 
 use crate::{
     binary::stderr_tail,
@@ -32,6 +44,13 @@ use crate::{
 const ENDS_PROCESS: &str = "[e2e] test ";
 /// What separates the test's name from its exit code in the marker.
 const ENDS_PROCESS_CODE: &str = " ends this process with exit code ";
+
+/// The stdout marker of a test that has started; what follows it is its name.
+///
+/// Printed by the test binary's shared harness on the thread libtest named
+/// after the test. Searched for rather than matched at the start, for the
+/// same reason as [`ENDS_PROCESS`].
+const RUNNING: &str = "[e2e] running ";
 
 /// How a process of the binary ended, with everything it printed.
 pub struct ProcessEnd {
@@ -72,6 +91,18 @@ pub trait Launcher {
     ///
     /// Returns the reason when the file cannot be written.
     fn keep_stderr(&self, pid: u32, stderr: &str) -> Result<PathBuf, String>;
+
+    /// The layer's own log of the process `pid`: the file, and its account of the end.
+    ///
+    /// The layer writes every line, its crash report included, into this
+    /// file and never to the pipes the runner reads, so a process the layer
+    /// ended says nothing on stderr and the file is the only account of it.
+    ///
+    /// # Errors
+    ///
+    /// Returns the reason when the file cannot be read, which for a process
+    /// that logged nothing is that it was never created.
+    fn layer_log(&self, pid: u32) -> Result<(PathBuf, String), String>;
 }
 
 /// What became of one test.
@@ -132,186 +163,249 @@ pub fn run_binary(
     fail_fast: bool,
     report: &mut dyn Report,
 ) -> Result<BinaryRun, String> {
+    let jobs = threads;
     let mut remaining = selection;
     let mut threads = threads;
+    let mut deferred: Vec<String> = Vec::new();
     let mut done: BTreeSet<String> = BTreeSet::new();
     let mut run = BinaryRun {
         processes: 0,
         failed: false,
     };
-    loop {
-        if remaining.as_ref().is_some_and(Vec::is_empty) {
-            break;
-        }
-        run.processes += 1;
-        let mut round = Round {
-            finished: Vec::new(),
-            started: None,
-            summary: None,
-        };
-        let end = launcher.run(remaining.as_deref(), threads, &mut |event| match event {
-            Event::Started(name) => round.started = Some(name),
-            Event::Finished { name, outcome } => {
-                round.started = None;
-                round.finished.push((name, outcome));
+    // The inner loop runs one binary's rounds; leaving it means the rounds
+    // are done, and the outer one picks up whatever a narrowed round set
+    // aside and runs it at the width the caller asked for.
+    'binary: loop {
+        loop {
+            if remaining.as_ref().is_some_and(Vec::is_empty) {
+                break;
             }
-            Event::Summary(summary) => round.summary = Some(summary),
-        })?;
-        let ran_something = !round.finished.is_empty();
-        let reported = round.finished.len();
-        let declared = declared_exit(&end.stdout);
-        let ends_itself = declared.is_some();
-        if let Some((name, code)) = declared {
-            let verdict = if end.kind == ExitKind::Code(code) {
-                Verdict::Passed
-            } else {
-                run.failed = true;
-                Verdict::Failed(format!(
-                    "the test ends this process with exit code {code}; it ended with {}",
-                    end.kind.describe()
-                ))
+            run.processes += 1;
+            let mut round = Round {
+                finished: Vec::new(),
+                started: None,
+                summary: None,
             };
-            done.insert(name.clone());
-            report.result(TestResult { name, verdict });
-        }
-        for (name, outcome) in round.finished {
-            let verdict = match outcome {
-                Outcome::Ok => Verdict::Passed,
-                Outcome::Ignored => Verdict::Ignored,
-                Outcome::Failed => {
-                    run.failed = true;
-                    Verdict::Failed(
-                        libtest::failure_report(&end.stdout, &name)
-                            .unwrap_or_else(|| "libtest reported FAILED".to_owned()),
-                    )
+            let end = launcher.run(remaining.as_deref(), threads, &mut |event| match event {
+                Event::Started(name) => round.started = Some(name),
+                Event::Finished { name, outcome } => {
+                    round.started = None;
+                    round.finished.push((name, outcome));
                 }
-            };
-            done.insert(name.clone());
-            report.result(TestResult { name, verdict });
-        }
+                Event::Summary(summary) => round.summary = Some(summary),
+            })?;
+            let ran_something = !round.finished.is_empty();
+            let reported = round.finished.len();
+            let declared = declared_exit(&end.stdout);
+            let ends_itself = declared.is_some();
+            if let Some((name, code)) = declared {
+                let verdict = if end.kind == ExitKind::Code(code) {
+                    Verdict::Passed
+                } else {
+                    run.failed = true;
+                    Verdict::Failed(format!(
+                        "the test ends this process with exit code {code}; it ended with {}",
+                        end.kind.describe()
+                    ))
+                };
+                done.insert(name.clone());
+                report.result(TestResult { name, verdict });
+            }
+            for (name, outcome) in round.finished {
+                let verdict = match outcome {
+                    Outcome::Ok => Verdict::Passed,
+                    Outcome::Ignored => Verdict::Ignored,
+                    Outcome::Failed => {
+                        run.failed = true;
+                        Verdict::Failed(
+                            libtest::failure_report(&end.stdout, &name)
+                                .unwrap_or_else(|| "libtest reported FAILED".to_owned()),
+                        )
+                    }
+                };
+                done.insert(name.clone());
+                report.result(TestResult { name, verdict });
+            }
 
-        let clean = ends_itself || (end.kind == ExitKind::Code(0) && round.summary.is_some());
-        let complete = remaining
-            .as_ref()
-            .is_none_or(|names| names.iter().all(|name| done.contains(name)));
-        if clean && complete {
-            break;
-        }
-        if clean {
-            // libtest ran to the end without these: they are not tests it knows.
-            for name in remaining.take().into_iter().flatten() {
-                if done.insert(name.clone()) {
-                    run.failed = true;
-                    report.result(TestResult {
-                        name,
-                        verdict: Verdict::Failed(
-                            "the binary ran to completion without running this test".to_owned(),
-                        ),
-                    });
-                }
+            let clean = ends_itself || (end.kind == ExitKind::Code(0) && round.summary.is_some());
+            let complete = remaining
+                .as_ref()
+                .is_none_or(|names| names.iter().all(|name| done.contains(name)));
+            if clean && complete {
+                break;
             }
-            break;
-        }
-        let reason = end.kind.describe();
-        // libtest's own tally, when it got that far, says whether anything
-        // was still in flight without a `--list`.
-        let tallied = round.summary.as_ref().is_some_and(|s| {
-            s.passed + s.failed + s.ignored == u32::try_from(reported).unwrap_or(u32::MAX)
-        });
-        if tallied && complete {
-            report.note(&format!(
+            if clean {
+                // libtest ran to the end without these: they are not tests it knows.
+                for name in remaining.take().into_iter().flatten() {
+                    if done.insert(name.clone()) {
+                        run.failed = true;
+                        report.result(TestResult {
+                            name,
+                            verdict: Verdict::Failed(
+                                "the binary ran to completion without running this test".to_owned(),
+                            ),
+                        });
+                    }
+                }
+                break;
+            }
+            let reason = end.kind.describe();
+            // libtest's own tally, when it got that far, says whether anything
+            // was still in flight without a `--list`.
+            let tallied = round.summary.as_ref().is_some_and(|s| {
+                s.passed + s.failed + s.ignored == u32::try_from(reported).unwrap_or(u32::MAX)
+            });
+            if tallied && complete {
+                report.note(&format!(
                 "the process ended with {reason} after reporting every test; nothing to run again"
             ));
-            break;
-        }
+                break;
+            }
 
-        // The process ended with tests unaccounted for: which were in flight?
-        let listed = match remaining.take() {
-            Some(names) => names,
-            None => launcher.list()?,
-        };
-        let mut in_flight: Vec<String> = listed
-            .into_iter()
-            .filter(|name| !done.contains(name))
-            .collect();
-        if in_flight.is_empty() {
-            break;
-        }
-        let kept = kept_stderr(launcher.keep_stderr(end.pid, &end.stderr));
-        report.note(&format!(
-            "the process ended with {reason}; {} of its tests unaccounted for; {kept}; its last lines:\n{}",
-            in_flight.len(),
-            stderr_tail(&end.stderr)
-        ));
-        let named = libtest::panicked_tests(&end.stderr)
-            .into_iter()
-            .find(|name| in_flight.contains(name));
-        if named.is_none() && threads == 1 && !ran_something && round.started.is_none() {
-            // One thread, nothing ran, nothing names a test: the binary itself
-            // is broken, and running it again would only say so again.
-            run.failed = true;
-            let detail = format!(
-                "the process ended ({reason}) before running any test; {kept}\n{}",
-                stderr_tail(&end.stderr)
-            );
-            for name in in_flight {
-                done.insert(name.clone());
-                report.result(TestResult {
-                    name,
-                    verdict: Verdict::Failed(detail.clone()),
-                });
+            // The process ended with tests unaccounted for: which were in flight?
+            let listed = match remaining.take() {
+                Some(names) => names,
+                None => launcher.list()?,
+            };
+            let mut in_flight: Vec<String> = listed
+                .into_iter()
+                .filter(|name| !done.contains(name))
+                .collect();
+            if in_flight.is_empty() {
+                break;
             }
-            break;
-        }
-        let victim = named.clone().or_else(|| {
-            (threads == 1 || in_flight.len() == 1).then(|| {
-                round
-                    .started
-                    .filter(|name| in_flight.contains(name))
-                    .unwrap_or_else(|| in_flight[0].clone())
-            })
-        });
-        if let Some(name) = victim {
-            let detail = named
-                .as_ref()
-                .and_then(|_| libtest::panic_report(&end.stderr, &name))
-                .unwrap_or_else(|| {
-                    format!(
-                        "the process ended ({reason}) while this test ran; {kept}\n{}",
-                        stderr_tail(&end.stderr)
-                    )
-                });
-            in_flight.retain(|other| *other != name);
-            done.insert(name.clone());
-            run.failed = true;
-            report.result(TestResult {
-                name,
-                verdict: Verdict::Failed(detail),
-            });
-        } else {
-            // Several tests were in flight and nothing names one: run them one
-            // at a time, where the start line does.
-            threads = 1;
-            report.note("nothing names the test it ended in; running those again one at a time");
-        }
-        if fail_fast && run.failed {
-            for name in in_flight {
-                report.result(TestResult {
-                    name,
-                    verdict: Verdict::NotRun,
-                });
-            }
-            break;
-        }
-        if !in_flight.is_empty() {
+            let kept = kept_stderr(launcher.keep_stderr(end.pid, &end.stderr));
+            // The tests that had named themselves and never reported a result:
+            // exactly what was running on the threads when the process ended.
+            let mut running: Vec<String> = announced(&end.stdout)
+                .into_iter()
+                .filter(|name| in_flight.contains(name))
+                .collect();
             report.note(&format!(
-                "running the {} tests left in a fresh process",
-                in_flight.len()
+                "the process ended with {reason}; {} of its tests unaccounted for\n\
+                 {}{kept}; its last lines:\n{}\n{}",
+                in_flight.len(),
+                in_flight_line(&running),
+                stderr_tail(&end.stderr),
+                layer_log(launcher.layer_log(end.pid))
             ));
+            let named = libtest::panicked_tests(&end.stderr)
+                .into_iter()
+                .find(|name| in_flight.contains(name));
+            if named.is_none() && threads == 1 && !ran_something && round.started.is_none() {
+                // One thread, nothing ran, nothing names a test: the binary itself
+                // is broken, and running it again would only say so again.
+                run.failed = true;
+                let detail = format!(
+                    "the process ended ({reason}) before running any test; {kept}\n{}",
+                    stderr_tail(&end.stderr)
+                );
+                for name in in_flight {
+                    done.insert(name.clone());
+                    report.result(TestResult {
+                        name,
+                        verdict: Verdict::Failed(detail.clone()),
+                    });
+                }
+                break;
+            }
+            let victim = named.clone().or_else(|| {
+                (threads == 1 || in_flight.len() == 1).then(|| {
+                    round
+                        .started
+                        .filter(|name| in_flight.contains(name))
+                        .unwrap_or_else(|| in_flight[0].clone())
+                })
+            });
+            if let Some(name) = victim {
+                let detail = named
+                    .as_ref()
+                    .and_then(|_| libtest::panic_report(&end.stderr, &name))
+                    .unwrap_or_else(|| {
+                        format!(
+                            "the process ended ({reason}) while this test ran; {kept}\n{}",
+                            stderr_tail(&end.stderr)
+                        )
+                    });
+                in_flight.retain(|other| *other != name);
+                done.insert(name.clone());
+                run.failed = true;
+                report.result(TestResult {
+                    name,
+                    verdict: Verdict::Failed(detail),
+                });
+            } else {
+                // Several tests were in flight and nothing names one: run them one
+                // at a time, where the start line does. The tests that named
+                // themselves are that set, so only they run that way; the rest
+                // are nothing to do with this end and wait for a process of
+                // their own at the caller's width.
+                threads = 1;
+                if !running.is_empty() {
+                    deferred.extend(
+                        in_flight
+                            .iter()
+                            .filter(|name| !running.contains(name))
+                            .cloned(),
+                    );
+                    in_flight = mem::take(&mut running);
+                }
+                report
+                    .note("nothing names the test it ended in; running those again one at a time");
+            }
+            if fail_fast && run.failed {
+                for name in in_flight.into_iter().chain(mem::take(&mut deferred)) {
+                    report.result(TestResult {
+                        name,
+                        verdict: Verdict::NotRun,
+                    });
+                }
+                break;
+            }
+            if !in_flight.is_empty() {
+                report.note(&format!(
+                    "running the {} tests left in a fresh process",
+                    in_flight.len()
+                ));
+            }
+            remaining = Some(in_flight);
         }
-        remaining = Some(in_flight);
+        if deferred.is_empty() {
+            break 'binary;
+        }
+        report.note(&format!(
+            "running the {} tests the narrowed round set aside",
+            deferred.len()
+        ));
+        remaining = Some(mem::take(&mut deferred));
+        threads = jobs;
     }
     Ok(run)
+}
+
+/// The tests that named themselves on `stdout`, in the order they did.
+fn announced(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .filter_map(|line| line.split_once(RUNNING))
+        .map(|(_, name)| name.trim().to_owned())
+        .collect()
+}
+
+/// The report line naming what was in flight, or nothing when no test named itself.
+fn in_flight_line(running: &[String]) -> String {
+    if running.is_empty() {
+        return String::new();
+    }
+    format!("in flight when it ended: {}\n", running.join(", "))
+}
+
+/// Where the layer's own log of a dead process is and what it says about the end.
+fn layer_log(read: Result<(PathBuf, String), String>) -> String {
+    match read {
+        Ok((path, tail)) => format!("the layer's own log is {}:\n{tail}", path.display()),
+        Err(why) => format!("the layer wrote no log of it ({why})"),
+    }
 }
 
 /// Where a dead process's whole stderr went, or why it could not be kept.

--- a/unix/e2e/src/attribute/tests.rs
+++ b/unix/e2e/src/attribute/tests.rs
@@ -9,6 +9,11 @@
 //! after the first failure with the rest reported unrun, and a test that
 //! declares the code it ends its process with passes only on that code,
 //! and a dead process keeps its whole stderr in a file the note names.
+//!
+//! Two more pin what a death nothing on stderr accounts for still says: the
+//! note names the tests that had named themselves and not finished, and
+//! only those run again one at a time, and the layer's own log of the
+//! process is quoted with them.
 
 use std::{
     collections::VecDeque,
@@ -18,15 +23,21 @@ use std::{
 };
 
 use super::{Launcher, ProcessEnd, Report, TestResult, Verdict, run_binary};
-use crate::{binary::keep_stderr, libtest::Parser, run::ExitKind};
+use crate::{
+    binary::{keep_stderr, layer_tail},
+    libtest::Parser,
+    run::ExitKind,
+};
 
 /// The pid every scripted process ends under, so a test knows the file's name.
 const PID: u32 = 4242;
 
-/// One scripted process: its stdout, stderr, and how it ends.
+/// One scripted process: its stdout, stderr, the layer's log of it, and how it ends.
 struct Script {
     stdout: &'static str,
     stderr: String,
+    /// What the layer wrote into its own log file; `None` = it wrote none.
+    layer: Option<&'static str>,
     kind: ExitKind,
 }
 
@@ -37,6 +48,8 @@ struct Scripted {
     launched: Vec<(Option<Vec<String>>, u32)>,
     /// A directory of this launcher's own, so tests running at once do not share one.
     log_dir: PathBuf,
+    /// The layer log of the process that ended last, as the script gave it.
+    layer: Option<&'static str>,
 }
 
 impl Scripted {
@@ -52,6 +65,7 @@ impl Scripted {
             scripts: scripts.into(),
             launched: Vec::new(),
             log_dir,
+            layer: None,
         }
     }
 }
@@ -65,6 +79,7 @@ impl Launcher for Scripted {
     ) -> Result<ProcessEnd, String> {
         self.launched.push((names.map(<[String]>::to_vec), threads));
         let script = self.scripts.pop_front().expect("a script per process");
+        self.layer = script.layer;
         let mut parser = Parser::default();
         for line in script.stdout.lines() {
             if let Some(event) = parser.line(line) {
@@ -85,6 +100,14 @@ impl Launcher for Scripted {
 
     fn keep_stderr(&self, pid: u32, stderr: &str) -> Result<PathBuf, String> {
         keep_stderr(&self.log_dir, "scripted", pid, stderr)
+    }
+
+    fn layer_log(&self, pid: u32) -> Result<(PathBuf, String), String> {
+        let path = self.log_dir.join(format!("scripted-{pid}.log"));
+        let log = self
+            .layer
+            .ok_or_else(|| format!("{}: no such file", path.display()))?;
+        Ok((path, layer_tail(log)))
     }
 }
 
@@ -133,6 +156,7 @@ fn a_clean_run_costs_one_process_and_never_lists() {
         vec![Script {
             stdout: "running 3 tests\ntest a::one ... ok\ntest a::two ... ignored\ntest b::three ... ok\n\ntest result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
             stderr: String::new(),
+            layer: None,
             kind: ExitKind::Code(0),
         }],
     );
@@ -157,11 +181,13 @@ fn a_panic_names_its_test_and_the_rest_run_again() {
             Script {
                 stdout: "running 3 tests\ntest a::one ... ok\n",
                 stderr: "thread 'a::two' panicked at x.rs:1:1:\nassertion failed: it\n".to_owned(),
+                layer: None,
                 kind: ExitKind::Code(101),
             },
             Script {
                 stdout: "running 1 test\ntest b::three ... ok\n\ntest result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
                 stderr: String::new(),
+                layer: None,
                 kind: ExitKind::Code(0),
             },
         ],
@@ -190,11 +216,13 @@ fn an_unnamed_crash_under_threads_is_attributed_on_one_thread() {
             Script {
                 stdout: "running 3 tests\ntest a::one ... ok\n",
                 stderr: "wine: Unhandled page fault\n".to_owned(),
+                layer: None,
                 kind: ExitKind::Code(5),
             },
             Script {
                 stdout: "running 2 tests\ntest a::two ... ok\ntest b::three ... ",
                 stderr: "wine: Unhandled page fault\n".to_owned(),
+                layer: None,
                 kind: ExitKind::Code(5),
             },
         ],
@@ -220,11 +248,13 @@ fn a_hang_is_the_test_whose_start_line_has_no_outcome() {
             Script {
                 stdout: "running 2 tests\ntest a::one ... ",
                 stderr: String::new(),
+                layer: None,
                 kind: ExitKind::TimedOut(Duration::from_secs(5)),
             },
             Script {
                 stdout: "running 1 test\ntest a::two ... ok\n\ntest result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
                 stderr: String::new(),
+                layer: None,
                 kind: ExitKind::Code(0),
             },
         ],
@@ -243,11 +273,13 @@ fn a_binary_that_dies_before_any_test_fails_whole_without_a_retry_loop() {
             Script {
                 stdout: "",
                 stderr: "wine: could not load d3d9.dll\n".to_owned(),
+                layer: None,
                 kind: ExitKind::Code(1),
             },
             Script {
                 stdout: "",
                 stderr: "wine: could not load d3d9.dll\n".to_owned(),
+                layer: None,
                 kind: ExitKind::Code(1),
             },
         ],
@@ -267,6 +299,7 @@ fn fail_fast_stops_after_the_first_failure_and_reports_the_rest_unrun() {
         vec![Script {
             stdout: "running 3 tests\ntest a::one ... ",
             stderr: "thread 'a::one' panicked at x.rs:1:1:\nno\n".to_owned(),
+            layer: None,
             kind: ExitKind::Code(101),
         }],
     );
@@ -289,6 +322,7 @@ fn a_failure_libtest_survived_is_read_from_its_report() {
         vec![Script {
             stdout: "running 2 tests\ntest a::one ... FAILED\ntest a::two ... ok\n\nfailures:\n\n---- a::one stdout ----\nleft != right\n\n\nfailures:\n    a::one\n\ntest result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
             stderr: String::new(),
+            layer: None,
             kind: ExitKind::Code(101),
         }],
     );
@@ -308,6 +342,7 @@ fn a_selected_name_the_binary_does_not_know_is_a_failure() {
         vec![Script {
             stdout: "running 1 test\ntest a::one ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.1s\n",
             stderr: String::new(),
+            layer: None,
             kind: ExitKind::Code(0),
         }],
     );
@@ -328,6 +363,7 @@ fn an_unclean_exit_after_a_full_tally_costs_no_list_and_no_process() {
         vec![Script {
             stdout: "running 2 tests\ntest a::one ... ok\ntest a::two ... ok\n\ntest result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
             stderr: String::new(),
+            layer: None,
             kind: ExitKind::Code(3),
         }],
     );
@@ -350,6 +386,7 @@ fn a_declared_exit_code_the_process_ends_with_passes_its_test() {
         vec![Script {
             stdout: "running 1 test\ntest a::ends ... \n[e2e] test a::ends ends this process with exit code 42\n",
             stderr: String::new(),
+            layer: None,
             kind: ExitKind::Code(42),
         }],
     );
@@ -368,6 +405,7 @@ fn a_declared_exit_code_the_process_misses_fails_its_test() {
         vec![Script {
             stdout: "running 1 test\ntest a::ends ... [e2e] test a::ends ends this process with exit code 42\n",
             stderr: String::new(),
+            layer: None,
             kind: ExitKind::Code(0),
         }],
     );
@@ -390,6 +428,7 @@ fn a_dead_process_keeps_its_whole_stderr_and_the_note_names_the_file() {
         vec![Script {
             stdout: "running 2 tests\ntest a::one ... ok\n",
             stderr: stderr.clone(),
+            layer: None,
             kind: ExitKind::Signal(11),
         }],
     );
@@ -406,4 +445,90 @@ fn a_dead_process_keeps_its_whole_stderr_and_the_note_names_the_file() {
         std::fs::read_to_string(&path).expect("the kept stderr"),
         stderr
     );
+}
+
+#[test]
+fn the_note_names_what_was_in_flight_and_only_those_run_one_at_a_time() {
+    let mut launcher = Scripted::new(
+        &["a::one", "a::two", "a::three", "a::four"],
+        vec![
+            Script {
+                stdout: "running 4 tests\n[e2e] running a::one\n[e2e] running a::two\n[e2e] running a::three\ntest a::one ... ok\n",
+                stderr: String::new(),
+                layer: None,
+                kind: ExitKind::Code(1),
+            },
+            Script {
+                stdout: "running 2 tests\ntest a::two ... ok\ntest a::three ... ok\n\ntest result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
+                stderr: String::new(),
+                layer: None,
+                kind: ExitKind::Code(0),
+            },
+            Script {
+                stdout: "running 1 test\ntest a::four ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
+                stderr: String::new(),
+                layer: None,
+                kind: ExitKind::Code(0),
+            },
+        ],
+    );
+    let mut log = Log::default();
+    let run = run_binary(&mut launcher, None, 4, false, &mut log).unwrap();
+    assert_eq!(run.processes, 3);
+    assert!(!run.failed);
+    assert!(
+        log.notes[0].contains("in flight when it ended: a::two, a::three"),
+        "{:?}",
+        log.notes
+    );
+    assert_eq!(
+        launcher.launched[1],
+        (Some(vec!["a::two".to_owned(), "a::three".to_owned()]), 1),
+        "only the tests that were running go one at a time"
+    );
+    assert_eq!(
+        launcher.launched[2],
+        (Some(vec!["a::four".to_owned()]), 4),
+        "the tests the narrowed round set aside run at the caller's width"
+    );
+}
+
+#[test]
+fn a_death_stderr_is_silent_about_is_quoted_from_the_layers_own_log() {
+    let mut launcher = Scripted::new(
+        &["a::one", "a::two"],
+        vec![
+            Script {
+                stdout: "running 2 tests\n[e2e] running a::one\n[e2e] running a::two\n",
+                stderr: String::new(),
+                layer: Some(
+                    "ordinary line\n[mtld3d::unix] FATAL: SIGSEGV fault=0x0\n[mtld3d::unix] thread=mtld3d-encoder\n",
+                ),
+                kind: ExitKind::Code(1),
+            },
+            Script {
+                stdout: "running 2 tests\ntest a::one ... ok\ntest a::two ... ok\n\ntest result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
+                stderr: String::new(),
+                layer: None,
+                kind: ExitKind::Code(0),
+            },
+        ],
+    );
+    let mut log = Log::default();
+    run_binary(&mut launcher, None, 2, false, &mut log).unwrap();
+    let note = &log.notes[0];
+    assert!(note.contains("exit code 1"), "{note}");
+    assert!(note.contains("[mtld3d::unix] FATAL: SIGSEGV"), "{note}");
+    assert!(note.contains("thread=mtld3d-encoder"), "{note}");
+    assert!(
+        note.contains(
+            &launcher
+                .log_dir
+                .join(format!("scripted-{PID}.log"))
+                .display()
+                .to_string()
+        ),
+        "{note}"
+    );
+    assert!(!note.contains("ordinary line"), "{note}");
 }

--- a/unix/e2e/src/attribute/tests.rs
+++ b/unix/e2e/src/attribute/tests.rs
@@ -13,7 +13,8 @@
 //! Two more pin what a death nothing on stderr accounts for still says: the
 //! note names the tests that had named themselves and not finished, and
 //! only those run again one at a time, and the layer's own log of the
-//! process is quoted with them.
+//! process is quoted with them and kept under a name the layer's retention
+//! does not match.
 
 use std::{
     collections::VecDeque,
@@ -24,13 +25,16 @@ use std::{
 
 use super::{Launcher, ProcessEnd, Report, TestResult, Verdict, run_binary};
 use crate::{
-    binary::{keep_stderr, layer_tail},
+    binary::{LayerLog, keep_layer_log, keep_stderr},
     libtest::Parser,
     run::ExitKind,
 };
 
 /// The pid every scripted process ends under, so a test knows the file's name.
 const PID: u32 = 4242;
+
+/// The stem the layer names a scripted process's log after: the binary's name and a hash.
+const STEM: &str = "scripted-0a1b2c3d";
 
 /// One scripted process: its stdout, stderr, the layer's log of it, and how it ends.
 struct Script {
@@ -102,12 +106,13 @@ impl Launcher for Scripted {
         keep_stderr(&self.log_dir, "scripted", pid, stderr)
     }
 
-    fn layer_log(&self, pid: u32) -> Result<(PathBuf, String), String> {
-        let path = self.log_dir.join(format!("scripted-{pid}.log"));
-        let log = self
-            .layer
-            .ok_or_else(|| format!("{}: no such file", path.display()))?;
-        Ok((path, layer_tail(log)))
+    fn keep_layer_log(&self, pid: u32) -> Result<LayerLog, String> {
+        // The layer's file exists only when the script says it logged; the
+        // real move then runs on it, so the note names the file it made.
+        if let Some(log) = self.layer {
+            std::fs::write(self.log_dir.join(format!("{STEM}-{pid}.log")), log).expect("layer log");
+        }
+        keep_layer_log(&self.log_dir, STEM, "scripted", pid)
     }
 }
 
@@ -520,15 +525,19 @@ fn a_death_stderr_is_silent_about_is_quoted_from_the_layers_own_log() {
     assert!(note.contains("exit code 1"), "{note}");
     assert!(note.contains("[mtld3d::unix] FATAL: SIGSEGV"), "{note}");
     assert!(note.contains("thread=mtld3d-encoder"), "{note}");
+    assert!(!note.contains("ordinary line"), "{note}");
+    let kept = launcher.log_dir.join(format!("scripted-{PID}.layer-log"));
     assert!(
-        note.contains(
-            &launcher
-                .log_dir
-                .join(format!("scripted-{PID}.log"))
-                .display()
-                .to_string()
-        ),
+        note.contains(&format!("kept as {}", kept.display())),
         "{note}"
     );
-    assert!(!note.contains("ordinary line"), "{note}");
+    assert_eq!(
+        std::fs::read_to_string(&kept).expect("the kept layer log"),
+        "ordinary line\n[mtld3d::unix] FATAL: SIGSEGV fault=0x0\n[mtld3d::unix] thread=mtld3d-encoder\n",
+        "the whole log is kept, not the quoted part"
+    );
+    assert!(
+        !launcher.log_dir.join(format!("{STEM}-{PID}.log")).exists(),
+        "the layer's own file is gone, so its retention has nothing to remove"
+    );
 }

--- a/unix/e2e/src/binary.rs
+++ b/unix/e2e/src/binary.rs
@@ -2,7 +2,10 @@
 //!
 //! Two accounts survive a process the runner lost: the stderr it kept in a
 //! file of its own, and the log the layer wrote, which is where the layer's
-//! crash report goes and the only place it goes.
+//! crash report goes and the only place it goes. The layer keeps only the
+//! newest ten of its logs and removes the rest as later processes create
+//! theirs, so the runner moves the log of a lost process to a name that
+//! retention never matches, beside the stderr, and caps those itself.
 
 use std::{
     fs,
@@ -16,8 +19,18 @@ use crate::{
     run::{self, ExitKind},
 };
 
-/// How many kept stderr files a directory holds, as many as the layer keeps logs.
+/// How many kept files of each kind a directory holds, as many as the layer keeps logs.
 const KEEP: usize = 10;
+
+/// The extension of a kept stderr: `<binary>-<pid>.stderr`.
+const STDERR_EXT: &str = "stderr";
+
+/// The extension of a kept layer log: `<binary>-<pid>.layer-log`.
+///
+/// Anything but `log`: that is the extension the layer's own retention
+/// matches, and a file under it is gone once ten newer processes have
+/// logged, which one run of the suite nearly does.
+const LAYER_LOG_EXT: &str = "layer-log";
 
 /// How many of the process's own stderr lines a report shows.
 const TAIL_LINES: usize = 15;
@@ -153,7 +166,7 @@ impl Launcher for WineLauncher {
         keep_stderr(&self.log_dir, &binary_name(&self.exe), pid, stderr)
     }
 
-    fn layer_log(&self, pid: u32) -> Result<(PathBuf, String), String> {
+    fn keep_layer_log(&self, pid: u32) -> Result<LayerLog, String> {
         // The layer names the file after the executable's whole stem, cargo
         // hash and all, and after the host pid, which is the one the runner
         // spawned the process under.
@@ -162,12 +175,18 @@ impl Launcher for WineLauncher {
             .file_stem()
             .and_then(|stem| stem.to_str())
             .unwrap_or_default();
-        let path = self
-            .log_dir
-            .join(mtld3d_shared::log_paths::log_file_name(stem, pid));
-        let text = fs::read_to_string(&path).map_err(|e| format!("{}: {e}", path.display()))?;
-        Ok((path, layer_tail(&text)))
+        keep_layer_log(&self.log_dir, stem, &binary_name(&self.exe), pid)
     }
+}
+
+/// The layer's log of a dead process: where it is now, and its account of the end.
+pub struct LayerLog {
+    /// The kept file, or the layer's own when the move failed.
+    pub path: PathBuf,
+    /// The lines that account for the end, see [`layer_tail`].
+    pub tail: String,
+    /// Why the file is still the layer's own, when it is.
+    pub not_kept: Option<String>,
 }
 
 /// Write one dead process's whole stderr into `dir`, and name the file.
@@ -183,10 +202,41 @@ impl Launcher for WineLauncher {
 /// Returns the reason when the directory or the file cannot be written.
 pub fn keep_stderr(dir: &Path, binary: &str, pid: u32, stderr: &str) -> Result<PathBuf, String> {
     fs::create_dir_all(dir).map_err(|e| format!("{}: {e}", dir.display()))?;
-    prune(dir, KEEP - 1);
-    let path = dir.join(format!("{binary}-{pid}.stderr"));
+    prune(dir, STDERR_EXT, KEEP - 1);
+    let path = dir.join(format!("{binary}-{pid}.{STDERR_EXT}"));
     fs::write(&path, stderr).map_err(|e| format!("{}: {e}", path.display()))?;
     Ok(path)
+}
+
+/// Move the layer's log of the dead process `pid` out of the layer's retention.
+///
+/// The layer's file is `<stem>-<pid>.log` in `dir`; it becomes
+/// `<binary>-<pid>.layer-log` beside the kept stderr, the newest ten of
+/// which stay. The account of the end is read before the move, so a move
+/// that fails still quotes it and names the file where it is.
+///
+/// # Errors
+///
+/// Returns the reason when the layer's file cannot be read, which for a
+/// process that logged nothing is that it was never created.
+pub fn keep_layer_log(dir: &Path, stem: &str, binary: &str, pid: u32) -> Result<LayerLog, String> {
+    let from = dir.join(mtld3d_shared::log_paths::log_file_name(stem, pid));
+    let text = fs::read_to_string(&from).map_err(|e| format!("{}: {e}", from.display()))?;
+    let tail = layer_tail(&text);
+    prune(dir, LAYER_LOG_EXT, KEEP - 1);
+    let to = dir.join(format!("{binary}-{pid}.{LAYER_LOG_EXT}"));
+    Ok(match fs::rename(&from, &to) {
+        Ok(()) => LayerLog {
+            path: to,
+            tail,
+            not_kept: None,
+        },
+        Err(e) => LayerLog {
+            path: from,
+            tail,
+            not_kept: Some(format!("could not be moved to {}: {e}", to.display())),
+        },
+    })
 }
 
 /// The last lines of a process's stderr that the process itself printed.
@@ -238,20 +288,20 @@ pub fn layer_tail(log: &str) -> String {
     lines[start..end].join("\n")
 }
 
-/// Remove the oldest kept stderr files in `dir` beyond the newest `keep`.
+/// Remove the oldest kept files with extension `ext` in `dir` beyond the newest `keep`.
 ///
 /// Age is the modification time; an entry whose metadata cannot be read is
 /// left alone, and so is one whose removal fails, which the next process to
 /// die tries again. Nothing here reports, because a directory that cannot
 /// be tidied is not a reason to say less about the process that died.
-fn prune(dir: &Path, keep: usize) {
+fn prune(dir: &Path, ext: &str, keep: usize) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
     let mut aged: Vec<(SystemTime, PathBuf)> = entries
         .filter_map(Result::ok)
         .map(|entry| entry.path())
-        .filter(|path| path.extension().is_some_and(|ext| ext == "stderr"))
+        .filter(|path| path.extension().is_some_and(|found| found == ext))
         .filter_map(|path| Some((fs::metadata(&path).ok()?.modified().ok()?, path)))
         .collect();
     if aged.len() <= keep {

--- a/unix/e2e/src/binary.rs
+++ b/unix/e2e/src/binary.rs
@@ -1,4 +1,8 @@
-//! A test binary on disk: its name, the launcher that runs it under Wine, and its stderr.
+//! A test binary on disk: its name, the launcher that runs it, and the accounts of its processes.
+//!
+//! Two accounts survive a process the runner lost: the stderr it kept in a
+//! file of its own, and the log the layer wrote, which is where the layer's
+//! crash report goes and the only place it goes.
 
 use std::{
     fs,
@@ -17,6 +21,13 @@ const KEEP: usize = 10;
 
 /// How many of the process's own stderr lines a report shows.
 const TAIL_LINES: usize = 15;
+
+/// How many layer-log lines a report shows once a fatal line anchors them.
+///
+/// The crash report is a banner, the faulting thread, the program counter,
+/// the registers and a symbolised stack: enough lines that the plain tail
+/// would cut the banner off, and few enough to quote whole.
+const FATAL_LINES: usize = 40;
 
 /// The classes Wine's debug channels print, the first field of every line they emit.
 const WINE_CLASSES: [&str; 4] = ["err", "warn", "fixme", "trace"];
@@ -141,6 +152,22 @@ impl Launcher for WineLauncher {
     fn keep_stderr(&self, pid: u32, stderr: &str) -> Result<PathBuf, String> {
         keep_stderr(&self.log_dir, &binary_name(&self.exe), pid, stderr)
     }
+
+    fn layer_log(&self, pid: u32) -> Result<(PathBuf, String), String> {
+        // The layer names the file after the executable's whole stem, cargo
+        // hash and all, and after the host pid, which is the one the runner
+        // spawned the process under.
+        let stem = self
+            .exe
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or_default();
+        let path = self
+            .log_dir
+            .join(mtld3d_shared::log_paths::log_file_name(stem, pid));
+        let text = fs::read_to_string(&path).map_err(|e| format!("{}: {e}", path.display()))?;
+        Ok((path, layer_tail(&text)))
+    }
 }
 
 /// Write one dead process's whole stderr into `dir`, and name the file.
@@ -190,6 +217,25 @@ fn is_wine_chatter(line: &str) -> bool {
         return false;
     };
     WINE_CLASSES.contains(&class) && (class == "fixme" || channel == "dbghelp")
+}
+
+/// The part of a layer log that accounts for the process's end.
+///
+/// From the fatal banner when the layer wrote one, since everything after it
+/// is the crash report and everything before it is ordinary work; the last
+/// lines otherwise, which are what the layer was doing when it stopped.
+#[must_use]
+pub fn layer_tail(log: &str) -> String {
+    let lines: Vec<&str> = log.lines().collect();
+    let fatal = lines
+        .iter()
+        .position(|line| line.contains(mtld3d_shared::fatal::BANNER));
+    let (start, len) = fatal.map_or_else(
+        || (lines.len().saturating_sub(TAIL_LINES), TAIL_LINES),
+        |at| (at, FATAL_LINES),
+    );
+    let end = start.saturating_add(len).min(lines.len());
+    lines[start..end].join("\n")
 }
 
 /// Remove the oldest kept stderr files in `dir` beyond the newest `keep`.

--- a/unix/e2e/src/binary/tests.rs
+++ b/unix/e2e/src/binary/tests.rs
@@ -1,8 +1,12 @@
-//! Unit tests for the binary naming and for what a dead process's stderr leaves behind.
+//! Unit tests for the binary naming and for the accounts a dead process leaves behind.
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
-use super::{KEEP, binary_name, keep_stderr, stderr_tail};
+use super::{FATAL_LINES, KEEP, WineLauncher, binary_name, keep_stderr, layer_tail, stderr_tail};
+use crate::attribute::Launcher as _;
 
 /// A fresh directory under the temp dir, named after the test using it.
 fn dir(tag: &str) -> PathBuf {
@@ -94,4 +98,66 @@ fn the_kept_files_are_capped_and_never_touch_the_layers_logs() {
     };
     assert_eq!(kept("stderr"), KEEP);
     assert_eq!(kept("log"), 1);
+}
+
+#[test]
+fn a_layer_log_is_read_from_its_fatal_line_on() {
+    let work: String = (0..30)
+        .map(|i| format!("[2026-01-01T00:00:00Z INFO  mtld3d::unix] work {i}\n"))
+        .collect::<Vec<_>>()
+        .concat();
+    let log = format!(
+        "{work}[mtld3d::unix] FATAL: SIGSEGV fault=0x0\n[mtld3d::unix] thread=mtld3d-encoder\n"
+    );
+    let tail = layer_tail(&log);
+    assert!(tail.starts_with("[mtld3d::unix] FATAL: SIGSEGV"), "{tail}");
+    assert!(tail.ends_with("thread=mtld3d-encoder"), "{tail}");
+    assert!(!tail.contains("work 29"), "{tail}");
+}
+
+#[test]
+fn a_layer_log_without_a_fatal_line_is_tailed_like_stderr() {
+    let log = (0..20)
+        .map(|i| format!("line {i}\n"))
+        .collect::<Vec<_>>()
+        .concat();
+    assert_eq!(layer_tail(&log), stderr_tail(&log));
+    assert!(layer_tail(&log).starts_with("line 5\n"));
+}
+
+#[test]
+fn a_fatal_line_early_in_a_long_log_is_quoted_to_a_bound() {
+    let log = format!(
+        "[mtld3d::unix] FATAL: SIGABRT\n{}",
+        (0..200)
+            .map(|i| format!("frame {i}\n"))
+            .collect::<Vec<_>>()
+            .concat()
+    );
+    assert_eq!(layer_tail(&log).lines().count(), FATAL_LINES);
+}
+
+#[test]
+fn the_layers_log_of_a_process_is_found_by_the_stem_and_the_pid() {
+    let dir = dir("layer");
+    let exe = Path::new("/t/deps/e2e-1030f4ab05278ecb.exe");
+    let launcher = WineLauncher::new(
+        Path::new("/usr/bin/true"),
+        exe,
+        Some(&dir),
+        Duration::from_secs(1),
+        Box::new(|_| {}),
+    );
+    assert!(
+        launcher.layer_log(4242).is_err(),
+        "a process that logged nothing has no file"
+    );
+    std::fs::write(
+        dir.join("e2e-1030f4ab05278ecb-4242.log"),
+        "[mtld3d::unix] FATAL: SIGSEGV fault=0x8\n",
+    )
+    .expect("layer log");
+    let (path, tail) = launcher.layer_log(4242).expect("the layer log");
+    assert_eq!(path, dir.join("e2e-1030f4ab05278ecb-4242.log"));
+    assert_eq!(tail, "[mtld3d::unix] FATAL: SIGSEGV fault=0x8");
 }

--- a/unix/e2e/src/binary/tests.rs
+++ b/unix/e2e/src/binary/tests.rs
@@ -5,7 +5,10 @@ use std::{
     time::Duration,
 };
 
-use super::{FATAL_LINES, KEEP, WineLauncher, binary_name, keep_stderr, layer_tail, stderr_tail};
+use super::{
+    FATAL_LINES, KEEP, LAYER_LOG_EXT, WineLauncher, binary_name, keep_layer_log, keep_stderr,
+    layer_tail, stderr_tail,
+};
 use crate::attribute::Launcher as _;
 
 /// A fresh directory under the temp dir, named after the test using it.
@@ -83,11 +86,13 @@ fn the_whole_stderr_lands_in_a_file_the_report_can_name() {
 }
 
 #[test]
-fn the_kept_files_are_capped_and_never_touch_the_layers_logs() {
+fn the_kept_files_are_capped_per_kind_and_never_touch_the_layers_logs() {
     let dir = dir("capped");
     std::fs::write(dir.join("e2e-1.log"), "the layer's own").expect("log");
     for pid in 0..u32::try_from(KEEP).expect("small") + 5 {
         keep_stderr(&dir, "e2e", pid, "stderr").expect("kept");
+        std::fs::write(dir.join(format!("e2e-abcd-{pid}.log")), "dead").expect("layer log");
+        keep_layer_log(&dir, "e2e-abcd", "e2e", pid).expect("kept");
     }
     let kept = |ext: &str| {
         std::fs::read_dir(&dir)
@@ -97,7 +102,8 @@ fn the_kept_files_are_capped_and_never_touch_the_layers_logs() {
             .count()
     };
     assert_eq!(kept("stderr"), KEEP);
-    assert_eq!(kept("log"), 1);
+    assert_eq!(kept(LAYER_LOG_EXT), KEEP);
+    assert_eq!(kept("log"), 1, "a live process's log is not the runner's");
 }
 
 #[test]
@@ -138,7 +144,7 @@ fn a_fatal_line_early_in_a_long_log_is_quoted_to_a_bound() {
 }
 
 #[test]
-fn the_layers_log_of_a_process_is_found_by_the_stem_and_the_pid() {
+fn the_layers_log_of_a_dead_process_is_moved_out_of_the_layers_retention() {
     let dir = dir("layer");
     let exe = Path::new("/t/deps/e2e-1030f4ab05278ecb.exe");
     let launcher = WineLauncher::new(
@@ -149,15 +155,36 @@ fn the_layers_log_of_a_process_is_found_by_the_stem_and_the_pid() {
         Box::new(|_| {}),
     );
     assert!(
-        launcher.layer_log(4242).is_err(),
+        launcher.keep_layer_log(4242).is_err(),
         "a process that logged nothing has no file"
     );
-    std::fs::write(
-        dir.join("e2e-1030f4ab05278ecb-4242.log"),
-        "[mtld3d::unix] FATAL: SIGSEGV fault=0x8\n",
-    )
-    .expect("layer log");
-    let (path, tail) = launcher.layer_log(4242).expect("the layer log");
-    assert_eq!(path, dir.join("e2e-1030f4ab05278ecb-4242.log"));
-    assert_eq!(tail, "[mtld3d::unix] FATAL: SIGSEGV fault=0x8");
+    let log = "ordinary line\n[mtld3d::unix] FATAL: SIGSEGV fault=0x8\n";
+    let own = dir.join("e2e-1030f4ab05278ecb-4242.log");
+    std::fs::write(&own, log).expect("layer log");
+    let kept = launcher.keep_layer_log(4242).expect("the layer log");
+    assert_eq!(kept.path, dir.join("e2e-4242.layer-log"));
+    assert_eq!(kept.tail, "[mtld3d::unix] FATAL: SIGSEGV fault=0x8");
+    assert!(kept.not_kept.is_none());
+    assert!(
+        kept.path.extension().is_none_or(|ext| ext != "log"),
+        "the layer prunes by the `log` extension"
+    );
+    assert!(!own.exists(), "moved, not copied");
+    assert_eq!(std::fs::read_to_string(&kept.path).expect("read"), log);
+}
+
+#[test]
+fn a_layer_log_that_cannot_be_moved_is_still_quoted_where_it_is() {
+    let dir = dir("unmovable");
+    let own = dir.join("e2e-abcd-7.log");
+    std::fs::write(&own, "[mtld3d::unix] FATAL: SIGBUS\n").expect("layer log");
+    // A directory in the way of the kept name makes the move fail.
+    std::fs::create_dir(dir.join("e2e-7.layer-log")).expect("blocker");
+    let kept = keep_layer_log(&dir, "e2e-abcd", "e2e", 7).expect("read");
+    assert_eq!(kept.path, own);
+    assert_eq!(kept.tail, "[mtld3d::unix] FATAL: SIGBUS");
+    assert!(
+        kept.not_kept
+            .is_some_and(|why| why.contains("e2e-7.layer-log"))
+    );
 }

--- a/unix/e2e/src/cli.rs
+++ b/unix/e2e/src/cli.rs
@@ -15,7 +15,7 @@ pub struct Config {
     pub fail_fast: bool,
     /// `--filter`: substrings a test id has to contain one of; empty = every test.
     pub filter: Vec<String>,
-    /// `--log-dir`: where a dead process's stderr is kept; `None` = beside the test binary.
+    /// `--log-dir`: where the files of a dead process go; `None` = beside the test binary.
     pub log_dir: Option<PathBuf>,
     /// The test binaries, after `--`.
     pub exes: Vec<PathBuf>,

--- a/unix/shared/src/fatal.rs
+++ b/unix/shared/src/fatal.rs
@@ -1,0 +1,12 @@
+//! The banner the unix side writes when a fatal signal ends the process.
+//!
+//! It goes to the process's log file and nowhere else, because the log file
+//! is where every line of both sides goes and a signal handler cannot pick a
+//! second destination. A parent that reads only the process's pipes
+//! therefore sees a bare exit status for a death the layer reported in full,
+//! so anything that has to recognise such a death (the e2e runner, reading
+//! the log of a process it lost) looks for this prefix, and the two sides
+//! name it once.
+
+/// The first thing the crash handler writes, followed by the signal's name.
+pub const BANNER: &str = "[mtld3d::unix] FATAL: ";

--- a/unix/shared/src/lib.rs
+++ b/unix/shared/src/lib.rs
@@ -3,6 +3,7 @@ use strum::{EnumCount, VariantArray};
 pub mod blit_geometry;
 mod commands;
 pub mod crumb;
+pub mod fatal;
 pub mod ffi_boundary;
 pub mod ftol;
 pub mod identity;

--- a/unix/unix/src/crash.rs
+++ b/unix/unix/src/crash.rs
@@ -49,7 +49,7 @@ use core::{
 };
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicUsize, Ordering};
 
-use mtld3d_shared::crumb;
+use mtld3d_shared::{crumb, fatal};
 
 /// Re-entrancy guard: reading the faulting stack/registers can itself fault on a corrupted context.
 ///
@@ -223,7 +223,7 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
     // takes locks. Stack-buffered hex formatting via `write_hex`.
     let mut buf = [0u8; 192];
     let mut pos = 0;
-    push(&mut buf, &mut pos, b"[mtld3d::unix] FATAL: ");
+    push(&mut buf, &mut pos, fatal::BANNER.as_bytes());
     push(&mut buf, &mut pos, signal_name(signo));
 
     if !info.is_null() && (signo == libc::SIGSEGV || signo == libc::SIGBUS) {

--- a/windows/tests/COVERAGE.md
+++ b/windows/tests/COVERAGE.md
@@ -10,7 +10,7 @@ of that one Wine process, each test with its own device and window;
 binaries because each needs a process of its own. The runner is `unix/e2e`, and the
 host-native `mtld3d-core`/`mtld3d-shared` unit tests run too.
 
-Two things follow from sharing a process. A test that needs a non-default
+Three things follow from sharing a process. A test that needs a non-default
 option asks for it on its own harness (`Harness::with_config`,
 `Harness::factory_only_with_config`, or `HarnessConfig::config_entries`):
 configuration resolves at each `Direct3DCreate9` and belongs to the
@@ -34,6 +34,15 @@ rasterized spaces instead of staying in one of them, `cursor.software` in
 the counting cases pin it false so they read the count rather than the
 permissive stub the fence reading of a FLUSH poll answers with, and one case
 pins it true for the stub itself.
+
+And a process that dies takes every test in flight with it, which libtest
+does not name: past one test thread it prints a test's name only once the
+test has finished. So a test names itself on stdout as it reaches the layer
+([`in_flight.rs`](src/in_flight.rs)), and the runner reports the names it has
+no outcome line for as the set that was running and runs only those again one
+at a time. A test that returns before it builds an interface names nothing,
+which is the right coverage: it never reached the code that could end the
+process.
 
 The whole suite also runs under every `intel.*` key at once with
 `make test INTEL=1`, the way it would on an Intel/AMD Mac, for a machine

--- a/windows/tests/src/harness.rs
+++ b/windows/tests/src/harness.rs
@@ -212,9 +212,14 @@ pub struct Harness {
 /// appended to `MTLD3D_CONFIG` for the duration of the call and the variable
 /// put back afterwards, for a harness that carries entries of its own.
 ///
+/// The thread names the test it runs first: this is the one call every test
+/// that reaches the layer makes, so the account of what was in flight when a
+/// process died is written before anything can end it.
+///
 /// # Panics
 /// Panics if the factory cannot be created.
 fn create_factory(entries: &str) -> *mut c_void {
+    crate::in_flight::announce();
     let d3d9 = if entries.is_empty() {
         let _shared = ENVIRONMENT.read().unwrap_or_else(PoisonError::into_inner);
         // SAFETY: Win32-style factory entrypoint with no preconditions.

--- a/windows/tests/src/in_flight.rs
+++ b/windows/tests/src/in_flight.rs
@@ -7,10 +7,10 @@
 //! reaches `d3d9.dll` names itself here instead, and the runner reads the
 //! names it has no outcome line for as the set that was in flight.
 //!
-//! The name is the thread's, because libtest names every test thread after
-//! its test. The main thread is skipped: that is where libtest runs the
-//! tests when there is one thread, and there its own start line already
-//! names them. Once per thread, since a test may build more than one
+//! The name is the thread's, because libtest runs every test on a thread
+//! named after it, at any thread count. The main thread is skipped: libtest
+//! runs a test there only when it cannot spawn a thread, and then the name
+//! would be nobody's. Once per thread, since a test may build more than one
 //! interface and libtest gives each test a thread of its own.
 
 use std::{cell::Cell, thread};

--- a/windows/tests/src/in_flight.rs
+++ b/windows/tests/src/in_flight.rs
@@ -1,0 +1,36 @@
+//! The test a thread is running, named on stdout for the e2e runner.
+//!
+//! libtest writes a test's name before it runs only when there is one test
+//! thread; on more it writes nothing until the test finishes, so a process
+//! that dies with several tests in flight leaves no account of which they
+//! were and the runner has to run every test left to find out. A test that
+//! reaches `d3d9.dll` names itself here instead, and the runner reads the
+//! names it has no outcome line for as the set that was in flight.
+//!
+//! The name is the thread's, because libtest names every test thread after
+//! its test. The main thread is skipped: that is where libtest runs the
+//! tests when there is one thread, and there its own start line already
+//! names them. Once per thread, since a test may build more than one
+//! interface and libtest gives each test a thread of its own.
+
+use std::{cell::Cell, thread};
+
+/// The stdout marker; what follows it is the test's libtest path.
+const RUNNING: &str = "[e2e] running ";
+
+thread_local! {
+    /// Whether this thread has already named its test.
+    static NAMED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Name the test this thread runs on stdout, once per thread.
+pub fn announce() {
+    if NAMED.with(|named| named.replace(true)) {
+        return;
+    }
+    let thread = thread::current();
+    let Some(name) = thread.name().filter(|name| *name != "main") else {
+        return;
+    };
+    println!("{RUNNING}{name}");
+}

--- a/windows/tests/src/lib.rs
+++ b/windows/tests/src/lib.rs
@@ -9,6 +9,7 @@
 mod check;
 mod ffi;
 mod harness;
+mod in_flight;
 mod pixel;
 mod resource;
 mod shared;


### PR DESCRIPTION
## Symptoms

At `JOBS=4` a whole-suite run occasionally loses a test process part way through. It exits 1, nothing names a test, and the runner has to run everything left again:

```
NOTE e2e: the process ended with exit code 1; 301 of its tests unaccounted for; ...
NOTE e2e: nothing names the test it ended in; running those again one at a time
NOTE e2e: running the 301 tests left in a fresh process
```

The collected stderr carries no panic, no fault and no backtrace, only startup noise, and the re-run passes all 301, so the suite reports green and the death is never charged to anything.

## Root cause

Two things: why the death said nothing, which this fixes, and what the death is, which this locates but does not fix.

The status narrows the source. The only code in the tree that ends a process with status 1 is the unix crash handler's `libc::_exit(1)` (two sites in `unix/unix/src/crash.rs`). libtest exits 0 or 101; the harness panic hook terminates with 101 at the first failed assertion; `d3d9.dll`'s detach terminates with the status the exit hook recorded, 0 unless the process asked for another and 42 for the one test that asks. Wine can produce a 1 too: `get_unix_exit_code` folds every non-zero status whose low byte is zero into 1, and its own fatal paths (`server_protocol_error`, a nested exception on the signal stack, a stack overflow on the last page) exit 1, but every one of those prints to stderr first, and the stderr in the report is silent. A wineserver kill (`wineserver -k`, a `TerminateProcess` from another process) reaches a client as `SIGQUIT` and ends it with status 0. What remains is the crash handler, whose banner, faulting thread, program counter, registers and stack go to the layer's per-process log and nowhere else, since a signal handler cannot pick a second destination. That log did not survive: the layer keeps its ten newest logs and removes the rest as later processes create theirs, one run of the suite is up to ten processes over both legs, and the log of the process in the report was gone by the time it was looked for, while its stderr file, kept under an extension the layer never prunes, was still there. So the one account of the death was written and then deleted.

With the log kept, the death reproduced once in 12 x86_64 legs run alongside an i686 leg (it did not in 88 legs run alone, 58 x86_64 and 30 i686, on this tree and on bbe565d), and at the same place as the report: `render_scale::clear_rects_fill_only_the_rects_given` was in flight, the test the report's process died after. The kept log says what it is:

```
[mtld3d::unix] fault outside mtld3d.so: signo=11 tid=0x9ec27e pc=0x7ff80a5be573 image=AppKit+0x9a7573 sym=__reusableDependencyContextForKey_block_invoke+0x8e thread=
[mtld3d::unix] FATAL: SIGSEGV fault=0x2f0 si_code=0x1
[mtld3d::unix] fault_pc=0x20875151d   ntdll.so save_context + 573
 6  CoreFoundation  CFSetApplyFunction
10  AppKit          -[NSView _setSuperview:] + 1855
11  AppKit          -[NSView removeFromSuperview] + 286
13  AppKit          -[NSView _finalize] + 927
17  AppKit          -[NSThemeFrame dealloc] + 1042
21  libobjc         objc_autoreleasePoolPop + 236
22  winemac.so      PerformRequest + 283
35  AppKit          -[NSApplication run] + 522
36  winemac.so      run_cocoa_app + 409
43  ntdll.so        apple_main_thread + 135
```

The first fault is AppKit's, on the Cocoa main thread (no name, no Wine TEB), inside the dealloc of a window's frame view when winemac's request loop drains an autorelease pool: `-[NSView _setSuperview:]` walks a set of view-hierarchy dependency contexts and one of them is gone. No frame of `mtld3d.so` is on that stack, and the stack scan finds no return address into it. The crash handler forwards a fault outside its own image to Wine's `segv_handler`, which on a thread without a TEB faults itself in `save_context` (the null-plus-offset read at `0x2f0`), and that second fault is what the banner reports before `_exit(1)`. So the status is the handler's, the death is AppKit's, and the window whose frame view is being torn down belongs to a test that already finished: with four tests creating and destroying windows through winemac at once, that teardown reaches the Cocoa thread with state another window's work has invalidated. It reproduces only under load (a second suite on the machine), which fits the report's rate and its timing next to other runs, and it is the same family as the `JOBS=8` retarget failures in the report, where two Reset tests received each other's window messages. The fix for that is in winemac's or mtld3d's window handling and is not in this change.

The concurrent-leg runs lost processes with status 0 as well (7 of 28 legs), with no layer log or one that ends in ordinary work: that is the other leg's `configure-test-prefix` ending the shared prefix's session with `wineserver -k`, since two legs in one checkout share the prefix, a different mechanism that cannot cross checkouts under `ISOLATED=1`. `cp -c` gives the installed `mtld3d.so` a new inode on every install, so an install racing a running process is not a way to fault a mapped image either.

## Changes

`unix/e2e` moves the layer's log of a process that ended with tests unaccounted for to `<binary>-<pid>.layer-log` beside the `.stderr` it already keeps, the moment the process is gone and before any later process can create a log. The extension is not `log`, so the layer's retention never matches it; the runner caps those at ten like the stderr files. The note names the kept file and quotes the log from its fatal banner on when the layer wrote one, or its last lines when it did not; a move that fails still quotes it and says where the file is. `unix/shared/src/fatal.rs` holds the banner the crash handler writes, so the side that writes it and the side that looks for it name it once, and the runner takes the log's file name from `mtld3d_shared::log_paths` for the same reason, which is why `mtld3d-e2e` now depends on `mtld3d-shared`.

`windows/tests/src/in_flight.rs` names the test a thread is running on stdout, once per thread, from `create_factory`, the one call every test that reaches the layer makes. libtest runs every test on a thread named after it, so the name is the thread's; past one test thread libtest itself names a test only when it finishes, so without this a process that dies leaves no account of what was running. The runner reads the names it has no outcome line for as the set that was in flight: the note lists them, only they run again one at a time, and the rest wait for a process of their own at the caller's width instead of the whole remainder dropping to one thread. 463 of the e2e binary's 472 tests announce; the nine that do not return before they build an interface.

`.github/workflows/ci.yml` uploads `*.layer-log` with the logs and stderr files of every end-to-end leg. `CONTRIBUTING.md`, the Makefile's `LOG_DIR` note and `windows/tests/COVERAGE.md` describe the kept file and the marker.

## Alternatives

Write the fatal banner to stderr as well as to the log file: rejected, the layer logs to files by decision and a signal handler with a second descriptor is one more thing to get wrong; the file is there to be read.

Copy the layer's log instead of moving it: rejected, the copy leaves the original for the layer to prune and doubles the bytes for nothing; a move is one atomic call in the same directory.

Raise the layer's retention: rejected, it is a game-facing default and the suite would still exceed any count in a handful of runs.

Announce from `d3d9.dll` so a caller that is not the shared harness is covered too: rejected, a shipping DLL does not print to a test runner's stdout.

Charge the death to the whole in-flight set: rejected, one of those tests ended the process and the others were bystanders.

## Verification

`make fmt` and `make check` clean, audit clean over 302 files.

`make ISOLATED=1 test`: 950 PASS (475 per PE arch), 0 FAIL, 0 LEAK, 0 SIGABRT, 0 TIMEOUT, 4 processes per arch, host unit tests 1091 + 273 passed, both legs installed into this checkout's `.wine-isolated`.

`binary::tests::the_layers_log_of_a_dead_process_is_moved_out_of_the_layers_retention` pins the preservation: the layer's `<stem>-<pid>.log` becomes `<binary>-<pid>.layer-log`, whole, under an extension that is not `log`, and a process that logged nothing reports so. On the parent the runner reads that file where it lies and its test asserts the layer's own path, which the layer's retention removes. `binary::tests::the_kept_files_are_capped_per_kind_and_never_touch_the_layers_logs` pins the cap on both kinds, `binary::tests::a_layer_log_that_cannot_be_moved_is_still_quoted_where_it_is` the fallback.

`attribute::tests::a_death_stderr_is_silent_about_is_quoted_from_the_layers_own_log` pins the note: stderr is empty, the layer's log carries a fatal banner, and the note quotes it from the banner on, names the kept file, and the kept file holds the whole log while the layer's own is gone.

`attribute::tests::the_note_names_what_was_in_flight_and_only_those_run_one_at_a_time` pins the marker: three tests announce, one finishes, the process exits 1, and the note names the two that were running while the next process runs exactly those two on one thread and the third at the caller's width. It fails on the tree before the marker, where the note carries no such line and the second process runs all three remaining tests.

Two legs at once in one checkout exercised the real path: the status-1 death above was reported by the new note, naming its four in-flight tests, its `.layer-log` and the banner, and the runner recovered in four processes instead of running 302 tests one at a time.

Refs #461
