### PR TITLE
Cross-check the runner's tally against libtest's own counts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,15 @@ summary on both architectures. mtld3d's log of each test process is a file,
 `<binary>-<pid>.log` under `mtld3d-logs` next to the test executable in
 `windows/target`, one per process, so one file carries the whole suite's log.
 
+A process that ends cleanly is still checked against libtest's own account.
+Its `test result:` line counts the results it printed, and a runner tally
+short of that count means a result never arrived, whatever tore it off the
+pipe. The note is `libtest counted <n> results and the runner read <m>; no
+outcome for: <names>`, the named tests run again in a fresh process, and the
+summary's total therefore never falls short of the set the run was asked for.
+A second process that reports none of them again fails them rather than
+looping.
+
 A process that ends with tests unaccounted for leaves its whole stderr in the
 same directory as `<binary>-<pid>.stderr`, and every line the runner prints
 about that process names the file. What it prints inline is the last fifteen

--- a/unix/e2e/src/attribute.rs
+++ b/unix/e2e/src/attribute.rs
@@ -16,7 +16,17 @@
 //! several unaccounted for is narrowed to the tests that had named
 //! themselves and not finished. Those run one at a time, where a start line
 //! names the culprit; the rest wait for a process of their own at the width
-//! the caller asked for, since nothing so far says they were involved.
+//! the caller asked for, since nothing so far says they were involved. The
+//! announcements are on stderr, where they cannot land inside a result
+//! line libtest is writing to stdout.
+//!
+//! A process that ends cleanly is still checked against libtest's own
+//! account. Its `test result:` line counts the results it printed, and a
+//! tally short of that count means a result never reached the runner
+//! whatever the reason. The tests with no outcome are then named, out of
+//! the selection or out of `--list`, and run again in a fresh process, so
+//! the run reports on every test it was asked for rather than on a smaller
+//! suite.
 //!
 //! The layer keeps an account of its own. Its log file, not the process's
 //! stderr, is where its crash report goes, so a note about a process that
@@ -47,11 +57,12 @@ const ENDS_PROCESS: &str = "[e2e] test ";
 /// What separates the test's name from its exit code in the marker.
 const ENDS_PROCESS_CODE: &str = " ends this process with exit code ";
 
-/// The stdout marker of a test that has started; what follows it is its name.
+/// The stderr marker of a test that has started; what follows it is its name.
 ///
 /// Printed by the test binary's shared harness on the thread libtest named
-/// after the test. Searched for rather than matched at the start, for the
-/// same reason as [`ENDS_PROCESS`].
+/// after the test, and on stderr so that it can never land inside the
+/// result line libtest is writing to stdout. Searched for rather than
+/// matched at the start, since Wine's own chatter shares the stream.
 const RUNNING: &str = "[e2e] running ";
 
 /// How a process of the binary ended, with everything it printed.
@@ -200,7 +211,8 @@ pub fn run_binary(
                 Event::Summary(summary) => round.summary = Some(summary),
             })?;
             let ran_something = !round.finished.is_empty();
