### PR TITLE
Report a foreign fault on a thread Wine cannot serve

### DIFF
--- a/unix/unix/src/crash.rs
+++ b/unix/unix/src/crash.rs
@@ -30,14 +30,21 @@
 //! lies in a native image (a framework, libobjc, libsystem, Wine's own
 //! `.so`): `fault outside mtld3d.so:` with the signal number, the thread id
 //! and name, the PC as image plus offset and nearest symbol, then the return
-//! addresses into our own dylib found on the faulting stack. A fault there on
-//! a thread Wine does not own (ours, or a Metal completion thread) ends the
-//! process inside Wine's handler with nothing else said, and the game's log
-//! then has to name the image, the thread and our frames under it at least.
-//! Guest code and translated code resolve to no image and stay silent: those
-//! faults are Wine's ordinary work. The report is capped at a few per process
-//! and carries no signal name, since a fault Wine recovers
-//! must not read as a crash to anything that scans the log for one.
+//! addresses into our own dylib found on the faulting stack. Guest code and
+//! translated code resolve to no image and stay silent: those faults are
+//! Wine's ordinary work. The report is capped at a few per process and
+//! carries no signal name, since a fault Wine recovers must not read as a
+//! crash to anything that scans the log for one.
+//!
+//! Forwarding needs a thread Wine can serve. Wine's unix side keeps each
+//! thread's TEB in a pthread key and reads it as soon as a fault reaches
+//! `segv_handler`, so on a thread it did not create (the Cocoa main thread
+//! `winemac` runs its event loop on, or one of ours) the forward faults
+//! inside Wine, and the fault the report then names is that second one. The
+//! handler therefore asks Wine for the calling thread's TEB first, through
+//! the `NtCurrentTeb` its own code goes through, and a foreign fault on a
+//! thread without one is reported in full here and ends the process, so the
+//! report leads with the fault that caused it.
 //!
 //! `RUST_BACKTRACE=1` is also set here (if unset) so the default Rust
 //! panic hook prints message + backtrace before `abort()` flows through
@@ -85,6 +92,14 @@ static PREV: [PrevDisposition; 4] = [
     PrevDisposition::new(),
 ];
 
