### PR TITLE
Read AppKit display properties on the main thread and update CI Wine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ env:
   # Vulkan instance through it at every prefix boot; on the Intel image's
   # paravirtual device that made Metal abort inside explorer.exe, so no prefix
   # ever booted there.
-  WINE_RELEASE: cx-26.3.0-2
+  WINE_RELEASE: cx-26.3.0-4
   RUST_STABLE: 1.97.1
   RUST_NIGHTLY: nightly-2026-08-18
   CARGO_TOOLS: xwin@0.10.0

--- a/unix/unix/src/metal/macdrv.rs
+++ b/unix/unix/src/metal/macdrv.rs
@@ -843,7 +843,14 @@ pub fn attach_metal_layer(
     // SAFETY: `win_data` is non-null per the check above and points to a
     // wine-macdrv `struct macdrv_win_data` valid until `release_win_data`.
     let client_view = unsafe { (*win_data).client_cocoa_view };
-    let hint = view_display_caps(client_view);
+    // The window-data lock keeps the view alive across the dispatch. AppKit
+    // owns its window and screen relationships on the main thread.
+    let mut hint = None;
+    run_on_main_thread_sync(|| {
+        let mtm = objc2::MainThreadMarker::new().expect("display lookup runs on the main thread");
+        hint = Some(view_display_caps(client_view, mtm));
+    });
+    let hint = hint.expect("synchronous display lookup completed");
     // SAFETY: `macdrv_view_create_metal_view` is the dlsym'd wine export;
     // `client_view` is the Cocoa view we just read from `win_data`.
     let view = unsafe {
@@ -1200,13 +1207,8 @@ impl MacdrvFuncs {
 /// The colorspace flows through to `configure_metal_layer_inner` and drives
 /// the layer's `colorspace` property — SDR uses it directly (identity = max
 /// vibrance per display), HDR classifies it into an extended-linear variant.
-fn view_display_caps(view: *mut c_void) -> DisplayHint {
-    use objc2::MainThreadMarker;
+fn view_display_caps(view: *mut c_void, mtm: objc2::MainThreadMarker) -> DisplayHint {
     use objc2_app_kit::{NSScreen, NSView};
-
-    // SAFETY: see `set_display_sync_enabled` for the off-main-thread
-    // NSScreen rationale — we read static display capabilities only.
-    let mtm = unsafe { MainThreadMarker::new_unchecked() };
 
     // Prefer the NSScreen attached to the view's window so
     // multi-monitor setups with mixed scales pick the right display;


### PR DESCRIPTION
The attach path reads `NSView.window`, `NSWindow.screen`, and `NSScreen.colorSpace` on the calling Wine thread. A runtime getter probe captured all three off-main beneath `attach_metal_layer`. Wine's window-data lock protects the view from concurrent destruction, but it does not make these AppKit accesses safe off the main thread.

Dispatch the display snapshot through the existing synchronous main-thread helper while holding the Wine lock, then pass a checked `MainThreadMarker` into `view_display_caps`. This removes its unchecked marker and adds one main-thread hop per attachment, with no per-frame work.

Keeping the direct reads under the Wine lock was considered, but that lock only protects Wine's window data; AppKit manages the view/window/screen relationships on its own thread. Serializing the entire test harness would leave the application's attach path unchanged.

CI also pins Wine to [`cx-26.3.0-4`](https://github.com/athei/wine-build/releases/tag/cx-26.3.0-4). The shared `WINE_RELEASE` value feeds every SDK download and the cache keys, so this selects a fresh cache for the new release.

Refs #461. This fixes the demonstrated off-main access. Its connection to the rare AppKit autorelease-pool crash remains unproven, so this PR does not close that issue.

## Verification

- `WINE_SDK=<Wine SDK> make check`: passed on current main plus this change, including fmt, clippy, audit, and docs.
- `WINE_SDK=<Wine SDK> make test ISOLATED=1 JOBS=4 FAIL_FAST=0`: passed on current main plus this change; 1,091 core/type unit tests, 280 unix-workspace tests, and 478 e2e tests per PE architecture, four processes each.
- Before the borderless-harness change in #475, the same 20 render-scale tests under the getter probe changed from three off-main observations to six main-thread observations and zero off-main observations. Another 124 architecture-specific full-suite runs with this fix passed with no process deaths. Those runs used the earlier framed harness and are not a validation of the new harness or proof that #461 is resolved.

The published release contains `wine-cx-26.3.0-4-macos-x86_64.tar.xz`, matching the workflow download paths. The local test runs used the private clone of the existing Wine fork build at `935cf02c317`; the newly pinned release will be exercised by PR CI.

Rules check: no new static, config key, wire field, dependency, derive, lint suppression, or public API. The Wine pin update is included at the maintainer's request. The AppKit change reuses the existing dispatcher and keeps the raw view under Wine's existing lock. No shader, render-state, or conformance classification changes.