-            let reported = round.finished.len();
+            let reported = u32::try_from(round.finished.len()).unwrap_or(u32::MAX);
+            let before = done.len();
             let declared = declared_exit(&end.stdout);
             let ends_itself = declared.is_some();
             if let Some((name, code)) = declared {
@@ -233,17 +245,41 @@ pub fn run_binary(
             }
 
             let clean = ends_itself || (end.kind == ExitKind::Code(0) && round.summary.is_some());
+            let counted = round.summary.as_ref().map_or(0, Summary::counted);
+            // libtest's own tally, when it got that far, says whether anything
+            // was still in flight without a `--list`.
+            let tallied = round.summary.is_some() && counted == reported;
+            // A test that ends its own process is its whole account; libtest
+            // never reaches its summary line, so there is nothing to check.
+            let accounted = ends_itself || tallied;
             let complete = remaining
                 .as_ref()
                 .is_none_or(|names| names.iter().all(|name| done.contains(name)));
-            if clean && complete {
+            if clean && accounted && complete {
                 break;
             }
             if clean {
-                // libtest ran to the end without these: they are not tests it knows.
-                for name in remaining.take().into_iter().flatten() {
-                    if done.insert(name.clone()) {
-                        run.failed = true;
+                // A clean end that does not add up: libtest printed results
+                // the runner never read, or ran to completion without a test
+                // it was given. Either way the names with no outcome are what
+                // the run still owes, and only naming them costs a `--list`.
+                let narrowed = remaining.is_some();
+                let asked = match remaining.take() {
+                    Some(names) => names,
+                    None => launcher.list()?,
+                };
+                let owed: Vec<String> = asked
+                    .into_iter()
+                    .filter(|name| !done.contains(name))
+                    .collect();
+                if owed.is_empty() {
+                    break;
+                }
+                if accounted {
+                    // libtest ran to the end without these: they are not tests it knows.
+                    run.failed = true;
+                    for name in owed {
+                        done.insert(name.clone());
                         report.result(TestResult {
                             name,
                             verdict: Verdict::Failed(
@@ -251,15 +287,38 @@ pub fn run_binary(
                             ),
                         });
                     }
+                    break;
                 }
-                break;
+                report.note(&format!(
+                    "libtest counted {counted} results and the runner read {reported}; \
+                     no outcome for: {}",
+                    owed.join(", ")
+                ));
+                if narrowed && done.len() == before {
+                    // This round was already the one that ran nothing but
+                    // these, and it reported none of them: another would end
+                    // the same way.
+                    run.failed = true;
+                    for name in owed {
+                        done.insert(name.clone());
+                        report.result(TestResult {
+                            name,
+                            verdict: Verdict::Failed(
+                                "libtest counted a result for this test that never reached the runner"
+                                    .to_owned(),
+                            ),
+                        });
+                    }
+                    break;
+                }
+                report.note(&format!(
+                    "running the {} tests with no outcome in a fresh process",
+                    owed.len()
+                ));
+                remaining = Some(owed);
+                continue;
             }
             let reason = end.kind.describe();
-            // libtest's own tally, when it got that far, says whether anything
-            // was still in flight without a `--list`.
-            let tallied = round.summary.as_ref().is_some_and(|s| {
-                s.passed + s.failed + s.ignored == u32::try_from(reported).unwrap_or(u32::MAX)
-            });
             if tallied && complete {
                 report.note(&format!(
                 "the process ended with {reason} after reporting every test; nothing to run again"
@@ -282,7 +341,7 @@ pub fn run_binary(
             let kept = kept_stderr(launcher.keep_stderr(end.pid, &end.stderr));
             // The tests that had named themselves and never reported a result:
             // exactly what was running on the threads when the process ended.
-            let mut running: Vec<String> = announced(&end.stdout)
+            let mut running: Vec<String> = announced(&end.stderr)
                 .into_iter()
                 .filter(|name| in_flight.contains(name))
                 .collect();
@@ -388,9 +447,9 @@ pub fn run_binary(
     Ok(run)
 }
 
-/// The tests that named themselves on `stdout`, in the order they did.
-fn announced(stdout: &str) -> Vec<String> {
-    stdout
+/// The tests that named themselves on `stderr`, in the order they did.
+fn announced(stderr: &str) -> Vec<String> {
+    stderr
         .lines()
         .filter_map(|line| line.split_once(RUNNING))
         .map(|(_, name)| name.trim().to_owned())

--- a/unix/e2e/src/attribute/tests.rs
+++ b/unix/e2e/src/attribute/tests.rs
@@ -15,6 +15,11 @@
 //! only those run again one at a time, and the layer's own log of the
 //! process is quoted with them and kept under a name the layer's retention
 //! does not match.
+//!
+//! The last three pin the cross-check a clean end gets: a torn result line
+//! costs nothing because the parser reads it, a tally short of libtest's
+//! own count names the tests with no outcome and runs them again, and a
+//! second round that loses the same result fails it rather than looping.
 
 use std::{
     collections::VecDeque,
@@ -86,7 +91,7 @@ impl Launcher for Scripted {
         self.layer = script.layer;
         let mut parser = Parser::default();
         for line in script.stdout.lines() {
-            if let Some(event) = parser.line(line) {
+            for event in parser.line(line) {
                 on_event(event);
             }
         }
@@ -458,8 +463,9 @@ fn the_note_names_what_was_in_flight_and_only_those_run_one_at_a_time() {
         &["a::one", "a::two", "a::three", "a::four"],
         vec![
             Script {
-                stdout: "running 4 tests\n[e2e] running a::one\n[e2e] running a::two\n[e2e] running a::three\ntest a::one ... ok\n",
-                stderr: String::new(),
+                stdout: "running 4 tests\ntest a::one ... ok\n",
+                stderr: "[e2e] running a::one\n[e2e] running a::two\n[e2e] running a::three\n"
+                    .to_owned(),
                 layer: None,
                 kind: ExitKind::Code(1),
             },
@@ -504,8 +510,8 @@ fn a_death_stderr_is_silent_about_is_quoted_from_the_layers_own_log() {
         &["a::one", "a::two"],
         vec![
             Script {
-                stdout: "running 2 tests\n[e2e] running a::one\n[e2e] running a::two\n",
-                stderr: String::new(),
+                stdout: "running 2 tests\n",
+                stderr: "[e2e] running a::one\n[e2e] running a::two\n".to_owned(),
                 layer: Some(
                     "ordinary line\n[mtld3d::unix] FATAL: SIGSEGV fault=0x0\n[mtld3d::unix] thread=mtld3d-encoder\n",
                 ),
@@ -539,5 +545,107 @@ fn a_death_stderr_is_silent_about_is_quoted_from_the_layers_own_log() {
     assert!(
         !launcher.log_dir.join(format!("{STEM}-{PID}.log")).exists(),
         "the layer's own file is gone, so its retention has nothing to remove"
+    );
+}
+
+/// A result and an announcement sharing a line still count as a result.
+///
+/// The tally is complete, so nothing is noted and no second process runs.
+#[test]
+fn a_torn_result_line_costs_no_note_and_no_process() {
+    let mut launcher = Scripted::new(
+        &["a::one", "a::two"],
+        vec![Script {
+            stdout: "running 2 tests\ntest a::one ... ok[e2e] running a::two\n\ntest a::two ... ok\n\ntest result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
+            stderr: String::new(),
+            layer: None,
+            kind: ExitKind::Code(0),
+        }],
+    );
+    let mut log = Log::default();
+    let run = run_binary(&mut launcher, None, 4, true, &mut log).unwrap();
+    assert_eq!(run.processes, 1);
+    assert!(!run.failed);
+    assert_eq!(
+        verdicts(&log.results),
+        [("a::one", "pass"), ("a::two", "pass")]
+    );
+    assert!(log.notes.is_empty(), "{:?}", log.notes);
+}
+
+/// A tally short of libtest's own count names what has no outcome and runs it again.
+#[test]
+fn a_tally_short_of_the_summary_is_noted_and_run_again() {
+    let mut launcher = Scripted::new(
+        &["a::one", "a::two", "a::three"],
+        vec![
+            Script {
+                stdout: "running 3 tests\ntest a::one ... ok\ntest a::three ... ok\n\ntest result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
+                stderr: String::new(),
+                layer: None,
+                kind: ExitKind::Code(0),
+            },
+            Script {
+                stdout: "running 1 test\ntest a::two ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.1s\n",
+                stderr: String::new(),
+                layer: None,
+                kind: ExitKind::Code(0),
+            },
+        ],
+    );
+    let mut log = Log::default();
+    let run = run_binary(&mut launcher, None, 4, true, &mut log).unwrap();
+    assert_eq!(run.processes, 2);
+    assert!(!run.failed);
+    assert_eq!(
+        verdicts(&log.results),
+        [("a::one", "pass"), ("a::three", "pass"), ("a::two", "pass")],
+        "every test the binary lists is reported on"
+    );
+    assert!(
+        log.notes[0].contains("libtest counted 3 results and the runner read 2"),
+        "{:?}",
+        log.notes
+    );
+    assert!(
+        log.notes[0].contains("no outcome for: a::two"),
+        "{:?}",
+        log.notes
+    );
+    assert_eq!(
+        launcher.launched[1],
+        (Some(vec!["a::two".to_owned()]), 4),
+        "only the test with no outcome runs again"
+    );
+}
+
+/// A second round that loses the same result fails the test instead of looping.
+#[test]
+fn a_result_lost_twice_fails_its_test() {
+    let short = Script {
+        stdout: "running 1 test\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
+        stderr: String::new(),
+        layer: None,
+        kind: ExitKind::Code(0),
+    };
+    let mut launcher = Scripted::new(
+        &["a::one"],
+        vec![
+            short,
+            Script {
+                stdout: "running 1 test\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
+                stderr: String::new(),
+                layer: None,
+                kind: ExitKind::Code(0),
+            },
+        ],
+    );
+    let mut log = Log::default();
+    let run = run_binary(&mut launcher, None, 1, false, &mut log).unwrap();
+    assert_eq!(run.processes, 2, "one round to lose it, one to say so");
+    assert!(run.failed);
+    assert_eq!(verdicts(&log.results), [("a::one", "fail")]);
+    assert!(
+        matches!(&log.results[0].verdict, Verdict::Failed(r) if r.contains("never reached the runner"))
     );
 }

--- a/unix/e2e/src/binary.rs
+++ b/unix/e2e/src/binary.rs
@@ -123,7 +123,7 @@ impl Launcher for WineLauncher {
             (self.on_line)(line);
             stdout.push_str(line);
             stdout.push('\n');
-            if let Some(event) = parser.line(line) {
+            for event in parser.line(line) {
                 on_event(event);
             }
         })?;

--- a/unix/e2e/src/libtest.rs
+++ b/unix/e2e/src/libtest.rs
@@ -5,10 +5,15 @@
 //! libtest writes `test <name> ... ` before it runs the test and the outcome
 //! after, so a process that dies mid-test leaves the name of the test it was
 //! running as an unfinished line; with more threads every line is written on
-//! completion. The tests run with `--nocapture`, so a test's own prints can
-//! land between the two halves of a line; the parser treats a `test` line
-//! without an outcome as a start and a bare outcome line as the finish of
-//! the last started test.
+//! completion.
+//!
+//! Three writes make one result line: the name, the outcome word, and the
+//! newline. The tests run with `--nocapture`, so a print from a test thread
+//! can land between any two of them. The parser treats a `test` line without
+//! an outcome as a start, a bare outcome line as the finish of the last
+//! started test, and an outcome with text after it as the finish plus a line
+//! of its own, which is what a print between the outcome and its newline
+//! leaves behind.
 //!
 //! stderr carries the panic reports: the default hook writes
 //! `thread '<name>' panicked at ...`, and libtest names every test thread
@@ -48,6 +53,14 @@ pub struct Summary {
     pub filtered_out: u32,
 }
 
+impl Summary {
+    /// How many results libtest says it printed: everything but what the filter left out.
+    #[must_use]
+    pub const fn counted(&self) -> u32 {
+        self.passed + self.failed + self.ignored
+    }
+}
+
 /// Line-by-line reader of one process's stdout.
 #[derive(Default)]
 pub struct Parser {
@@ -56,36 +69,75 @@ pub struct Parser {
 }
 
 impl Parser {
-    /// The event `line` carries, if any.
-    pub fn line(&mut self, line: &str) -> Option<Event> {
+    /// The events `line` carries, in the order libtest wrote them.
+    ///
+    /// None or one for a line nothing interrupted; two where a print landed
+    /// between an outcome and its newline, since what follows the outcome is
+    /// read again as a line of its own.
+    pub fn line(&mut self, line: &str) -> Vec<Event> {
+        let mut events = Vec::new();
+        self.read(line, &mut events);
+        events
+    }
+
+    /// Push what `line` carries onto `events`, recursing into the text after an outcome.
+    ///
+    /// Each recursion drops at least the outcome word, so the line shrinks
+    /// and the recursion ends.
+    fn read(&mut self, line: &str, events: &mut Vec<Event>) {
         if let Some(counts) = line.strip_prefix("test result: ") {
-            return Some(Event::Summary(parse_summary(counts)));
+            events.push(Event::Summary(parse_summary(counts)));
+            return;
         }
         if let Some((name, tail)) = line
             .strip_prefix("test ")
             .and_then(|rest| rest.split_once(" ... "))
         {
             let name = name.to_owned();
-            if let Some(outcome) = parse_outcome(tail) {
-                self.pending = None;
-                return Some(Event::Finished { name, outcome });
-            }
-            self.pending = Some(name.clone());
-            return Some(Event::Started(name));
+            let Some((outcome, rest)) = parse_outcome(tail) else {
+                self.pending = Some(name.clone());
+                events.push(Event::Started(name));
+                return;
+            };
+            self.pending = None;
+            events.push(Event::Finished { name, outcome });
+            self.read(rest, events);
+            return;
         }
-        let outcome = parse_outcome(line.trim())?;
-        let name = self.pending.take()?;
-        Some(Event::Finished { name, outcome })
+        let Some((outcome, rest)) = parse_outcome(line.trim()) else {
+            return;
+        };
+        let Some(name) = self.pending.take() else {
+            return;
+        };
+        events.push(Event::Finished { name, outcome });
+        self.read(rest, events);
     }
 }
 
-fn parse_outcome(tail: &str) -> Option<Outcome> {
-    match tail.trim_end() {
-        "ok" => Some(Outcome::Ok),
-        "FAILED" => Some(Outcome::Failed),
-        tail if tail.starts_with("ignored") => Some(Outcome::Ignored),
-        _ => None,
+/// The outcome `tail` opens with, and whatever is left of the line after it.
+///
+/// libtest writes the outcome word and the newline after it as two writes,
+/// so a test thread's print can put its text right behind the word. The
+/// word ends where a character that cannot continue it does, which keeps a
+/// print that itself opens with one of the words from being read as it.
+/// `ignored` carries a free-text reason and nothing tells that reason from
+/// such a print, so nothing is left after it.
+fn parse_outcome(tail: &str) -> Option<(Outcome, &str)> {
+    if let Some(rest) = word_after("ok", tail) {
+        return Some((Outcome::Ok, rest));
     }
+    if let Some(rest) = word_after("FAILED", tail) {
+        return Some((Outcome::Failed, rest));
+    }
+    tail.starts_with("ignored")
+        .then_some((Outcome::Ignored, ""))
+}
+
+/// What follows `word` in `tail`, when `tail` opens with `word` as a whole word.
+fn word_after<'a>(word: &str, tail: &'a str) -> Option<&'a str> {
+    let rest = tail.strip_prefix(word)?;
+    (!rest.starts_with(|c: char| c.is_alphanumeric() || c == '_')).then(|| rest.trim())
 }
 
 /// The counts out of `ok. 3 passed; 1 failed; 0 ignored; 0 measured; 2 filtered out; ...`.

--- a/unix/e2e/src/libtest/tests.rs
+++ b/unix/e2e/src/libtest/tests.rs
@@ -2,8 +2,8 @@
 //!
 //! The lines are what a test binary prints under Wine: the threaded and the
 //! single-threaded forms of a result, a start line a dying process leaves
-//! behind, a test's own output landing inside a line, the summary counts,
-//! and the panic report that names the failing test.
+//! behind, a test's own output landing inside a line and behind an outcome,
+//! the summary counts, and the panic report that names the failing test.
 
 use super::{
     Event, Outcome, Parser, Summary, failure_report, listed_tests, panic_report, panicked_test,
@@ -17,45 +17,53 @@ fn finished(name: &str, outcome: Outcome) -> Event {
     }
 }
 
+fn one(events: Vec<Event>) -> Option<Event> {
+    assert!(events.len() <= 1, "{events:?}");
+    events.into_iter().next()
+}
+
 #[test]
 fn a_whole_result_line_finishes_a_test() {
     let mut parser = Parser::default();
     assert_eq!(
-        parser.line("test textures::lock_a8r8g8b8 ... ok"),
+        one(parser.line("test textures::lock_a8r8g8b8 ... ok")),
         Some(finished("textures::lock_a8r8g8b8", Outcome::Ok))
     );
     assert_eq!(
-        parser.line("test device::reset ... FAILED"),
+        one(parser.line("test device::reset ... FAILED")),
         Some(finished("device::reset", Outcome::Failed))
     );
     assert_eq!(
-        parser.line("test msaa::resolve ... ignored, no 4x"),
+        one(parser.line("test msaa::resolve ... ignored, no 4x")),
         Some(finished("msaa::resolve", Outcome::Ignored))
     );
-    assert_eq!(parser.line("running 3 tests"), None);
-    assert_eq!(parser.line(""), None);
+    assert_eq!(one(parser.line("running 3 tests")), None);
+    assert_eq!(one(parser.line("")), None);
 }
 
 #[test]
 fn a_start_line_is_closed_by_the_next_bare_outcome() {
     let mut parser = Parser::default();
     assert_eq!(
-        parser.line("test draw::quad ... "),
+        one(parser.line("test draw::quad ... ")),
         Some(Event::Started("draw::quad".to_owned()))
     );
-    assert_eq!(parser.line("ok"), Some(finished("draw::quad", Outcome::Ok)));
-    assert_eq!(parser.line("ok"), None, "nothing pending any more");
+    assert_eq!(
+        one(parser.line("ok")),
+        Some(finished("draw::quad", Outcome::Ok))
+    );
+    assert_eq!(one(parser.line("ok")), None, "nothing pending any more");
 }
 
 #[test]
 fn a_print_inside_a_start_line_still_starts_the_test() {
     let mut parser = Parser::default();
     assert_eq!(
-        parser.line("test draw::quad ... device created"),
+        one(parser.line("test draw::quad ... device created")),
         Some(Event::Started("draw::quad".to_owned()))
     );
     assert_eq!(
-        parser.line("FAILED"),
+        one(parser.line("FAILED")),
         Some(finished("draw::quad", Outcome::Failed))
     );
 }
@@ -65,7 +73,7 @@ fn the_summary_counts_are_read() {
     let mut parser = Parser::default();
     let line = "test result: FAILED. 3 passed; 1 failed; 2 ignored; 0 measured; 5 filtered out; finished in 0.23s";
     assert_eq!(
-        parser.line(line),
+        one(parser.line(line)),
         Some(Event::Summary(Summary {
             passed: 3,
             failed: 1,
@@ -120,5 +128,48 @@ fn the_list_output_yields_the_names() {
     assert_eq!(
         listed_tests("a::b: test\nc: test\n\n2 tests, 0 benchmarks\n"),
         ["a::b", "c"]
+    );
+}
+
+/// A print landing between an outcome and its newline still yields the result.
+///
+/// libtest writes the outcome word and the newline after it separately, so
+/// with more than one test thread a print from another test lands between
+/// them and the two share a line. Reading that line as a start would lose
+/// the result the process did report.
+#[test]
+fn a_print_behind_an_outcome_does_not_lose_the_result() {
+    let mut parser = Parser::default();
+    assert_eq!(
+        parser.line("test clip_planes::state_block ... ok[e2e] running textures::lock"),
+        [finished("clip_planes::state_block", Outcome::Ok)]
+    );
+    assert_eq!(
+        one(parser.line("")),
+        None,
+        "the newline libtest wrote after the print is a line of its own"
+    );
+    assert_eq!(
+        parser.line("test device::reset ... FAILED[e2e] running msaa::resolve"),
+        [finished("device::reset", Outcome::Failed)]
+    );
+    assert_eq!(
+        parser.line("test draw::quad ... "),
+        [Event::Started("draw::quad".to_owned())]
+    );
+    assert_eq!(
+        parser.line("ok[e2e] running draw::tri"),
+        [finished("draw::quad", Outcome::Ok)],
+        "a bare outcome carries a print behind it too"
+    );
+}
+
+/// A word that only opens with an outcome is not one.
+#[test]
+fn a_print_that_opens_like_an_outcome_is_not_read_as_one() {
+    let mut parser = Parser::default();
+    assert_eq!(
+        parser.line("test draw::quad ... okay, device created"),
+        [Event::Started("draw::quad".to_owned())]
     );
 }

--- a/windows/tests/src/in_flight.rs
+++ b/windows/tests/src/in_flight.rs
@@ -1,4 +1,4 @@
-//! The test a thread is running, named on stdout for the e2e runner.
+//! The test a thread is running, named on stderr for the e2e runner.
 //!
 //! libtest writes a test's name before it runs only when there is one test
 //! thread; on more it writes nothing until the test finishes, so a process
@@ -6,6 +6,12 @@
 //! were and the runner has to run every test left to find out. A test that
 //! reaches `d3d9.dll` names itself here instead, and the runner reads the
 //! names it has no outcome line for as the set that was in flight.
+//!
+//! The name goes to stderr because libtest's report goes to stdout, and a
+//! result line there is three writes: the name, the outcome word, and the
+//! newline. A print from a test thread that lands between the last two
+//! joins the result and the announcement into one line, which is a result
+//! the runner has to work to read back.
 //!
 //! The name is the thread's, because libtest runs every test on a thread
 //! named after it, at any thread count. The main thread is skipped: libtest
@@ -15,7 +21,7 @@
 
 use std::{cell::Cell, thread};
 
-/// The stdout marker; what follows it is the test's libtest path.
+/// The stderr marker; what follows it is the test's libtest path.
 const RUNNING: &str = "[e2e] running ";
 
 thread_local! {
@@ -23,7 +29,7 @@ thread_local! {
     static NAMED: Cell<bool> = const { Cell::new(false) };
 }
 
-/// Name the test this thread runs on stdout, once per thread.
+/// Name the test this thread runs on stderr, once per thread.
 pub fn announce() {
     if NAMED.with(|named| named.replace(true)) {
         return;
@@ -32,5 +38,5 @@ pub fn announce() {
     let Some(name) = thread.name().filter(|name| *name != "main") else {
         return;
     };
-    println!("{RUNNING}{name}");
+    eprintln!("{RUNNING}{name}");
 }


### PR DESCRIPTION
## Symptoms

One x86_64 end-to-end leg reported `Summary: 474 tests: 474 passed, 0 failed, 0 ignored, 0 not run; 4 processes` for a binary that carries 475 tests, with no note and an exit status of 0. `e2e::clip_planes::state_block_all_captures_and_restores_the_planes` was neither reported nor named as missing, and every other leg of the same tree ran it. A green run reported on a smaller suite than it was asked for and nothing said so.

## Root cause

libtest's pretty formatter writes a result line to stdout in three writes: `test <name> ... `, then the outcome word, then the newline (`write_result` in the toolchain's `library/test/src/formatters/pretty.rs` calls `write_test_name`, `write_ok`/`write_failed`/`write_ignored`, then `write_plain("\n")`, each flushed). The tests run with `--nocapture` and, on more than one test thread, every test names itself on stdout from the shared harness so the runner knows what was in flight when a process dies. A `println!` from a test thread that lands between the outcome word and its newline joins the two into one line: `test a ... ok[e2e] running b`, followed by libtest's newline as an empty line.

`Parser::line` matched the outcome exactly, so that tail was not an outcome, the line was taken as a start, and the result was dropped when the next real result line replaced the pending start. The runner's total is its own tally of `Finished` events and it was never compared with the `passed`/`failed`/`ignored` counts on libtest's `test result:` line, so a lost line became a smaller suite instead of a discrepancy. The tear itself is conjecture consistent with both sources; the raw stdout of the affected run was not kept.

## Changes

The in-flight announcement moves from stdout to stderr (`windows/tests/src/in_flight.rs`), where it cannot reach a line libtest is writing, and the runner reads it from `end.stderr`. A hand-run of the x86_64 `e2e` binary on four threads now shows only libtest's report on stdout and the three `[e2e] running` lines on stderr.

The parser accepts an outcome with text behind it and reads that text as a line of its own, for `test <name> ... <outcome>` and for a bare outcome closing a started test. An outcome word is only read as one when what follows it cannot continue the word, so a print that itself opens with `okay` is still a print. `ignored` carries a free-text reason that nothing tells from a print, so nothing is read after it.

A clean process is now checked against libtest's own account before the binary is done. `Summary::counted` is the results libtest says it printed; a tally short of that means a result never arrived. The tests with no outcome are named out of the selection, or out of `--list` when the whole binary ran, and run again in a fresh process. Only naming them costs a `--list`, so a run where everything adds up spawns no extra process and the `processes` count in the summary is unchanged. A process that reports none of the tests it was narrowed to fails them rather than looping, and a test that ends its own process is exempt because libtest never reaches its summary line.

`CONTRIBUTING.md` gains the new note shape in its section on reading a test run.

## Alternatives

Read the announcements from stdout and only harden the parser: rejected, it leaves every future stdout print one write away from the same class of bug.

Cross-check every clean process against `--list`: rejected, it costs one Wine process per binary per run on the happy path to check what libtest's own counts already answer.

Give up the announcements and narrow a dead process by running everything left one at a time: rejected, that is the cost the announcements were added to avoid.

## Verification

`make fmt`, `make check` green (audit clean, 303 files).

`make ISOLATED=1 test`: native units 1091 passed across 3 binaries and 280 passed (1 leaky) across 4; end-to-end 477 PASS, 0 FAIL, 0 SKIP, 4 processes on i686 and the same on x86_64, exit 0. `make ISOLATED=1 test-e2e-x86_64 JOBS=4 FILTER='e2e::clip_planes e2e::vertex_decl'` reports 13 of 13, the lost test among them, in one process.

New unit tests, all of which fail on the parser and the loop as they stand: `libtest::tests::a_print_behind_an_outcome_does_not_lose_the_result` feeds `test a ... ok[e2e] running b` and the empty line libtest's newline leaves, and asserts the result is read; `a_print_that_opens_like_an_outcome_is_not_read_as_one` pins the word boundary; `attribute::tests::a_torn_result_line_costs_no_note_and_no_process` runs that stdout through the whole loop and asserts one process and no note; `a_tally_short_of_the_summary_is_noted_and_run_again` asserts the note names the test with no outcome, that only it runs again, and that the run reports on all three tests; `a_result_lost_twice_fails_its_test` asserts the second round fails it instead of looping. The two scripted launchers that fed announcements on stdout now feed them on stderr.

Closes #471
