### PR TITLE
Avoid secondary faults while scanning crash stacks

### DIFF
--- a/unix/unix/src/crash.rs
+++ b/unix/unix/src/crash.rs
@@ -100,6 +100,28 @@ static PREV: [PrevDisposition; 4] = [
 /// reads the atomic.
 static WINE_CURRENT_TEB: AtomicUsize = AtomicUsize::new(0);
 
+// macOS interfaces absent or deprecated in libc, provided by libSystem.
+unsafe extern "C" {
+    static mut mach_task_self_: libc::mach_port_t;
+    fn mach_vm_read_overwrite(
+        target_task: libc::vm_map_t,
+        address: libc::mach_vm_address_t,
+        size: libc::mach_vm_size_t,
+        data: libc::mach_vm_address_t,
+        outsize: *mut libc::mach_vm_size_t,
+    ) -> libc::kern_return_t;
+    fn backtrace(array: *mut *mut c_void, size: c_int) -> c_int;
+    fn backtrace_symbols_fd(array: *const *mut c_void, size: c_int, fd: c_int);
+    /// macOS `pthread_getname_np` (not exposed by the `libc` crate).
+    ///
+    /// Reads the calling thread's name into `buf`.
+    fn pthread_getname_np(
+        thread: libc::pthread_t,
+        buf: *mut core::ffi::c_char,
+        len: usize,
+    ) -> c_int;
+}
+
 /// Index into [`PREV`] for a signal we handle, or `None` for anything else.
 const fn signal_slot(signo: c_int) -> Option<usize> {
     match signo {
@@ -569,9 +591,9 @@ fn report_foreign_fault(signo: c_int, ctx: *mut c_void, terminal: bool) {
     }
 
     // The faulting stack. The fault may be one Wine recovers, so the scan
-    // must not fault itself: it probes each page before reading it rather
-    // than trusting a stack bound, since a Wine thread runs its unix calls
-    // on a stack Wine allocated, not the one its pthread record names.
+    // must not fault itself: the kernel copies each word or reports failure.
+    // A mapping probe cannot establish readability, and a Wine thread runs
+    // unix calls on a stack Wine allocated, not its pthread stack.
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     {
         let sp = mcontext_u64(ctx, SP_OFFSET);
@@ -635,10 +657,10 @@ fn push_thread_name(buf: &mut [u8; 192], pos: &mut usize) {
 ///
 /// Walks up to 4096 words from `sp` and `backtrace_symbols_fd`-prints each
 /// value that `dladdr` resolves into a module whose path contains `mtld3d`.
-/// Caps the printed count so a deep stack can't flood. Async-signal-safe: only
-/// `dladdr` (no malloc on the resolve path here) + `backtrace_symbols_fd` + raw
-/// stack reads. Arch-neutral: a spilled return address is a stack word on both
-/// arches, and the 4-byte step below already tolerates either alignment.
+/// Caps the printed count so a deep stack can't flood. Stack words are copied
+/// by the kernel into local storage, without dereferencing the faulting stack.
+/// Arch-neutral: a spilled return address is a stack word on both arches, and
+/// the 4-byte step below already tolerates either alignment.
 fn scan_stack_for_our_frames(sp: u64) {
     /// Header for the guest-stack pass below.
     const GUEST_HDR: &[u8] = b"[mtld3d::unix] guest (PE) stack words:\n";
@@ -646,7 +668,6 @@ fn scan_stack_for_our_frames(sp: u64) {
     const GUEST_CAP: u32 = 64;
 
     our_frames_on_stack(sp, STACK_SCAN_WORDS);
-    let base = sp as *const u8;
     // Second pass: the 32-bit guest stack. `dladdr` can't see Wine's PE
     // builtins (not dyld images), so collect raw 4-byte words that land in the
     // PE-builtin zone [0x7A00_0000, 0x7C00_0000) (ntdll/user32/win32u/d3d9/…)
@@ -666,11 +687,10 @@ fn scan_stack_for_our_frames(sp: u64) {
     let mut guest_printed = 0u32;
     let mut slot = 0usize;
     while slot < STACK_SCAN_WORDS && guest_printed < GUEST_CAP {
-        // SAFETY: as the loop above, an offset into stack memory near `sp`.
-        let word = unsafe { base.add(slot * 4) };
-        // SAFETY: as above; an unmapped read re-faults into the re-entrancy
-        // guard, bounding the walk.
-        let guest_addr = unsafe { word.cast::<u32>().read_unaligned() };
+        let Some(bytes) = stack_word(sp, slot) else {
+            break;
+        };
+        let guest_addr = u32::from_ne_bytes(bytes);
         let in_builtin = (0x7A00_0000..0x7C00_0000).contains(&guest_addr);
         let in_exe = (0x0040_0000..0x0080_0000).contains(&guest_addr);
         if in_builtin || in_exe {
@@ -702,27 +722,13 @@ fn our_frames_on_stack(sp: u64, words: usize) {
     /// Print cap for the pass.
     const OURS_CAP: u32 = 48;
 
-    let base = sp as *const u8;
     let mut printed = 0u32;
     let mut slot = 0usize;
-    let mut probed_page = 0u64;
     while slot < words && printed < OURS_CAP {
-        // The word plus the seven bytes after it; a read that would cross
-        // into a page nobody mapped ends the walk instead of faulting.
-        let end = sp.wrapping_add((slot * 4) as u64 + 7);
-        let page = page_of(end);
-        if page != probed_page {
-            if !page_is_mapped(page) {
-                break;
-            }
-            probed_page = page;
-        }
-        // SAFETY: an offset into stack memory near `sp`, on a page the probe
-        // above found mapped.
-        let word = unsafe { base.add(slot * 4) };
-        // SAFETY: as above; `read_unaligned` tolerates a 4-byte-aligned 32-bit
-        // stack.
-        let addr = unsafe { word.cast::<u64>().read_unaligned() };
+        let Some(bytes) = stack_word(sp, slot) else {
+            break;
+        };
+        let addr = u64::from_ne_bytes(bytes);
         if addr >= 0x1000 && dladdr_is_ours(addr) {
             let mut frame = [addr as *mut c_void; 1];
             // SAFETY: single in-bounds frame pointer; `backtrace_symbols_fd`
@@ -734,24 +740,48 @@ fn our_frames_on_stack(sp: u64, words: usize) {
     }
 }
 
-/// The page `addr` lies on.
-fn page_of(addr: u64) -> u64 {
-    // SAFETY: `sysconf` reads a constant.
-    let page = u64::try_from(unsafe { libc::sysconf(libc::_SC_PAGESIZE) })
-        .unwrap_or(4096)
-        .max(1);
-    addr & !(page - 1)
-}
-
-/// Whether the page at `page` is mapped, asked of the kernel rather than found out by a fault.
+/// Copy a stack word without dereferencing the faulting stack.
 ///
-/// `mincore` answers `ENOMEM` for an address no mapping covers and is a
-/// plain system call, which is what a signal handler can afford.
-fn page_is_mapped(page: u64) -> bool {
-    let mut vec = [0i8; 1];
-    // SAFETY: `mincore` reads no user memory but the one-byte out vector.
-    let rc = unsafe { libc::mincore(page as *const c_void, 1, vec.as_mut_ptr()) };
-    rc == 0
+/// The Mach call copies into fixed local storage and returns an error for an
+/// unreadable source, including a mapping whose protection changes during the
+/// copy. Only a complete copy is used. No allocation or logger lock is needed;
+/// a failed read writes directly to the crash descriptor and ends that scan.
+fn stack_word<const N: usize>(sp: u64, slot: usize) -> Option<[u8; N]> {
+    const UNREADABLE: &[u8] = b"[mtld3d::unix] stack read unavailable, stopping scan\n";
+
+    let address = slot
+        .checked_mul(4)
+        .and_then(|offset| sp.checked_add(offset as u64))
+        .filter(|address| address.checked_add(N as u64).is_some());
+    if let Some(address) = address {
+        let mut bytes = [0u8; N];
+        let mut copied = 0;
+        // SAFETY: reads libSystem's task port for this process.
+        let task = unsafe { mach_task_self_ };
+        // SAFETY: the kernel validates the source address. The destination
+        // holds N writable bytes, and `copied` is a live size out-parameter.
+        let status = unsafe {
+            mach_vm_read_overwrite(
+                task,
+                address,
+                N as u64,
+                bytes.as_mut_ptr() as usize as u64,
+                &raw mut copied,
+            )
+        };
+        if status == libc::KERN_SUCCESS && copied == N as u64 {
+            return Some(bytes);
+        }
+    }
+    // SAFETY: write(2) is async-signal-safe; the bytes have static storage.
+    unsafe {
+        let _ = libc::write(
+            crate::log_file::raw_fd(),
+            UNREADABLE.as_ptr().cast::<c_void>(),
+            UNREADABLE.len(),
+        );
+    }
+    None
 }
 
 /// What dyld knows about `addr`: its image, and the nearest symbol below it.
@@ -867,17 +897,10 @@ const CALLER_LABEL: &[u8] = b"caller(lr)=";
 ///
 /// `x86_64` `CALL` pushes it, so for a jump-through-garbage fault (which faults
 /// at the callee's first instruction, before any prologue) it is the word at
-/// `[rsp]`; a bad `rsp` re-faults into the re-entrancy guard rather than
-/// looping.
+/// `[rsp]`; an unreadable `rsp` reports no return address.
 #[cfg(target_arch = "x86_64")]
 fn caller_pc(_ctx: *mut c_void, sp: u64) -> u64 {
-    if sp == 0 {
-        return 0;
-    }
-    // SAFETY: `sp` is the faulting stack pointer, whose top word is the return
-    // address the faulting `CALL` pushed. An unmapped read terminates through
-    // the re-entrancy guard.
-    unsafe { (sp as *const u64).read() }
+    stack_word(sp, 0).map_or(0, u64::from_ne_bytes)
 }
 
 /// The return address of the frame that faulted, or 0 if it can't be read.
@@ -954,21 +977,6 @@ const fn mcontext_u64(ctx: *mut c_void, offset: usize) -> u64 {
     let field = unsafe { mctx.add(offset) };
     // SAFETY: reads the saved register (unaligned-safe, no write).
     unsafe { field.cast::<u64>().read_unaligned() }
-}
-
-// Declared here because the `libc` crate does not expose the macOS
-// `<execinfo.h>` family; both live in libSystem, which is always linked.
-unsafe extern "C" {
-    fn backtrace(array: *mut *mut c_void, size: c_int) -> c_int;
-    fn backtrace_symbols_fd(array: *const *mut c_void, size: c_int, fd: c_int);
-    /// macOS `pthread_getname_np` (not exposed by the `libc` crate).
-    ///
-    /// Reads the calling thread's name into `buf`.
-    fn pthread_getname_np(
-        thread: libc::pthread_t,
-        buf: *mut core::ffi::c_char,
-        len: usize,
-    ) -> c_int;
 }
 
 const fn signal_name(signo: libc::c_int) -> &'static [u8] {

--- a/unix/unix/src/crash/tests.rs
+++ b/unix/unix/src/crash/tests.rs
@@ -38,6 +38,9 @@ const ILL_SELFTEST_ENV: &str = "MTLD3D_CRASH_ILL_SELFTEST";
 /// Set in the re-executed child so its foreign fault has no TEB behind it.
 const NO_TEB_SELFTEST_ENV: &str = "MTLD3D_CRASH_NO_TEB_SELFTEST";
 
+/// Set in a child that scans across a protected stack boundary.
+const STACK_SELFTEST_ENV: &str = "MTLD3D_CRASH_STACK_SELFTEST";
+
 /// The byte a stand-in TEB pointer points at; only its address is ever used.
 static FAKE_TEB: u8 = 0;
 
@@ -309,4 +312,141 @@ fn illegal_instruction_in_our_code_is_fatal() {
     let report = String::from_utf8_lossy(&out.stderr);
     assert_eq!(out.status.code(), Some(1), "{report}");
     assert!(report.contains("FATAL: SIGILL"), "{report}");
+}
+
+#[test]
+fn native_stack_scan_stops_at_unreadable_memory() {
+    check_stack_boundaries(
+        "crash::tests::native_stack_scan_stops_at_unreadable_memory",
+        |sp| super::our_frames_on_stack(sp, 16),
+    );
+}
+
+#[test]
+fn stack_words_preserve_unaligned_values() {
+    let bytes = [
+        0x11u8, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+    ];
+    let sp = bytes.as_ptr() as usize as u64 + 1;
+    assert_eq!(
+        super::stack_word::<4>(sp, 0),
+        Some([0x22, 0x33, 0x44, 0x55])
+    );
+    assert_eq!(
+        super::stack_word::<8>(sp, 1),
+        Some([0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd])
+    );
+    assert_eq!(super::stack_word::<8>(sp, usize::MAX), None);
+    assert_eq!(super::stack_word::<4>(u64::MAX - 1, 1), None);
+}
+
+#[test]
+fn unreadable_stack_does_not_prevent_signal_forwarding() {
+    check_stack_boundaries(
+        "crash::tests::unreadable_stack_does_not_prevent_signal_forwarding",
+        forward_with_stack,
+    );
+}
+
+/// A previous signal owner reached with the original signal ends the child successfully.
+extern "C" fn forwarded_signal(signo: libc::c_int, _info: *mut libc::siginfo_t, _ctx: *mut c_void) {
+    // SAFETY: ends only the regression-test child, without running exit hooks.
+    unsafe { libc::_exit(i32::from(signo != libc::SIGSEGV)) }
+}
+
+/// Run the real handler with a foreign PC and a stack that ends at a guard page.
+fn forward_with_stack(sp: u64) {
+    // SAFETY: all-zero sigaction is a valid starting value for initialization.
+    let mut action: libc::sigaction = unsafe { core::mem::zeroed() };
+    action.sa_sigaction = forwarded_signal as *const () as usize;
+    action.sa_flags = libc::SA_SIGINFO;
+    // SAFETY: action contains a valid mask out-parameter.
+    assert_eq!(unsafe { libc::sigemptyset(&raw mut action.sa_mask) }, 0);
+    assert_eq!(
+        // SAFETY: installs a correctly typed handler in this child process only.
+        unsafe { libc::sigaction(libc::SIGSEGV, &raw const action, ptr::null_mut()) },
+        0
+    );
+    super::install();
+
+    // Model the kernel-owned context with live, aligned local storage. Only
+    // the register slots read by the handler need nonzero values.
+    let mut registers = [0u64; 40];
+    #[cfg(target_arch = "x86_64")]
+    let pc_slot = 144 / 8;
+    #[cfg(target_arch = "aarch64")]
+    let pc_slot = 272 / 8;
+    registers[pc_slot] = libc::strlen as *const () as usize as u64;
+    registers[super::SP_OFFSET / 8] = sp;
+    let mut context = [0u64; 7];
+    context[0x30 / 8] = registers.as_ptr() as usize as u64;
+    super::handler(libc::SIGSEGV, ptr::null_mut(), context.as_mut_ptr().cast());
+    unreachable!("the previous signal owner must terminate the child");
+}
+
+#[test]
+fn guest_stack_scan_stops_at_unreadable_memory() {
+    check_stack_boundaries(
+        "crash::tests::guest_stack_scan_stops_at_unreadable_memory",
+        super::scan_stack_for_our_frames,
+    );
+}
+
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn caller_stack_read_tolerates_unreadable_memory() {
+    check_stack_boundaries(
+        "crash::tests::caller_stack_read_tolerates_unreadable_memory",
+        |sp| assert_eq!(super::caller_pc(ptr::null_mut(), sp), 0),
+    );
+}
+
+/// Exercise stack readers in a child so an unsafe read fails one test only.
+///
+/// The first page is readable and zero-filled, the second is mapped with no
+/// access. Reads start just before the boundary, on it, and after unmapping
+/// both pages; overflowing addresses must also return without a signal.
+fn check_stack_boundaries(test: &str, scan: fn(u64)) {
+    if std::env::var_os(STACK_SELFTEST_ENV).is_some() {
+        // SAFETY: sysconf reads the process's constant page size.
+        let page = usize::try_from(unsafe { libc::sysconf(libc::_SC_PAGESIZE) })
+            .expect("positive page size");
+        // SAFETY: anonymous mapping with no fixed address or backing file.
+        let mapping = unsafe {
+            libc::mmap(
+                ptr::null_mut(),
+                page * 2,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANON,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(mapping, libc::MAP_FAILED);
+        let base = mapping as usize as u64;
+        let boundary = base + page as u64;
+        // SAFETY: the second page is inside the live mapping and page-aligned.
+        let protected = unsafe { libc::mprotect(boundary as *mut c_void, page, libc::PROT_NONE) };
+        assert_eq!(protected, 0);
+        scan(boundary - 8);
+        scan(boundary - 4);
+        scan(boundary - 2);
+        scan(boundary);
+        // SAFETY: releases the complete mapping created above, exactly once.
+        assert_eq!(unsafe { libc::munmap(mapping, page * 2) }, 0);
+        scan(base);
+        scan(0);
+        scan(u64::MAX - 3);
+        return;
+    }
+
+    let out = std::process::Command::new(std::env::current_exe().expect("test binary path"))
+        .args(["--exact", test, "--nocapture"])
+        .env(STACK_SELFTEST_ENV, "1")
+        .output()
+        .expect("re-exec the test binary");
+    let report = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "{}: {report}", out.status);
+    assert!(!report.contains("FATAL"), "{report}");
+    assert!(report.contains("stack read unavailable"), "{report}");
 }


### PR DESCRIPTION
GTA IV could die during startup while mtld3d was reporting a fault outside its own image. The report ended with `[mtld3d::unix] FATAL: SIGBUS fault=0x0000000003500000`, and the faulting instruction was the stack read in `our_frames_on_stack`, before the original signal reached Wine.

The scanner used `mincore` to check whether a page was mapped, then dereferenced it. A mapped page can still be unreadable. The guest-stack scan and the x86_64 return-address read also dereferenced the faulting stack directly.

## Fix

Use `mach_vm_read_overwrite` to copy each stack word into fixed local storage. Accept only a successful, complete copy, reject address arithmetic overflow, and stop the scan with a raw diagnostic when a read fails. The native scan, guest scan, and saved return-address read share this helper. Scan limits, four-byte stepping, and signal forwarding remain unchanged.

Checking page protections before dereferencing would still leave a race with unmapping or protection changes. Kernel-mediated copying reports a failed read without requiring the crash handler to touch the source memory itself. It adds a kernel call per inspected word, confined to the bounded diagnostic scan.

## Verification

- Before the fix, all three protected-stack subprocess regressions failed with SIGBUS. After the fix, they pass. Coverage includes readable and unaligned words, protected and unmapped pages, reads crossing a page boundary, address overflow, and forwarding the original signal with an unreadable saved stack.
- `cargo +stable test -p mtld3d-unix --target x86_64-apple-darwin crash::tests -- --nocapture`: 10 passed.
- `cargo +stable test -p mtld3d-unix --target aarch64-apple-darwin crash::tests -- --nocapture`: 9 passed.
- `make fmt` and `make check`: passed, including formatting, clippy, audit, and documentation checks.
- `make test ISOLATED=1`: 1,091 Windows-workspace host tests and 284 Unix-workspace host tests passed. End-to-end: 478 passed, 0 failed on each PE architecture, four processes per architecture.
- Installed both Unix architectures and both PE architectures into the local launcher bundle, verified the installed artifacts and debug symbols against the build, and confirmed GTA IV starts through Steam. Its log records successful device creation with the deployed Unix UUID; early stack scans stop at unreadable memory without the secondary SIGBUS.

Conformance was not run because the change does not touch rendering, state translation, or shader emission.

## Rules check

Reviewed against CONTRIBUTING.md and docs/CONVENTIONS.md. No public API, wire field, runtime config key, dependency, derive, or lint suppression is added. The Mach declarations use SDK types and refer to libSystem's existing task-port storage. The only new environment selector is test-only and follows the existing subprocess-test pattern. Regression tests remain in `crash/tests.rs`. Failed reads use the existing raw crash descriptor because the signal path cannot take the normal logger's lock. The applicable mechanical gates ran green as listed above.
