### PR TITLE
Reuse command vectors at concurrent pass demand

### DIFF
--- a/windows/core/src/passes.rs
+++ b/windows/core/src/passes.rs
@@ -153,12 +153,6 @@ pub const LAST_BOUND_MAX_STAGES: usize = 16;
 /// Vertex texture fetch slots (`vs_3_0` s0..s3, `D3DVERTEXTEXTURESAMPLER0..3`).
 pub const VERTEX_SAMPLER_SLOTS: usize = 4;
 
-/// Cap on `command_vec_pool` size.
-///
-/// A 5-pass frame is the typical shape; 16 absorbs every realistic
-/// pass-count spike without parking unused capacity forever.
-const MAX_CMD_VEC_POOL: usize = 16;
-
 /// Cascade-summary probe target.
 ///
 /// Used both to gate the per-frame summary log line at submit time AND
@@ -1339,25 +1333,21 @@ pub struct PassState {
     /// Distinct from `submit_seq` (encoder-thread): incremented in
     /// `reset_frame`.
     frame_seq: u64,
-    /// Running per-frame total of bytes Metal will memcpy as a result of `Vec` doublings.
+    /// Per-frame estimate of command-vector growth copy bytes.
     ///
-    /// The doublings are `Vec<Command>::push` growing `Pass::commands`.
-    /// Incremented in `emit_command` when `len == capacity` before push (the
-    /// doubling is about to fire); the increment is the *old* capacity in
-    /// bytes, which is exactly what `realloc` has to copy from the old buffer
-    /// to the new one. Drained by `take_cmd_vec_realloc_bytes` once per frame
-    /// and rolled into the perf summary as `cmd_realloc`. Reset in
-    /// `reset_frame` as a safety net for the case where the drain is somehow
-    /// skipped.
+    /// Adds the old capacity in bytes whenever `emit_command` grows a full
+    /// vector. The allocator may extend a buffer in place, so this is potential
+    /// copy volume, not measured memory traffic. Initial allocations of 64
+    /// commands are excluded. Drained by `take_cmd_vec_realloc_bytes` once per
+    /// submission and reset by `reset_frame` as a safety net.
     cmd_vec_realloc_bytes: u64,
     /// Free-list of `Vec<Command>`s recycled across frames.
     ///
-    /// `reset_frame` drains each retired `Pass`'s `commands` into the pool
-    /// with capacity preserved; the next frame's `ensure_pass_open` pops one
-    /// instead of freshly `Vec::with_capacity(64)`. Once warmed, the pool's
-    /// Vecs converge on the steady-state high-water capacity per pass and no
-    /// further `Vec::push` doublings fire. Capped at `MAX_CMD_VEC_POOL` (~16
-    /// entries) so a one-off heavy frame can't grow the pool unboundedly.
+    /// Retired batches return in reverse pass order so the next frame pops
+    /// capacities in its original pass order. Every allocated vector is kept:
+    /// the pool grows with maximum concurrent demand, including detached submit
+    /// payloads, and retains that command capacity until device teardown.
+    /// Stable pass workloads stop allocating once their vectors have warmed.
     command_vec_pool: Vec<Vec<Command>>,
 
     /// Index one past the last texture-upload pass inserted this frame.
@@ -1448,7 +1438,7 @@ impl PassState {
             frame_cascade_samples: FxHashMap::with_capacity_and_hasher(8, FxBuildHasher),
             frame_seq: 0,
             cmd_vec_realloc_bytes: 0,
-            command_vec_pool: Vec::with_capacity(MAX_CMD_VEC_POOL),
+            command_vec_pool: Vec::new(),
             upload_pass_end: 0,
             drawn_ranges: DrawnRangeTracker::new(),
             #[cfg(debug_assertions)]
@@ -1490,23 +1480,10 @@ impl PassState {
             render_scale,
             continues_frame,
         } = reset;
-        // Recycle each retired pass's `commands` Vec back into the pool
-        // (capacity preserved, length zeroed). Once warm, the pool's
-        // Vecs carry the steady-state high-water capacity and the next
-        // frame's `ensure_pass_open` reuses them — eliminating the
-        // `Vec::with_capacity(64)` → many doublings cycle that the
-        // `cmd_realloc` perf row measures. Cap so a one-off frame with
-        // many passes (rare) can't park unused capacity forever.
-        for pass in self.passes.drain(..) {
-            if self.command_vec_pool.len() >= MAX_CMD_VEC_POOL {
-                break;
-            }
-            let mut cmds = pass.commands;
-            cmds.clear();
-            self.command_vec_pool.push(cmds);
+        // Reverse retirement keeps the first pass's capacity on top of the LIFO pool.
+        for pass in self.passes.drain(..).rev() {
+            recycle_command_vec(&mut self.command_vec_pool, pass.commands);
         }
-        // Belt-and-braces in case the break-on-cap fired mid-drain.
-        self.passes.clear();
         self.upload_pass_end = 0;
         self.current_pass_closed = true;
         // No pass open → no viewport emitted yet; the next pass's open
@@ -1636,20 +1613,12 @@ impl PassState {
 
     /// Drain finished passes' `commands` vecs back into the recycle pool.
     ///
-    /// Capacity preserved, length zeroed, capped at `MAX_CMD_VEC_POOL`. The
-    /// counterpart to [`Self::take_finished_passes`]: once the submit stage is
-    /// done reading a taken pass list, this returns its command vecs so the
-    /// next frame's `ensure_pass_open` reuses them instead of freshly
-    /// allocating. `drain(..)` always empties `passes` (retaining its
-    /// capacity); the cap only bounds how many vecs the pool parks.
+    /// The submit stage must have finished reading the taken passes. Draining
+    /// in reverse order restores their capacities to the LIFO pool in next-use
+    /// order. The pass list retains its own capacity and becomes empty.
     pub fn recycle_passes(&mut self, passes: &mut Vec<Pass>) {
-        for pass in passes.drain(..) {
-            if self.command_vec_pool.len() >= MAX_CMD_VEC_POOL {
-                continue;
-            }
-            let mut cmds = pass.commands;
-            cmds.clear();
-            self.command_vec_pool.push(cmds);
+        for pass in passes.drain(..).rev() {
+            recycle_command_vec(&mut self.command_vec_pool, pass.commands);
         }
     }
 
@@ -2523,11 +2492,8 @@ impl PassState {
             {
                 pass.has_counting_visibility = true;
             }
-            // Detect Vec::push doubling: the realloc memcpys
-            // `capacity * size_of::<Command>()` bytes from the old
-            // buffer to the new one. The running total is the churn
-            // figure the perf summary reports as `cmd_realloc`; once
-            // `command_vec_pool` is warm it settles at zero.
+            // Count old capacity at growth as potential copy volume. An
+            // allocator may grow in place; this does not measure actual copies.
             if pass.commands.len() == pass.commands.capacity() {
                 let bytes = pass
                     .commands
@@ -2561,27 +2527,27 @@ impl PassState {
         self.debug_emitted = DebugBoundShadow::default();
     }
 
-    /// Drain and return the running per-frame total of bytes Metal will memcpy.
+    /// Drain the command-vector growth copy estimate for this submission.
     ///
-    /// The bytes are the memcpy cost of `Pass::commands` `Vec` doublings.
-    /// Called once per frame from the encoder's `log_perf_summary`. Zeroes the
-    /// field so the next frame starts fresh.
+    /// Sums old capacity bytes at growth, excluding initial allocations and
+    /// without distinguishing in-place growth from copies. Called by the
+    /// encoder's `log_perf_summary`; zeroes the counter for the next submission.
     pub const fn take_cmd_vec_realloc_bytes(&mut self) -> u64 {
         let bytes = self.cmd_vec_realloc_bytes;
         self.cmd_vec_realloc_bytes = 0;
         bytes
     }
 
-    /// Sum `Vec::capacity() * size_of::<Command>()` across every pass's command buffer.
+    /// Sum command-vector capacity bytes in the submitted pass list.
     ///
-    /// Summed at end-of-frame. The pool recycles these vectors across frames
-    /// so capacity is the resident-memory footprint, not a per-frame
-    /// allocation cost. Paired with `take_cmd_vec_realloc_bytes` so the diag
-    /// row can show steady-state size alongside growth churn.
+    /// Counts only the supplied payload's passes, excluding idle pooled vectors
+    /// and other outstanding payloads. Call after detaching the passes from this
+    /// state. This is reused capacity, not allocation volume; potential growth copies are
+    /// tracked separately by [`Self::take_cmd_vec_realloc_bytes`].
     #[must_use]
-    pub fn cmd_vec_capacity_bytes(&self) -> u64 {
+    pub fn cmd_vec_capacity_bytes(passes: &[Pass]) -> u64 {
         let elem = core::mem::size_of::<Command>() as u64;
-        self.passes
+        passes
             .iter()
             .map(|p| p.commands.capacity() as u64 * elem)
             .sum()
@@ -4163,7 +4129,7 @@ impl PassState {
             return;
         }
         let before = self.passes.len();
-        self.passes.retain(|p| {
+        self.passes.retain_mut(|p| {
             let has_draw = p.commands.iter().any(|c| {
                 c.cmd == CommandType::DrawPrimitives as u32
                     || c.cmd == CommandType::DrawIndexedPrimitives as u32
@@ -4183,7 +4149,11 @@ impl PassState {
             let depth_writes = !p.depth_texture.is_null()
                 && (matches!(p.depth_store, StoreAction::Store)
                     || !p.depth_resolve_texture.is_null());
-            color_writes || depth_writes
+            let keep = color_writes || depth_writes;
+            if !keep {
+                recycle_command_vec(&mut self.command_vec_pool, core::mem::take(&mut p.commands));
+            }
+            keep
         });
         if log_enabled!(target: TRACE_TARGET, Level::Trace) {
             let dropped = before - self.passes.len();
@@ -4290,7 +4260,8 @@ impl PassState {
                         "pass-coalesce drop idx={i} (clear-only) → fold into idx={t} color={target_color:#x} depth={target_depth:#x}",
                     );
                 }
-                self.passes.remove(i);
+                let retired = self.passes.remove(i);
+                recycle_command_vec(&mut self.command_vec_pool, retired.commands);
                 // Don't increment i — what was at i+1 is now at i.
             } else {
                 i += 1;
@@ -5573,6 +5544,15 @@ impl LastBoundCache {
                 "fragment-sampler[{stage}] cache desync (cache vs encoder-emitted)"
             );
         }
+    }
+}
+
+/// Return allocated command storage after its consumer has finished.
+fn recycle_command_vec(pool: &mut Vec<Vec<Command>>, mut commands: Vec<Command>) {
+    // Synthetic blit-only passes have no command allocation to retain.
+    if commands.capacity() != 0 {
+        commands.clear();
+        pool.push(commands);
     }
 }
 

--- a/windows/core/src/passes/tests.rs
+++ b/windows/core/src/passes/tests.rs
@@ -37,6 +37,11 @@ fn backbuffer_srgb() -> MetalHandle<MTLTextureKind> {
 
 fn fresh() -> PassState {
     let mut s = PassState::new();
+    reset_test_frame(&mut s);
+    s
+}
+
+fn reset_test_frame(s: &mut PassState) {
     s.reset_frame(&FrameReset {
         backbuffer: backbuffer(),
         backbuffer_srgb: backbuffer_srgb(),
@@ -51,7 +56,6 @@ fn fresh() -> PassState {
         render_scale: RenderScale::IDENTITY,
         continues_frame: false,
     });
-    s
 }
 
 /// A frame rasterizing the back buffer at half the reported resolution.
@@ -3467,8 +3471,14 @@ fn rule_e_merges_a_clear_only_pass_into_the_same_target_set() {
     s.emit_command(dummy_draw());
     s.end_current_pass("test");
     assert_eq!(s.passes().len(), 3);
+    let original = command_allocations(s.passes());
     s.coalesce_clear_only_passes();
     assert_eq!(s.passes().len(), 2, "clear-only pass folded");
+    assert_eq!(command_allocations(s.passes()), original[1..]);
+    assert_eq!(s.command_vec_pool.len(), 1);
+    assert_eq!(s.command_vec_pool[0].as_ptr(), original[0].0);
+    assert_eq!(s.command_vec_pool[0].capacity(), original[0].1);
+    assert!(s.command_vec_pool[0].is_empty());
     let merged = &s.passes()[1];
     let clear = ColorLoad::Clear {
         r: 1,
@@ -4864,4 +4874,245 @@ fn a_clear_only_pass_does_not_fold_past_a_colour_resolve_into_its_target() {
         matches!(s.passes()[2].color_load(), ColorLoad::Load),
         "the draw after the resolve loads what it wrote"
     );
+}
+
+fn uneven_command_frame(s: &mut PassState) {
+    for pass in 0..37 {
+        for _ in 0..(65 << (pass % 6)) {
+            s.emit_command(dummy_draw());
+        }
+        s.end_current_pass("test");
+    }
+}
+
+fn command_allocations(passes: &[Pass]) -> Vec<(*const Command, usize)> {
+    passes
+        .iter()
+        .map(|p| (p.commands.as_ptr(), p.commands.capacity()))
+        .collect()
+}
+
+#[test]
+fn command_pool_reuses_37_uneven_passes_on_reset() {
+    let mut s = fresh();
+    uneven_command_frame(&mut s);
+    let allocations = command_allocations(s.passes());
+    let capacity = PassState::cmd_vec_capacity_bytes(s.passes());
+    let warmup_copies = s.take_cmd_vec_realloc_bytes();
+    assert!(warmup_copies > 0);
+    for _ in 0..8 {
+        reset_test_frame(&mut s);
+        assert_eq!(s.command_vec_pool.len(), 37);
+        uneven_command_frame(&mut s);
+        assert_eq!(command_allocations(s.passes()), allocations);
+        assert_eq!(s.take_cmd_vec_realloc_bytes(), 0);
+        assert_eq!(PassState::cmd_vec_capacity_bytes(s.passes()), capacity);
+    }
+    println!(
+        "37 passes: retained={capacity} bytes, warmup growth copy estimate={warmup_copies} bytes, steady growth copy estimate=0, steady command-vector allocations=0"
+    );
+}
+
+#[test]
+fn command_pool_reuses_detached_passes_and_accounts_only_the_payload() {
+    let mut s = fresh();
+    uneven_command_frame(&mut s);
+    let mut payload = s.take_finished_passes();
+    let allocations = command_allocations(&payload);
+    let capacity = PassState::cmd_vec_capacity_bytes(&payload);
+    assert!(capacity > 0);
+    assert_eq!(PassState::cmd_vec_capacity_bytes(s.passes()), 0);
+    reset_test_frame(&mut s);
+    assert!(s.command_vec_pool.is_empty());
+    for _ in 0..8 {
+        let pass_capacity = payload.capacity();
+        s.recycle_passes(&mut payload);
+        assert_eq!(payload.capacity(), pass_capacity);
+        assert!(payload.is_empty());
+        uneven_command_frame(&mut s);
+        assert_eq!(command_allocations(s.passes()), allocations);
+        assert_eq!(s.take_cmd_vec_realloc_bytes(), 0);
+        payload = s.take_finished_passes();
+        assert_eq!(PassState::cmd_vec_capacity_bytes(&payload), capacity);
+        reset_test_frame(&mut s);
+    }
+}
+
+#[test]
+fn command_pool_keeps_two_outstanding_payloads_disjoint() {
+    let mut s = fresh();
+    uneven_command_frame(&mut s);
+    let mut first = s.take_finished_passes();
+    let first_allocations = command_allocations(&first);
+    reset_test_frame(&mut s);
+    uneven_command_frame(&mut s);
+    let mut second = s.take_finished_passes();
+    let second_allocations = command_allocations(&second);
+    reset_test_frame(&mut s);
+    uneven_command_frame(&mut s);
+    let third_allocations = command_allocations(s.passes());
+    assert_eq!(command_allocations(&first), first_allocations);
+    assert_eq!(command_allocations(&second), second_allocations);
+    for (left, right) in [
+        (&first_allocations, &second_allocations),
+        (&first_allocations, &third_allocations),
+        (&second_allocations, &third_allocations),
+    ] {
+        assert!(
+            left.iter()
+                .all(|(ptr, _)| right.iter().all(|(other, _)| ptr != other))
+        );
+    }
+    let mut third = s.take_finished_passes();
+    reset_test_frame(&mut s);
+    for _ in 0..8 {
+        s.recycle_passes(&mut first);
+        uneven_command_frame(&mut s);
+        assert_eq!(command_allocations(s.passes()), first_allocations);
+        assert_eq!(command_allocations(&second), second_allocations);
+        assert_eq!(command_allocations(&third), third_allocations);
+        assert_eq!(s.take_cmd_vec_realloc_bytes(), 0);
+        first = s.take_finished_passes();
+        reset_test_frame(&mut s);
+        s.recycle_passes(&mut second);
+        uneven_command_frame(&mut s);
+        assert_eq!(command_allocations(s.passes()), second_allocations);
+        assert_eq!(command_allocations(&first), first_allocations);
+        assert_eq!(command_allocations(&third), third_allocations);
+        assert_eq!(s.take_cmd_vec_realloc_bytes(), 0);
+        second = s.take_finished_passes();
+        reset_test_frame(&mut s);
+        s.recycle_passes(&mut third);
+        uneven_command_frame(&mut s);
+        assert_eq!(command_allocations(s.passes()), third_allocations);
+        assert_eq!(command_allocations(&first), first_allocations);
+        assert_eq!(command_allocations(&second), second_allocations);
+        assert_eq!(s.take_cmd_vec_realloc_bytes(), 0);
+        third = s.take_finished_passes();
+        reset_test_frame(&mut s);
+    }
+    let capacity = PassState::cmd_vec_capacity_bytes(&first)
+        + PassState::cmd_vec_capacity_bytes(&second)
+        + PassState::cmd_vec_capacity_bytes(&third);
+    s.recycle_passes(&mut first);
+    s.recycle_passes(&mut second);
+    s.recycle_passes(&mut third);
+    assert_eq!(s.command_vec_pool.len(), 111);
+    assert_eq!(
+        s.command_vec_pool
+            .iter()
+            .map(|v| v.capacity() as u64 * size_of::<Command>() as u64)
+            .sum::<u64>(),
+        capacity
+    );
+    println!(
+        "Two outstanding payloads plus a live 37-pass list: retained={capacity} bytes, steady growth copy estimate=0, steady command-vector allocations=0"
+    );
+}
+
+#[test]
+fn command_pool_retires_dead_clears_without_reordering_survivors() {
+    let mut s = fresh();
+    for _ in 0..6 {
+        s.ensure_pass_open();
+        s.end_current_pass("test");
+    }
+    s.passes[0].commands.push(dummy_draw());
+    s.passes[1].color_store = StoreAction::DontCare;
+    s.passes[1].depth_store = StoreAction::DontCare;
+    s.passes[2].leading_blits.push(dummy_blit());
+    s.passes[3].color_store = StoreAction::DontCare;
+    s.passes[3].depth_store = StoreAction::DontCare;
+    s.passes[4].color_store = StoreAction::Store;
+    s.passes[5].color_resolve_texture = tex(0x4000);
+    let original = command_allocations(s.passes());
+    s.cull_dead_clear_only_passes();
+    assert_eq!(
+        command_allocations(s.passes()),
+        [original[0], original[2], original[4], original[5]]
+    );
+    assert_eq!(s.command_vec_pool.len(), 2);
+    let pooled: Vec<_> = s
+        .command_vec_pool
+        .iter()
+        .map(|v| (v.as_ptr(), v.capacity()))
+        .collect();
+    assert!(pooled.contains(&original[1]));
+    assert!(pooled.contains(&original[3]));
+    assert!(s.command_vec_pool.iter().all(Vec::is_empty));
+}
+
+#[test]
+fn command_pool_does_not_park_unallocated_blit_pass_vectors() {
+    let mut s = fresh();
+    s.ensure_pass_open();
+    s.end_current_pass("test");
+    let allocation = command_allocations(s.passes());
+    s.ensure_pass_open();
+    s.end_current_pass("test");
+    s.passes[1].commands = Vec::new();
+    s.passes[1].leading_blits.push(dummy_blit());
+    let mut payload = s.take_finished_passes();
+    s.recycle_passes(&mut payload);
+    assert_eq!(s.command_vec_pool.len(), 1);
+    reset_test_frame(&mut s);
+    s.ensure_pass_open();
+    assert_eq!(command_allocations(s.passes()), allocation);
+}
+
+fn mixed_command_frame(s: &mut PassState) {
+    for count in [65, 513, 129] {
+        for _ in 0..count {
+            s.emit_command(dummy_draw());
+        }
+        s.end_current_pass("test");
+    }
+    assert!(s.resolve_depth_texture(&DepthResolve {
+        source: depth(),
+        level: 0,
+        size: BB_SIZE,
+        destination: tex(0x4000),
+        filter: DepthResolveFilter::Sample0,
+        source_is_sampleable: true,
+    }));
+    for target in [tex(0x5000), tex(0x6000)] {
+        s.push_upload_pass(
+            &UploadPassTarget {
+                texture: target,
+                subresource: (0, 0),
+                size: BB_SIZE,
+                format: BB_FORMAT,
+                rect: (0, 0, BB_SIZE.0, BB_SIZE.1),
+            },
+            &[dummy_draw()],
+        );
+    }
+    assert_eq!(s.passes.len(), 6);
+    assert_eq!(s.passes[0].color_texture, tex(0x5000));
+    assert_eq!(s.passes[1].color_texture, tex(0x6000));
+    assert!(s.passes[5].commands.is_empty());
+    assert_eq!(s.passes[5].depth_resolve_texture, tex(0x4000));
+}
+
+#[test]
+fn command_pool_converges_with_head_uploads_and_depth_resolves() {
+    let mut s = fresh();
+    // Uploads move to the front after borrowing vectors in recording order,
+    // so their capacity alignment can take more than one frame to converge.
+    for _ in 0..12 {
+        mixed_command_frame(&mut s);
+        reset_test_frame(&mut s);
+    }
+    mixed_command_frame(&mut s);
+    let mut allocations = command_allocations(s.passes());
+    allocations.sort_unstable();
+    for _ in 0..12 {
+        reset_test_frame(&mut s);
+        assert_eq!(s.command_vec_pool.len(), 6);
+        mixed_command_frame(&mut s);
+        let mut next = command_allocations(s.passes());
+        next.sort_unstable();
+        assert_eq!(next, allocations);
+        assert_eq!(s.take_cmd_vec_realloc_bytes(), 0);
+    }
 }

--- a/windows/core/src/perf.rs
+++ b/windows/core/src/perf.rs
@@ -1625,12 +1625,12 @@ pub struct CacheSizes {
     /// is exceeding the chunk size and motivating its own chunk per frame.
     pub scratch_oversized_blocks: u32,
     pub scratch_bytes: u64,
-    /// Live `Vec<Command>` capacity in bytes across every pass at frame end.
+    /// Command-vector capacity bytes in this submission's payload.
     ///
-    /// Sourced from `PassState::cmd_vec_capacity_bytes`. The pool recycles
-    /// these vectors across frames, so this is resident footprint — paired
-    /// with `cmd_vec_realloc_bytes` on `FrameSample` (steady-state size
-    /// vs. growth churn).
+    /// Sourced from `PassState::cmd_vec_capacity_bytes` after passes detach.
+    /// Excludes idle pooled vectors and other outstanding payloads. Paired
+    /// with `cmd_vec_realloc_bytes` on `FrameSample` to separate reused
+    /// capacity from growth copies.
     pub cmd_vec_capacity_bytes: u64,
     pub pending_blit_retention_depth: usize,
     pub pending_resource_retention_depth: usize,
@@ -2316,22 +2316,22 @@ struct FrameSample {
     scratch_small_blocks: u32,
     scratch_oversized_blocks: u32,
     scratch_bytes: u64,
-    /// Resident `Vec<Command>` capacity bytes summed across every pass at end-of-frame.
+    /// Command-vector capacity bytes in this submission's payload.
     ///
-    /// Steady-state size of the encoder's command storage (the pool keeps
-    /// these around between frames). Paired with `cmd_vec_realloc_bytes`
-    /// below to separate footprint from churn.
+    /// Excludes idle pooled vectors and other outstanding payloads. Paired
+    /// with `cmd_vec_realloc_bytes` below to separate capacity from churn.
     cmd_vec_capacity_bytes: u64,
     vbib_retention_depth: usize,
     vbib_retained_bytes: usize,
     pending_blit_retention_depth: usize,
     tex_staging_retained_bytes: usize,
-    /// Per-frame total of bytes memcpy'd by `Pass::commands` `Vec` doublings.
+    /// Per-frame estimate of command-vector growth copy bytes.
     ///
     /// Sourced from `PassState::take_cmd_vec_realloc_bytes` once per
     /// frame. Paired with `cmd_vec_capacity_bytes` above so the diag row
-    /// shows growth churn next to resident footprint; a working pool
-    /// drives this near zero in steady state.
+    /// shows potential growth copies alongside submitted capacity. Initial
+    /// allocations are excluded, and in-place growth still counts the old
+    /// capacity. A warmed pool drives this to zero for stable workloads.
     cmd_vec_realloc_bytes: u64,
     /// This frame's `PageBox` allocations reaching the global allocator.
     ///
@@ -4567,7 +4567,7 @@ impl<'a> Summary<'a> {
             "  size",
             &format!("{cap_avg_fmt} avg"),
             Some(&format!("peak {cap_peak_fmt}")),
-            "pool-resident Vec<Command> capacity across frames (recycled, not freed)",
+            "submitted payload Vec<Command> capacity (excludes idle pool and other payloads)",
         );
         let realloc_avg_kb = u64_to_f64_exact(w.cmd_vec_realloc_bytes.sum) / f / 1024.0;
         let realloc_peak_kb = u64_to_f64_exact(w.cmd_vec_realloc_bytes.max) / 1024.0;
@@ -4577,7 +4577,7 @@ impl<'a> Summary<'a> {
             "  realloc",
             &format!("{realloc_avg_fmt} avg"),
             Some(&format!("peak {realloc_peak_fmt}")),
-            "Vec<Command> doubling memcpy on emit_command (target ≈ 0 with Pass::commands pool)",
+            "Vec<Command> potential growth copies on emit_command (excludes initial allocations)",
         );
         // PageBox traffic that actually reached the global allocator this
         // window. Fresh pages fault on first touch under Wine, so a large

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -2457,7 +2457,7 @@ impl FrameEncoder {
     /// the payload is recycled only afterwards — reproducing the
     /// pre-split ordering exactly.
     fn log_perf_summary(&mut self, payload: &FramePayload, ctx: &FrameSummaryContext, status: i32) {
-        let caches = self.cache_sizes(&payload.scratch);
+        let caches = self.cache_sizes(payload);
         let cmd_vec_realloc_bytes = self.pass_state.take_cmd_vec_realloc_bytes();
         // One getrusage unix_call per 5 s window, only when the summary is
         // both enabled and about to emit; every other frame passes None.
@@ -2485,10 +2485,10 @@ impl FrameEncoder {
     /// Cache-length snapshot handed to `EncoderPerfState::log_frame_summary`.
     ///
     /// Walks every cache `HashMap` exactly once; cheap even at debug
-    /// log levels because `HashMap::len()` is O(1). `scratch` is passed in
-    /// (the just-submitted payload's filled arena) since `self.scratch` is
-    /// already the clean arena swapped in for the next frame.
-    fn cache_sizes(&self, scratch: &ScratchArena) -> CacheSizes {
+    /// log levels because `HashMap::len()` is O(1). The submitted payload owns
+    /// this frame's passes and filled scratch arena; the live encoder already
+    /// holds the clean state for the next frame.
+    fn cache_sizes(&self, payload: &FramePayload) -> CacheSizes {
         CacheSizes {
             textures: self.texture_cache.len(),
             pipelines: self.pipeline_cache.len(),
@@ -2496,10 +2496,10 @@ impl FrameEncoder {
             programs: self.program_cache.len(),
             libs: self.lib_cache.len(),
             depth_states: self.depth_stencil_cache.len(),
-            scratch_small_blocks: scratch.small_chunk_count(),
-            scratch_oversized_blocks: scratch.oversized_chunk_count(),
-            scratch_bytes: scratch.capacity_bytes(),
-            cmd_vec_capacity_bytes: self.pass_state.cmd_vec_capacity_bytes(),
+            scratch_small_blocks: payload.scratch.small_chunk_count(),
+            scratch_oversized_blocks: payload.scratch.oversized_chunk_count(),
+            scratch_bytes: payload.scratch.capacity_bytes(),
+            cmd_vec_capacity_bytes: PassState::cmd_vec_capacity_bytes(&payload.passes),
             pending_blit_retention_depth: self.pending_blit_retention.len(),
             pending_resource_retention_depth: self.pending_resource_retention.len(),
             pagebox_pool_bytes: crate::page_box_pool::PAGEBOX_POOL.pooled_bytes() as u64,


### PR DESCRIPTION
GTA IV uses about 37 passes in the measured scene, but the command-vector pool kept only 16 allocations. Vectors outside that limit grew again on subsequent frames. Forward retirement into the LIFO pool also mismatched uneven pass capacities, and the capacity counter read the emptied live pass list after submission detached it.

Retain command vectors according to maximum concurrent demand and return completed batches in reverse order. Recycle storage from culled clear-only passes and coalesced clears through the same helper, preserving removal predicates and surviving pass order. Read capacity from the submitted payload.

Raising the fixed limit would still discard allocations when concurrent demand exceeded it. Keeping the workload's high-water capacity avoids that churn, at the cost of retaining peak command storage until device teardown. The capacity counter excludes idle pooled vectors and other outstanding payloads.

## Verification

- `make fmt`, `make check` (format, clippy, audit and rustdoc), `make test ISOLATED=1`, and `make conformance ISOLATED=1` passed on this branch and with the constant-binding change applied.
- Standalone: 1,097 Windows host tests, 284 Unix tests and 478 end-to-end tests per PE architecture. Both conformance architectures matched the clean base, with no Metal API-validation errors.
- Regressions cover 37 uneven passes, synchronous and detached retirement, two outstanding payloads, clear retirement, mixed pass types and detached capacity accounting. A stable release probe reduced estimated growth-copy volume from 931,840 bytes/frame to zero after warmup.
- GTA IV with both changes, `PERF=1 PROD=1`: estimated command growth copies fell from about 563 KiB/frame to 2 KiB/frame in gameplay windows, excluding GPU captures. The runs used different scenes, so this establishes no FPS gain. Submitted command capacity averaged about 15.7 MiB and peaked at 20 MiB. Growth-copy accounting is an estimate, not measured allocator traffic.

## Rules check

Pure recycling logic stays in `mtld3d-core`; unit tests remain in the existing child test module. No new config keys, environment variables, wire fields, dependencies, statics, derives, lint suppressions or unsafe operations. Asynchronous payload ownership and draw order are preserved. Shader emission is unchanged, so no shader-cache schema bump is needed.
