### PR TITLE
Configure the test prefix once per prefix, under a lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,14 @@ $(info ==> ISOLATED=1: Wine SDK, install dir and prefix under $(ISOLATED_ROOT))
 endif
 export WINE_SDK
 
+# The prefix the test legs boot, named unconditionally: ISOLATED=1 points it at
+# the clone above, otherwise it is the ambient `WINEPREFIX` or Wine's default.
+# `configure-test-prefix` serialises on a lock file inside it, so the legs that
+# share one prefix are exactly the legs that contend for it, and two checkouts
+# with their own clones never wait on each other.
+TEST_PREFIX      := $(or $(WINEPREFIX),$(HOME)/.wine)
+TEST_PREFIX_LOCK := $(TEST_PREFIX)/.mtld3d-configure.lock
+
 # The Wine tools this Makefile runs, named by absolute path out of the same
 # install we build against and install into. Not found on PATH, and NOT by
 # exporting one either: make execs a simple recipe line itself rather than
@@ -272,7 +280,8 @@ TAG          ?= $(shell git describe --tags --exact-match 2>/dev/null)
 # Wine install, never into a file named after the target.
 .PHONY: all windows windows-i686 windows-x86_64 unix unix-x64 unix-arm64 \
 	install install-windows-i686 install-windows-x86_64 install-unix-x64 install-unix-arm64 \
-	bundle version-check stage configure-test-prefix clean-isolated clean-isolated-all \
+	bundle version-check stage clean-isolated clean-isolated-all \
+	configure-test-prefix configure-test-prefix-locked configure-test-prefix-session \
 	test test-unit test-e2e-i686 test-e2e-x86_64 \
 	conformance conformance-i686 conformance-x86_64 \
 	conformance-baseline conformance-baseline-i686 conformance-baseline-x86_64 \
@@ -608,7 +617,51 @@ define WINE_REG_ADD
 out=$$($(WINE) reg add $(1) 2>&1) || { echo "wine reg add $(1) failed:" >&2; echo "$$out" >&2; exit 1; }
 endef
 
+# Reads one value back through the running wineserver, so the answer is the
+# session's own rather than what the prefix last flushed to disk. False for a
+# value that is absent, and for one that holds anything else. Wine's own
+# chatter goes to stderr and is dropped; `reg query` prints the value name, its
+# type and its data on one line, and ends that line the Windows way, so the
+# pattern has to allow the carriage return the data is followed by.
+# $(1) = the key, $(2) = the value name, $(3) = the data it must hold.
+define WINE_REG_IS
+$(WINE) reg query $(1) /v $(2) 2>/dev/null | grep -qE '^[[:space:]]*$(2)[[:space:]]+REG_[A-Z]+[[:space:]]+$(3)[[:space:]]*$$'
+endef
+
+# Pin the prefix's display state for the tests, once per prefix rather than
+# once per leg.
+#
+# Configuring ends the prefix's wineserver, so a leg that does it beside a
+# running leg takes down the server that leg's test processes are attached to,
+# and they end with their tests unaccounted for. Two guards make that
+# impossible. `lockf` holds an exclusive flock(2) on a file in the prefix for
+# the sub-make, waits for whoever holds it, and drops it when that sub-make
+# ends however it ends, so a leg killed mid-configure leaves no stale lock. And
+# the sub-make configures nothing when the prefix is already configured, which
+# it is from the first leg of a checkout on.
 configure-test-prefix:
+	mkdir -p $(TEST_PREFIX)
+	lockf -k $(TEST_PREFIX_LOCK) $(MAKE) configure-test-prefix-locked
+
+# Runs only while that lock is held. A prefix whose persistent wineserver is up
+# and whose three keys read back through it is configured, and there is nothing
+# to restart. `wineserver -k0` is the server probe: it sends signal 0 to
+# whatever holds the server's lock file, so it reports whether a server runs
+# without touching one and without blocking, which `-w` cannot do here since
+# the persistent server below never terminates on its own. The answer cannot go
+# stale between the probe and the decision: the lock is what a leg holds while
+# it ends and reboots a server, so nothing can be mid-boot here, and a probe
+# that finds no server also proves this prefix has no test process attached to
+# one.
+configure-test-prefix-locked:
+	if $(WINESERVER) -k0 >/dev/null 2>&1 \
+		&& $(call WINE_REG_IS,'HKCU\Software\Wine\WineDbg',ShowCrashDialog,0x0) \
+		&& $(call WINE_REG_IS,'HKCU\Software\Wine\X11 Driver',EmulateModeset,Y) \
+		&& $(call WINE_REG_IS,'HKCU\Software\Wine\Mac Driver',RetinaMode,Y); \
+	then exit 0; fi; \
+	$(MAKE) configure-test-prefix-session
+
+configure-test-prefix-session:
 	# Keep automated tests non-interactive and independent of mutable prefix
 	# display settings. EmulateModeset prevents physical host mode changes;
 	# RetinaMode keeps Win32 monitor geometry in the same physical-pixel space


### PR DESCRIPTION
## Symptoms

