### PR TITLE
Run the e2e suite four tests at a time by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,11 +216,11 @@ jobs:
       - uses: ./.github/actions/runner
         with:
           wine-release: ${{ env.WINE_RELEASE }}
-      # One test at a time (`JOBS=1`): concurrent device creation aborts or
-      # hangs on the paravirtual GPU. The whole suite is reported rather than
-      # the first failure, and a test that is only slow there gets four
-      # minutes before it counts as a hang. A dispatch with `e2e_filter`
-      # narrows the run.
+      # One test at a time (`JOBS=1`, against the Makefile's default of four):
+      # concurrent device creation aborts or hangs on the paravirtual GPU
+      # these images have. The whole suite is reported rather than the first
+      # failure, and a test that is only slow there gets four minutes before
+      # it counts as a hang. A dispatch with `e2e_filter` narrows the run.
       # The layer's log of every test process, and the whole stderr of every
       # process that died with tests unaccounted for, go under the runner's
       # temp directory, where the step below picks them up, rather than beside

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,16 +77,17 @@ that touches `docs/CONVENTIONS.md`.
 
 The end-to-end suite is four test binaries per architecture, and the runner
 in `unix/e2e` runs each one once under Wine with every test of the binary on
-`JOBS` threads of that process (one at a time by default; the Makefile says
-what a higher `JOBS` waits for). It prints one `PASS`/`FAIL`/`SKIP` line per test and a
-summary that counts every test, so the summary is the thing to read; a
-failure is fatal to the default run (`FAIL_FAST=0` reports the whole suite).
-One trap remains: a pipeline reports the last stage's status, so
-`make test | tee log` returns the exit code of `tee`. Capture with a plain
-redirect, `make test > out.log 2>&1`, and judge the run by the runner's
-summary on both architectures. mtld3d's log of each test process is a file,
-`<binary>-<pid>.log` under `mtld3d-logs` next to the test executable in
-`windows/target`, one per process, so one file carries the whole suite's log.
+`JOBS` threads of that process (four at a time by default; the Makefile says
+what that assumes of the Wine it runs under). It prints one
+`PASS`/`FAIL`/`SKIP` line per test and a summary that counts every test, so
+the summary is the thing to read; a failure is fatal to the default run
+(`FAIL_FAST=0` reports the whole suite). One trap remains: a pipeline
+reports the last stage's status, so `make test | tee log` returns the exit
+code of `tee`. Capture with a plain redirect, `make test > out.log 2>&1`,
+and judge the run by the runner's summary on both architectures. mtld3d's
+log of each test process is a file, `<binary>-<pid>.log` under `mtld3d-logs`
+next to the test executable in `windows/target`, one per process, so one
+file carries the whole suite's log.
 
 A process that ends cleanly is still checked against libtest's own account.
 Its `test result:` line counts the results it printed, and a runner tally
@@ -301,9 +302,9 @@ where a real Intel/AMD Mac's driver does not. On an Apple-family machine the
 forced answers (`make test INTEL=1`, `make conformance-intel`) are the way to
 run the Intel paths without the hardware.
 
-The end-to-end legs run one test at a time in CI on purpose (`JOBS=1`),
-because parallel device creation aborts on a runner. A flake there is not
-fixed by re-enabling parallelism.
+The end-to-end legs run one test at a time in CI on purpose (`JOBS=1`, against
+a local default of four), because parallel device creation aborts on a runner.
+A flake there is not fixed by re-enabling parallelism.
 
 ## What sends a pull request back
 

--- a/Makefile
+++ b/Makefile
@@ -737,22 +737,33 @@ test-unit:
 # test rather than stopping at a summary.
 #
 # JOBS=<n> is how many tests run at once, each on its own thread with its
-# own device. The default is 1 until the Wine SDK carries the Mac driver fix
-# for a lock-order inversion its D3DMetal client-surface hack has:
-# `macdrv_DestroyWindow` releases those surfaces while it holds the window
-# data, taking win32u's surface lock, and every other window update
-# (`update_client_surfaces`, `detach_client_surfaces`) takes the two the
-# other way round, so a window torn down on one thread while another thread
-# creates, moves or destroys its own deadlocks the process. The runner's
-# watchdog then charges the hang and runs the rest one at a time, so a
-# `JOBS=4` run is correct today but slow (the suite is ~10 s when the
-# deadlock stays away and ~130 s when it hits); a CI runner, whose device
-# creation cannot overlap at all, stays at 1 either way. TIMEOUT=<secs> is
-# how long a process may go without reporting a result before the runner
-# kills it and charges the hang to the test that was running (default 60);
-# the same bound covers a process that has closed stdout but will not exit.
-# A process tree that keeps stderr open after the process is gone gets a
-# one-second grace, not the bound: nothing it says after that is the test's.
+# own device. Four rather than one is not about wall time, which it barely
+# moves. A parallel run is the only thing here that keeps several devices
+# alive at once, which is what a game does with a launcher or an overlay
+# beside it, so it is what holds the per-device rule: what one device owns
+# is keyed by that device, and a process-wide registry keyed without one
+# hands two devices each other's work.
+#
+# The default of 4 assumes a Wine built from `cx-26-patched` at or after
+# the winemac change that releases the D3DMetal client surfaces outside the
+# window data lock; no wine-build release up to `cx-26.3.0-3` carries it.
+# Without it the two locks are taken in both orders (`macdrv_DestroyWindow`
+# holds the window data and takes win32u's surface lock,
+# `update_client_surfaces` and `detach_client_surfaces` the other way
+# round), so a window torn down on one thread while another thread creates,
+# moves or destroys its own deadlocks the process. The report is still
+# right there, because the watchdog charges the hang and runs the rest one
+# at a time, but the suite takes ~130 s instead of ~10 s and JOBS=1 avoids
+# it outright. CI passes JOBS=1 for a reason of its own, that device
+# creation cannot overlap on a paravirtual GPU, so its value says nothing
+# about this default.
+#
+# TIMEOUT=<secs> is how long a process may go without reporting a result
+# before the runner kills it and charges the hang to the test that was
+# running (default 60); the same bound covers a process that has closed
+# stdout but will not exit. A process tree that keeps stderr open after the
+# process is gone gets a one-second grace, not the bound: nothing it says
+# after that is the test's.
 #
 # A scaled or Intel-variant run reports the whole suite instead of stopping at
 # the first failure, and FAIL_FAST=0 asks for that on any run. The point of