+/// Wine's `NtCurrentTeb`, resolved once so the handler can ask from a signal.
+///
+/// Zero when Wine's unix library is not in the process, which is every context
+/// but a Wine one, the unit tests among them. `dlsym` allocates and takes the
+/// loader's lock, so the lookup happens at install time and the handler only
+/// reads the atomic.
+static WINE_CURRENT_TEB: AtomicUsize = AtomicUsize::new(0);
+
 /// Index into [`PREV`] for a signal we handle, or `None` for anything else.
 const fn signal_slot(signo: c_int) -> Option<usize> {
     match signo {
@@ -111,6 +126,8 @@ pub fn install() {
         // concurrent reads/writes, which can't happen here.
         unsafe { std::env::set_var("RUST_BACKTRACE", "full") };
     }
+
+    resolve_wine_current_teb();
 
     // Diagnostic escape hatch: with `MTLD3D_NO_CRASH_HANDLER=1` we do NOT
     // intercept SIGSEGV/SIGBUS, so Wine's own SEH machinery translates the
@@ -146,6 +163,55 @@ fn install_signal_handler(signo: libc::c_int) {
         PREV[slot].action.store(old.sa_sigaction, Ordering::Relaxed);
         PREV[slot].flags.store(old.sa_flags, Ordering::Relaxed);
     }
+}
+
+/// Resolve Wine's `NtCurrentTeb` into [`WINE_CURRENT_TEB`].
+///
+/// `ntdll.so` publishes it into the process's global symbol space, and the
+/// handle `dlopen` returns for a null path is how to reach it without naming a
+/// path of Wine's. That handle is kept rather than closed: it stands for the
+/// process itself, and the address has to stay resolvable for as long as the
+/// handler can run.
+fn resolve_wine_current_teb() {
+    // SAFETY: `dlopen` with a null path loads nothing; it hands back a handle
+    // for the symbol space the process already has.
+    let handle = unsafe { libc::dlopen(ptr::null(), libc::RTLD_LAZY | libc::RTLD_LOCAL) };
+    if handle.is_null() {
+        return;
+    }
+    // SAFETY: `handle` is the process handle just opened and the name is a
+    // NUL-terminated C string; `dlsym` answers null when nothing exports it.
+    let entry = unsafe { libc::dlsym(handle, c"NtCurrentTeb".as_ptr()) };
+    WINE_CURRENT_TEB.store(entry as usize, Ordering::Relaxed);
+}
+
+/// The calling thread's Wine TEB, or 0 when the thread has none.
+///
+/// Wine's unix side stores it in a pthread key and reaches it through
+/// `NtCurrentTeb`, which reads that key and nothing else, so a signal handler
+/// can afford to ask. Zero on every thread Wine did not create, and in every
+/// process where the symbol did not resolve.
+fn wine_teb() -> u64 {
+    let entry = WINE_CURRENT_TEB.load(Ordering::Relaxed);
+    if entry == 0 {
+        return 0;
+    }
+    // SAFETY: `entry` is the address `dlsym` resolved for Wine's
+    // `NtCurrentTeb`, which takes no argument and returns the calling thread's
+    // TEB pointer.
+    let current_teb: extern "C" fn() -> *mut c_void = unsafe { mem::transmute::<usize, _>(entry) };
+    current_teb() as usize as u64
+}
+
+/// Whether Wine's own handler can serve a fault taken on the calling thread.
+///
+/// A forward lands in `segv_handler`, which saves the faulting context, and
+/// the debug registers it saves live in the TEB: a thread without one faults
+/// there instead of having its fault translated. True when Wine's unix library
+/// is absent, where the previous disposition is not Wine's and there is
+/// nothing to guard against.
+fn wine_serves_this_thread() -> bool {
+    WINE_CURRENT_TEB.load(Ordering::Relaxed) == 0 || wine_teb() != 0
 }
 
 /// True when the faulting instruction is in our own `.so`.
@@ -208,9 +274,28 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
     // SIGABRT is not shared this way: an abort is always terminal, and its PC
     // is inside libsystem rather than our code, so it stays ours to report.
     if signo != libc::SIGABRT && !fault_is_ours(ctx) {
-        report_foreign_fault(signo, ctx);
-        forward_to_previous(signo, info, ctx);
-        return;
+        /// Says why a foreign fault ends here rather than going back.
+        const NO_TEB: &[u8] =
+            b"[mtld3d::unix] faulting thread has no Wine TEB: reporting here, not forwarding\n";
+
+        // Wine's handler reads the TEB of the thread it is serving. On a
+        // thread that has none it faults doing so, and its fault, not this
+        // one, is what a report would name. Report this one in full instead
+        // and end the process below.
+        let terminal = !wine_serves_this_thread();
+        report_foreign_fault(signo, ctx, terminal);
+        if !terminal {
+            forward_to_previous(signo, info, ctx);
+            return;
+        }
+        // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
+        unsafe {
+            let _ = libc::write(
+                crate::log_file::raw_fd(),
+                NO_TEB.as_ptr().cast::<c_void>(),
+                NO_TEB.len(),
+            );
+        }
     }
 
     // Bail on the first re-entry (a faulting register/stack read below would
@@ -403,7 +488,11 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
 /// in pieces rather than one buffer, because an image path can be longer than
 /// the line buffer. Stops after [`FOREIGN_REPORT_LIMIT`] reports, since a game
 /// may probe with faults of its own and every one would cost the lookups.
-fn report_foreign_fault(signo: c_int, ctx: *mut c_void) {
+///
+/// `terminal` says the fault is not going back to anyone, so the cap does not
+/// apply to it and the stack pass is left to the fatal report that follows,
+/// which prints a superset of it.
+fn report_foreign_fault(signo: c_int, ctx: *mut c_void, terminal: bool) {
     /// How many faults outside our image get a report.
     const FOREIGN_REPORT_LIMIT: u32 = 4;
     static REPORTS: AtomicU32 = AtomicU32::new(0);
@@ -412,7 +501,7 @@ fn report_foreign_fault(signo: c_int, ctx: *mut c_void) {
     let Some(info) = dladdr_info(pc) else {
         return;
     };
-    if REPORTS.fetch_add(1, Ordering::AcqRel) >= FOREIGN_REPORT_LIMIT {
+    if REPORTS.fetch_add(1, Ordering::AcqRel) >= FOREIGN_REPORT_LIMIT && !terminal {
         return;
     }
     let fd = crate::log_file::raw_fd();
@@ -486,7 +575,7 @@ fn report_foreign_fault(signo: c_int, ctx: *mut c_void) {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     {
         let sp = mcontext_u64(ctx, SP_OFFSET);
-        if sp != 0 {
+        if sp != 0 && !terminal {
             const HDR: &[u8] = b"[mtld3d::unix] mtld3d.so return addrs on stack:\n";
             // SAFETY: write(2) is async-signal-safe; the descriptor is the log file's or fd 2.
             unsafe {
@@ -511,7 +600,10 @@ fn thread_id() -> u64 {
 /// Append the calling thread's name.
 ///
 /// `pthread_getname_np` only reads thread-local storage, which is
-/// signal-safe enough for a terminating handler.
+/// signal-safe enough for a terminating handler. A thread nobody named is
+/// named by what it is instead, because the one that matters here carries no
+/// name: the process's main thread is `AppKit`'s, and a fault under
+/// `winemac`'s Cocoa event loop lands on it.
 fn push_thread_name(buf: &mut [u8; 192], pos: &mut usize) {
     let mut name = [0u8; 64];
     // SAFETY: `pthread_self` is always safe to call; reads the current TLS.
@@ -525,6 +617,17 @@ fn push_thread_name(buf: &mut [u8; 192], pos: &mut usize) {
         );
     }
     let nlen = name.iter().position(|&b| b == 0).unwrap_or(name.len());
+    if nlen == 0 {
+        // SAFETY: `pthread_main_np` compares the calling thread against the
+        // process's first one and reads nothing else.
+        let label: &[u8] = if unsafe { libc::pthread_main_np() } == 0 {
+            b"unnamed"
+        } else {
+            b"cocoa main"
+        };
+        push(buf, pos, label);
+        return;
+    }
     push(buf, pos, &name[..nlen.min(96)]);
 }
 

--- a/unix/unix/src/crash/tests.rs
+++ b/unix/unix/src/crash/tests.rs
@@ -11,9 +11,17 @@
 //! not own is handed back to the signal's default action, and the report it
 //! writes first has to name the image with an offset, the thread, and our
 //! frames on the faulting stack. The third traps in our own code, which is
-//! fatal like a fault.
+//! fatal like a fault. The fourth takes the same foreign fault on a thread
+//! that answers with no TEB, where handing it back would fault inside Wine,
+//! and pins that the process ends here with the first fault named.
+//!
+//! Wine is not in a unit test's process, so the branch that asks it for the
+//! calling thread's TEB is exercised through a stand-in `NtCurrentTeb` stored
+//! where the install-time lookup would have put one: what the handler reads is
+//! a function address either way, so the stand-in exercises the same branch.
 
-use std::os::unix::process::ExitStatusExt as _;
+use core::{ffi::c_void, ptr};
+use std::{os::unix::process::ExitStatusExt as _, sync::atomic::Ordering};
 
 /// Set in the re-executed child so it faults instead of asserting.
 ///
@@ -26,6 +34,30 @@ const FOREIGN_SELFTEST_ENV: &str = "MTLD3D_CRASH_FOREIGN_SELFTEST";
 
 /// Set in the re-executed child so it executes a trap instruction.
 const ILL_SELFTEST_ENV: &str = "MTLD3D_CRASH_ILL_SELFTEST";
+
+/// Set in the re-executed child so its foreign fault has no TEB behind it.
+const NO_TEB_SELFTEST_ENV: &str = "MTLD3D_CRASH_NO_TEB_SELFTEST";
+
+/// The byte a stand-in TEB pointer points at; only its address is ever used.
+static FAKE_TEB: u8 = 0;
+
+/// Stands in for Wine's `NtCurrentTeb` on a thread Wine never created.
+extern "C" fn no_teb_stub() -> *mut c_void {
+    ptr::null_mut()
+}
+
+/// Stands in for Wine's `NtCurrentTeb` on a thread Wine created.
+extern "C" fn teb_stub() -> *mut c_void {
+    (&raw const FAKE_TEB).cast_mut().cast::<c_void>()
+}
+
+/// Install a stand-in `NtCurrentTeb`, replacing whatever the lookup found.
+///
+/// The handler reads one function address out of a static, so a stand-in put
+/// there reaches exactly the code a resolved `ntdll.so` would.
+fn pin_wine_teb(entry: extern "C" fn() -> *mut c_void) {
+    super::WINE_CURRENT_TEB.store(entry as usize, Ordering::Relaxed);
+}
 
 /// The bad pointer the child dereferences.
 ///
@@ -167,6 +199,78 @@ fn foreign_fault_is_named_then_forwarded() {
         report.contains("mtld3d.so return addrs on stack:"),
         "{report}"
     );
+}
+
+/// A thread with no TEB is not one Wine's handler can serve.
+///
+/// Three cases, since the guard has to leave the forwarding path alone
+/// wherever Wine is not the previous owner: no Wine in the process at all,
+/// which is what a plain pthread here is; a thread that has a TEB; and a
+/// thread that does not, on the calling thread and on a spawned one.
+#[test]
+fn a_thread_without_a_teb_is_not_one_wine_serves() {
+    super::resolve_wine_current_teb();
+    assert_eq!(super::wine_teb(), 0);
+    assert!(super::wine_serves_this_thread());
+
+    pin_wine_teb(teb_stub);
+    assert_ne!(super::wine_teb(), 0);
+    assert!(super::wine_serves_this_thread());
+
+    pin_wine_teb(no_teb_stub);
+    assert_eq!(super::wine_teb(), 0);
+    assert!(!super::wine_serves_this_thread());
+    let off_thread = std::thread::spawn(super::wine_serves_this_thread)
+        .join()
+        .expect("the spawned thread returns");
+    super::WINE_CURRENT_TEB.store(0, Ordering::Relaxed);
+    assert!(!off_thread);
+}
+
+/// A foreign fault on a thread with no TEB ends the process here.
+///
+/// Handing it back would fault inside Wine reading the TEB the thread does not
+/// have, and that second fault is what the report would name. The child dies
+/// through the handler's own `_exit(1)` instead, with the foreign fault named
+/// first and the fatal report under it.
+#[test]
+fn foreign_fault_without_a_teb_is_reported_not_forwarded() {
+    if std::env::var_os(NO_TEB_SELFTEST_ENV).is_some() {
+        super::install();
+        pin_wine_teb(no_teb_stub);
+        // SAFETY: deliberately unsound; this is the fault under test, taken
+        // in a child process that never returns from the handler.
+        let len = unsafe { libc::strlen(std::hint::black_box(BAD_ADDR as *const libc::c_char)) };
+        unreachable!("the strlen above must fault, not return {len}");
+    }
+
+    let exe = std::env::current_exe().expect("test binary path");
+    let out = std::process::Command::new(exe)
+        .args([
+            "--exact",
+            "crash::tests::foreign_fault_without_a_teb_is_reported_not_forwarded",
+            "--nocapture",
+        ])
+        .env(NO_TEB_SELFTEST_ENV, "1")
+        .output()
+        .expect("re-exec the test binary");
+    let report = String::from_utf8_lossy(&out.stderr);
+
+    // The handler ran to its own `_exit(1)` rather than dying on the signal's
+    // default action, which is where a forward would have ended up.
+    assert_eq!(out.status.code(), Some(1), "{report}");
+    assert_eq!(out.status.signal(), None, "{report}");
+    // The first fault is the one named, image and symbol included, and the
+    // fatal report that follows carries the stack the forwarded case lacks.
+    let foreign = report
+        .find("fault outside mtld3d.so")
+        .unwrap_or_else(|| panic!("no foreign-fault line:\n{report}"));
+    let fatal = report
+        .find("FATAL: SIGSEGV")
+        .unwrap_or_else(|| panic!("no fatal banner:\n{report}"));
+    assert!(foreign < fatal, "{report}");
+    assert!(report.contains("has no Wine TEB"), "{report}");
+    assert!(report.contains("native backtrace:"), "{report}");
 }
 
 /// A trap instruction in our own code is fatal and named like a fault.


### PR DESCRIPTION
## Symptoms

A crash taken in native code on the Cocoa main thread is reported twice, and the report leads with the wrong one. The kept layer log of a reproduced death has the real fault first, without a stack:

`[mtld3d::unix] fault outside mtld3d.so: signo=11 ... image=AppKit ... sym=__reusableDependencyContextForKey_block_invoke ... thread=`

and then the fault the first one provoked, which is what the banner names:

`[mtld3d::unix] FATAL: SIGSEGV fault=0x2f0` with `fault_pc` in `ntdll.so save_context+573` and a native backtrace reading `handler -> segv_handler -> handler -> CoreFoundation -> AppKit`.

The `thread=` field of both lines is empty, so nothing in the report says which thread it happened on.

## Root cause

`handler` treats a fault whose PC lies outside `mtld3d.so` as somebody else's and hands it to the previous handler, which is Wine's `segv_handler`. That is right for a guest fault on a Wine thread, and it is what keeps the x86 emulator's ordinary memory faults working on an arm64 host. It is wrong on a thread Wine did not create. Wine's unix side keeps each thread's TEB in a pthread key (`teb_key`, read by `NtCurrentTeb`), and `segv_handler` reaches it immediately: `save_context` copies the debug registers out of `NtCurrentTeb()->GdiTebBatch`, so on a thread with no TEB it dereferences null and faults at offset 0x2f0, which is exactly the `fault=0x2f0` in the report. The Cocoa main thread `winemac` runs its event loop on under `run_cocoa_app` is such a thread, and so are the layer's own.

That second fault re-enters `handler`. Its PC is in `ntdll.so`, so by the handler's own rule it is not ours either, but the re-entrancy latch is already armed by then, so the process ends at `_exit(1)` with a banner describing the consequence rather than the cause.

The empty `thread=` is a separate gap in the same report: `pthread_getname_np` answers with nothing for a thread nobody named, and the process's main thread is never named.

## Changes

`unix/unix/src/crash.rs` resolves Wine's `NtCurrentTeb` once from `install`, through `dlopen` on a null path plus `dlsym`, and keeps the address in an atomic the signal path reads. `dlsym` allocates and takes the loader's lock, so the lookup cannot happen in the handler; reading one atomic and calling through it can, since `NtCurrentTeb` reads a pthread key and nothing else.

Before forwarding, the handler asks whether the calling thread is one Wine can serve: it is when the thread has a TEB, and it is also when the symbol did not resolve at all, where the previous disposition is not Wine's and there is nothing to guard against. A foreign fault on a thread that has no TEB is reported in full instead of forwarded: the `fault outside mtld3d.so` line with the image, the offset, the nearest symbol and the thread, one line saying why the fault is not going back, then the fatal banner, the registers, the crumb dump and the symbolised native backtrace, and `_exit(1)`. Guest faults on Wine threads take the same path as before, unchanged.

`report_foreign_fault` takes the same answer: a fault the process is about to die on is reported whatever the per-process report cap says, and its stack pass is left to the fatal report below, which prints a superset of it.

`push_thread_name` names a thread nobody named: `cocoa main` when `pthread_main_np` says it is the process's main thread, `unnamed` otherwise, so both lines of the report say where the fault was taken.

## Alternatives

Register the layer's own threads and treat everything else as Wine's: wrong answer for the Cocoa main thread, which is neither, and it would still forward into Wine there.

Read the TEB the way `ntdll` does on Linux, off the signal stack mask: that path is `#ifdef __linux__`, and macOS Wine uses the pthread key instead, so it would answer for a machine we do not run on.

Stop forwarding foreign faults entirely: that is what the handler used to do, and it killed the game at startup on arm64 Wine, where the x86 emulator takes memory faults as ordinary work.

Keep forwarding and suppress the second report: the process still dies inside Wine with the first fault unexplained, which is the part that made the death hard to read.

## Verification

`make fmt`, `make check` (clippy nursery and pedantic on both PE targets and native, audit, doc) green.

`make ISOLATED=1 test` green: unit tests 1091 passed on the windows workspace and 275 on the unix workspace, both 0 failed; end-to-end 475 PASS / 0 FAIL / 0 LEAK / 0 SIGABRT / 0 TIMEOUT on i686 and the same on x86_64, 4 processes each.

Two unit tests in `unix/unix/src/crash/tests.rs`. Wine is not in a unit test's process, so both drive the branch through a stand-in `NtCurrentTeb` written into the same atomic the install-time lookup fills; what the handler reads is a function address either way.

`crash::tests::a_thread_without_a_teb_is_not_one_wine_serves` pins all three answers of the classification: no Wine in the process (a plain pthread, which is what a unit test has) leaves the forwarding path alone, a thread with a TEB is served, and a thread without one is not, on the calling thread and on a spawned one.

`crash::tests::foreign_fault_without_a_teb_is_reported_not_forwarded` re-executes the test binary, faults inside libsystem on a thread that answers with no TEB, and asserts the child died through the handler's own `_exit(1)` rather than the signal's default action, with the `fault outside mtld3d.so` line before the `FATAL: SIGSEGV` banner and the native backtrace under it. It fails before the change (the child forwards, dies on SIGSEGV, and the exit code is a signal rather than 1) and passes after.

No end-to-end test: raising a foreign fault on a non-Wine thread means faulting on the Cocoa main thread of a live test process, which cannot be done without killing the process the suite is measuring, and the guest side has no way to reach a thread Wine did not create.

Conformance was not run: nothing in the render, state or shader-emission path is touched.

Closes #464