Two end-to-end legs started at once in one checkout kill each other. Every leg runs `configure-test-prefix` first, and the rule ends the prefix's wineserver, so the second leg takes down the session the first leg's test processes are attached to. The runner reports that as a death of the process itself:

```
NOTE e2e: the process ended with exit code 0; 377 of its tests unaccounted for
```

Each one costs a re-run of the tests that were in flight, and a leg that loses enough of them fails outright. Nothing warns, and `make test`, which runs its legs one after the other, never hits it, so the trap only shows when a leg is run by hand beside another, which is the only way to put the machine under the load some of the window and device bugs need.

## Root cause

The rule writes three registry keys and then ends the prefix's wineserver with `-k` and `-w` before booting the persistent one. That is needed once: a wineserver session enumerates the display when its desktop starts and serves that geometry to every process in it afterwards, and the session the first `reg add` boots to create the prefix enumerates it before `RetinaMode` is written.

It is not needed again. The keys only need writing once per prefix, and every leg of a checkout shares one prefix, so from the second leg on the `-k` has nothing to fix and only clients to lose. When it lands on a leg that is already running, Wine ends that leg's test processes, `d3d9.dll`'s detach terminates each with the status it asked to exit with (0 for one that never asked), and the runner sees a process that ended without reporting the tests it had in flight. A kill that catches a process later in its shutdown reports as `signal 9`, the escalation `wineserver -k` makes when the server does not go down on SIGINT.

## Changes

`configure-test-prefix` now takes an exclusive `flock(2)` on `.mtld3d-configure.lock` inside the prefix, through `lockf`, and runs the configure as a sub-make while it holds it. `lockf` waits for whoever holds the lock and drops it when that sub-make ends however it ends, so a leg killed mid-configure leaves nothing stale behind. Every leg of one checkout contends for that lock, and only those legs do, since two checkouts under `ISOLATED=1` have their own prefixes.

Under the lock the rule decides whether there is anything to do. `wineserver -k0` is the server probe: `-k` with a signal number sends that signal to whatever holds the server's lock file and reports whether there was one, so signal 0 asks the question without touching the server and without blocking. `-w` cannot be the probe, because it never returns under the persistent server this rule boots. If a server answers, the three keys are read back through it with `reg query`, data and all. A prefix that answers both is configured and the rule ends there; anything else takes the old sequence, which now lives in `configure-test-prefix-session`.

The probe cannot misfire under a booting server. Ending and rebooting a server only ever happens inside the lock, so while the probe runs no leg of this prefix is between the two, and the answer cannot go stale before the decision that reads it. A probe that finds a server has also just proved the keys are readable through the session the tests will attach to. A probe that finds none proves this prefix has no live Wine process at all, so the restart it triggers has nothing to take down. A leg that arrives while another is mid-configure waits for the lock and then reads the configured prefix, rather than restarting it.

Reading the keys back rather than trusting a marker file keeps what the old rule guaranteed: a prefix whose display state has drifted, or one cloned from a prefix that never had the keys, is configured again.

## Alternatives

A lock file that refuses a second leg and names itself in the failure: rejected, the legs are meant to run beside each other, and refusing turns a working combination into an error.

A marker file written beside the keys instead of reading them back: rejected, it goes stale against a prefix that was reset, re-cloned or edited by hand, and the rule would then skip a prefix whose display state is not pinned.

`wineserver -w` under a short timeout as the liveness probe: rejected, it never returns under a persistent server, so it can only be read as a timeout, and the timeout would have to be long enough to cover a server that is still coming up.

Skipping only the `-k` and `-w` pair and keeping the rest: rejected, the three `reg add` calls and `wineboot` are four more Wine launches per leg with nothing to write.

## Verification

`make fmt` and `make check` green, `audit: clean (302 files)`.

`make ISOLATED=1 test`: 1091 unit tests in the windows workspace and 273 in the unix one, all passed; i686 475 PASS, 0 FAIL, 4 processes; x86_64 475 PASS, 0 FAIL, 4 processes.

Two legs of one checkout in parallel, `make ISOLATED=1 test-e2e-x86_64 JOBS=4 FAIL_FAST=0` with `make ISOLATED=1 test-e2e-i686 JOBS=4 FAIL_FAST=0` started as soon as the first leg's runner was up, four rounds each way on a machine that was also running other legs. Before the change, 3 of the 4 rounds lost a process (`exit code 0` twice, `signal 9` once) and those three legs took 6 processes instead of 4. After the change, 0 of 8 legs lost a process and every leg took 4.

The same interaction driven directly, one leg with `make ISOLATED=1 configure-test-prefix` run beside it every three seconds, which is what a second leg does first: before the change 4 of 4 rounds lost processes, 5 in total; after the change 0 lost processes across 13 configures in 4 rounds, and each of those configures left the leg's wineserver pid unchanged. One leg in those rounds lost a process to the `exit code 1` death inside AppKit that #461 tracks, which is not this failure and is unaffected by this change; its `.stderr` and `.layer-log` are kept.

Closes #466.