@@ -765,7 +776,7 @@ test-unit:
 # path>`, e.g. `e2e::msaa::resolve_counts_edge_pixels`) contains any of the
 # whitespace-separated patterns: `msaa::` is one file, `stencil` every test
 # with the word. A filter that selects nothing passes.
-JOBS ?= 1
+JOBS ?= 4
 TIMEOUT ?= 60
 E2E_FLAGS := --jobs $(JOBS) --timeout $(TIMEOUT) $(if $(filter 0,$(FAIL_FAST))$(SCALE)$(INTEL),--no-fail-fast) $(if $(FILTER),--filter '$(FILTER)') $(if $(LOG_DIR),--log-dir '$(LOG_DIR)')
 


### PR DESCRIPTION
## Symptoms

`JOBS ?= 1` made `make test` run the e2e suite one test at a time, so nothing in the tree kept two D3D devices alive at once. That is the shape a game has with a launcher or an overlay beside it, and it was untested: the crossings in #388, #445 and the queue-keyed caches around it were all a process-wide registry keyed without a device, and none of them could be reached with one device at a time.

The default was 1 because a parallel run could not be trusted. winemac's D3DMetal client-surface hack took the window data lock and win32u's surface lock in one order while every other window update took them in the other, so one thread destroying its window while another created or moved its own deadlocked the Wine process. `PENDING_CMDBUFS` keyed by `submit_seq` alone collided across two live devices, which Metal aborted as `waitUntilCompleted on uncommitted command buffer`. The readback scratch and the MetalFX scalers were process-wide maps keyed by size and format alone, so two devices at one back-buffer size shared them across queues. And the environment-isolation pin read `MTLD3D_CONFIG` without the harness lock.

## Changes

`JOBS ?= 4` in the Makefile.

The `JOBS` paragraph of the `test-e2e-*` comment block is rewritten. It said the default was 1 until the Wine SDK carried a Mac driver fix; that fix has landed on `cx-26-patched`, so the comment now states what the default is for and what it assumes:

- Why four rather than one, as the invariant it holds: a parallel run is the only thing here that keeps several devices alive at once, so what one device owns is keyed by that device, and a process-wide registry keyed without one hands two devices each other's work.
- What it assumes of the Wine it runs under, and what an older Wine costs. No wine-build release up to `cx-26.3.0-3` carries the winemac change; without it the watchdog charges the hang and re-runs the rest one at a time, so the report is still right and the run is slow.
- That CI's `JOBS=1` is for a reason of its own, that device creation cannot overlap on a paravirtual GPU, so its value says nothing about this default.

`CONTRIBUTING.md` says four at a time rather than one in "Reading a test run", and the CI paragraph now reads as a deliberate departure from the local default rather than as the default. The `ci.yml` comment says the same, so its explicit `JOBS=1` does not look redundant with the Makefile.

No behaviour change in CI: the e2e job passes `JOBS=1` explicitly and still does.

## Alternatives

Derive the default from the core count. Rejected: it makes a run non-reproducible across machines and hides the deliberate cap.

Pin a wine-build release carrying the winemac fix first, and raise the default after. Rejected: that bump also brings the SDK's `compatdb.so` work and a new `d3d9_test.exe`, which is a conformance-baseline question and belongs in its own change. An older Wine degrades rather than breaks here, and the comment says so.

Raise the default further. `JOBS=8` passed a single run once the window-move latch was keyed per window, but one run is not grounds to raise a default on, and it is no faster.

## Verification

`make check` and `make test-unit` green.

Five whole-suite runs per PE arch at the new default with `FAIL_FAST=0`, all ten reporting `478 tests: 478 passed, 0 failed, 0 ignored, 0 not run; 4 processes`, none of them re-running a process the runner had lost.

Three alternating runs per arch on a warm tree give a median of 16.5 s a leg at `JOBS=1` against 16 s at `JOBS=4`. The parallel run neither costs nor saves anything measurable, which is the point: it buys the concurrent-device coverage, not the clock. That it saves nothing is itself a defect and is filed as #473, with the measurements and the two causes ruled out by experiment.

The gates that enforce what this touches are `make check` (the audit reads the Makefile and the docs) and `make test`, which is the target whose default this changes; both ran green above. Nothing here adds a static, a config key, a wire field, a dependency, a derive, a lint suppression, an environment variable, or a file, so no derive inventory, `COVERAGE.md` row, config sample entry or conventions digest is due.
