### PR TITLE
Attribute worker-thread failures to their test and log the cursor build error

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -23,6 +23,7 @@ Most of this document is enforced by `make check`: `cargo +nightly fmt --check`,
 | `mod.rs` files = 0 | §Module style |
 | Inline `#[cfg(test)] mod tests { … }` blocks = 0 | §Unit tests live in `<stem>/tests.rs` |
 | Every end-to-end test file (`windows/tests/tests/*.rs` and `tests/e2e/*.rs`, `main.rs` aside) has a row in `windows/tests/COVERAGE.md`, and every row a file | §End-to-end tests are listed in `COVERAGE.md` |
+| Raw thread spawns (`.spawn(`, `.spawn_scoped(`, `thread::spawn(`, `thread::Builder`) = 0 under `windows/tests/tests/e2e/` | §Every end-to-end test names itself |
 | Every `extern "system" fn` in the device and child-object files opens with `let _api =`, the cursor window procedure excepted | §Every device entry point holds the API lock |
 | Release hygiene (see below) | §Release hygiene |
 
@@ -125,6 +126,14 @@ Watch relative paths on the way out: `include_str!` resolves against the contain
 `windows/tests/COVERAGE.md` is the index of the end-to-end suite: one row per test file, saying what that file pins. The files are the modules of `windows/tests/tests/e2e/main.rs`, the one binary whose tests share a process, plus the three files beside it under `windows/tests/tests/` that need a process of their own (`exit_code.rs`, `unload.rs`, `snmalloc_drift.rs`); `main.rs` declares the modules, pins nothing, and has no row. It is how a reader finds whether a behaviour is already covered, and how a reviewer sees what a change is claiming, so it is only useful while it is complete. `make audit` matches it against both directories in both directions: a test file with no row fails, and a row naming a file that is not there fails too. A new test file lands as a module of `main.rs` with its row in the same change, and a deleted one takes its row and its `mod` line with it.
 
 The row is one sentence per behaviour the file pins, not a summary of the file. A test added to an existing file extends that file's row rather than adding a new one.
+
+## Every end-to-end test names itself
+
+A thread an end-to-end test spawns is created through `mtld3d_tests::spawn_scoped`, never through `Scope::spawn`, `thread::spawn` or a `thread::Builder` of its own. The helper names the worker after the thread that spawns it, which libtest named after the test, so a worker of a worker is named after the test too.
+
+The tests of the `e2e` binary share one Wine process, and the harness's panic hook ends that process at the first failed assertion. What the runner then has to go on is the `thread '<name>' panicked at` line the default hook printed and the `[e2e] running <name>` line each thread wrote when it created its device. Both carry the thread's name. An unnamed worker prints `thread '<unnamed>'` and announces nothing, so a failure on it names no test, and the runner has to run every test that was in flight again, one at a time, to find which one it was. A worker carrying its test's name fails as that test, and the run costs one extra process instead of a serial round.
+
+`make audit` bans `.spawn(`, `.spawn_scoped(`, `thread::spawn(` and `thread::Builder` in `windows/tests/tests/e2e/*.rs`. The harness under `windows/tests/src` is where the one `Builder::spawn_scoped` call lives, outside the banned directory.
 
 ## No `pub(crate)` — use module hierarchy
 

--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -36,6 +36,14 @@ unix/unix/src/metal/upscale.rs'
 
 INLINE_ALWAYS_SITES='unix/shared/src/crumb.rs'
 
+# The end-to-end tests that share one process. A thread one of them spawns
+# goes through the harness's `in_flight::spawn_scoped`, which names it after
+# the test, so a panic on it and the device it creates attribute to the test
+# rather than to `<unnamed>`; the raw spawn calls are banned here.
+E2E_TESTS_DIR=windows/tests/tests/e2e
+E2E_SPAWN='\.spawn(_scoped)?\(|thread::spawn\(|thread::Builder'
+E2E_SPAWN_MESSAGE='raw thread spawn in an end-to-end test: use mtld3d_tests::spawn_scoped, which names the worker after its test'
+
 # The COM entry points that hold the device's API lock: every
 # `extern "system" fn` defined in these files opens with `let _api =`. The
 # cursor window procedure is the one exception, by name: it runs on the window
@@ -301,6 +309,11 @@ case "${1:-}" in
         'OnceLock static outside the runtime-argument sites' "$ONCELOCK_SITES" "$file"
     confined '#\[allow\(' 'Warning suppressions' \
         'lint suppression outside the three accepted per-site exceptions' "$ALLOW_SITES" "$file"
+    case $file in
+    "$E2E_TESTS_DIR"/*.rs)
+        banned "$E2E_SPAWN" 'Every end-to-end test names itself' "$E2E_SPAWN_MESSAGE" "$file"
+        ;;
+    esac
 
     exit $status
     ;;
@@ -360,6 +373,12 @@ confined '^[ \t]*static .*: *OnceLock' 'LazyLock over OnceLock' \
     'OnceLock static outside the runtime-argument sites' "$ONCELOCK_SITES" "$@"
 confined '#\[allow\(' 'Warning suppressions' \
     'lint suppression outside the three accepted per-site exceptions' "$ALLOW_SITES" "$@"
+
+e2e_tests=$(git ls-files "$E2E_TESTS_DIR/*.rs" || true)
+if [ -n "$e2e_tests" ]; then
+    # shellcheck disable=SC2086
+    banned "$E2E_SPAWN" 'Every end-to-end test names itself' "$E2E_SPAWN_MESSAGE" $e2e_tests
+fi
 
 modules=$(git ls-files '*/mod.rs' || true)
 if [ -n "$modules" ]; then

--- a/unix/e2e/src/attribute.rs
+++ b/unix/e2e/src/attribute.rs
@@ -447,13 +447,22 @@ pub fn run_binary(
     Ok(run)
 }
 
-/// The tests that named themselves on `stderr`, in the order they did.
+/// The tests that named themselves on `stderr`, each once, in the order they first did.
+///
+/// A test names itself on every thread it creates a device from, and its
+/// worker threads carry its name, so one test can announce several times.
 fn announced(stderr: &str) -> Vec<String> {
-    stderr
-        .lines()
-        .filter_map(|line| line.split_once(RUNNING))
-        .map(|(_, name)| name.trim().to_owned())
-        .collect()
+    let mut names: Vec<String> = Vec::new();
+    for line in stderr.lines() {
+        let Some((_, name)) = line.split_once(RUNNING) else {
+            continue;
+        };
+        let name = name.trim();
+        if !names.iter().any(|seen| seen == name) {
+            names.push(name.to_owned());
+        }
+    }
+    names
 }
 
 /// The report line naming what was in flight, or nothing when no test named itself.

--- a/unix/e2e/src/attribute/tests.rs
+++ b/unix/e2e/src/attribute/tests.rs
@@ -20,6 +20,11 @@
 //! costs nothing because the parser reads it, a tally short of libtest's
 //! own count names the tests with no outcome and runs them again, and a
 //! second round that loses the same result fails it rather than looping.
+//!
+//! A test with worker threads names itself once per thread, so two more pin
+//! that the announcements of one test read as one name, and that a panic
+//! on a worker carrying the test's name and its thread id is charged to
+//! that test with no serial round.
 
 use std::{
     collections::VecDeque,
@@ -28,7 +33,7 @@ use std::{
     time::Duration,
 };
 
-use super::{Launcher, ProcessEnd, Report, TestResult, Verdict, run_binary};
+use super::{Launcher, ProcessEnd, Report, TestResult, Verdict, announced, run_binary};
 use crate::{
     binary::{LayerLog, keep_layer_log, keep_stderr},
     libtest::Parser,
@@ -501,6 +506,82 @@ fn the_note_names_what_was_in_flight_and_only_those_run_one_at_a_time() {
         launcher.launched[2],
         (Some(vec!["a::four".to_owned()]), 4),
         "the tests the narrowed round set aside run at the caller's width"
+    );
+}
+
+/// A test that announces on several threads is one name, where it was first seen.
+#[test]
+fn a_duplicated_announcement_yields_one_name() {
+    let stderr = "[e2e] running a::one\n\
+        0024:fixme:d3d9:something [e2e] running a::two\n\
+        [e2e] running a::one\n\
+        [e2e] running a::two\n\
+        [e2e] running a::three\n\
+        [e2e] running a::one\n";
+    assert_eq!(announced(stderr), ["a::one", "a::two", "a::three"]);
+    assert_eq!(announced(""), Vec::<String>::new());
+}
+
+/// A worker named after its test fails as that test, whatever else the test announced.
+///
+/// The thread id the hook puts between the name and the verb is the id of
+/// the worker, not of libtest's own thread for the test, and the test has
+/// announced once per thread; neither changes which test is charged.
+#[test]
+fn a_named_workers_panic_is_charged_to_its_test_without_a_serial_round() {
+    let mut launcher = Scripted::new(
+        &["a::one", "a::two", "b::three"],
+        vec![
+            Script {
+                stdout: "running 3 tests\ntest a::one ... ok\n",
+                stderr: "[e2e] running a::two\n[e2e] running b::three\n\
+                    [e2e] running a::two\n[e2e] running a::two\n\
+                    thread 'a::two' (12) panicked at tests/e2e/device.rs:1830:21:\n\
+                    attribution probe\n"
+                    .to_owned(),
+                layer: None,
+                kind: ExitKind::Code(101),
+            },
+            Script {
+                stdout: "running 1 test\ntest b::three ... ok\n\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.1s\n",
+                stderr: String::new(),
+                layer: None,
+                kind: ExitKind::Code(0),
+            },
+        ],
+    );
+    let mut log = Log::default();
+    let run = run_binary(&mut launcher, None, 4, false, &mut log).unwrap();
+    assert_eq!(
+        run.processes, 2,
+        "the panic names its test: no serial round"
+    );
+    assert!(run.failed);
+    assert_eq!(
+        verdicts(&log.results),
+        [("a::one", "pass"), ("a::two", "fail"), ("b::three", "pass")]
+    );
+    assert!(
+        matches!(&log.results[1].verdict, Verdict::Failed(r) if r.contains("attribution probe")),
+        "{:?}",
+        log.results[1].verdict
+    );
+    assert!(
+        log.notes[0].contains("in flight when it ended: a::two, b::three\n"),
+        "each name once: {:?}",
+        log.notes
+    );
+    assert!(
+        log.notes
+            .iter()
+            .all(|note| !note.contains("nothing names the test")),
+        "{:?}",
+        log.notes
+    );
+    assert_eq!(
+        launcher.launched[1],
+        (Some(vec!["b::three".to_owned()]), 4),
+        "only what was left runs again, at full width"
     );
 }
 

--- a/unix/e2e/src/libtest/tests.rs
+++ b/unix/e2e/src/libtest/tests.rs
@@ -91,7 +91,9 @@ fn the_panic_report_names_the_test_thread() {
         \x20 left: 0\n\
         \x20right: 1\n\
         note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n\
-        wine: something else\n";
+        wine: something else\n\
+        thread 'device::concurrent_retargets' (12) panicked at tests/e2e/device.rs:1830:21:\n\
+        attribution probe\n";
     assert_eq!(
         panicked_test("thread 'device::reset_bad_dims' panicked at x.rs:1:1:"),
         Some("device::reset_bad_dims")
@@ -101,9 +103,18 @@ fn the_panic_report_names_the_test_thread() {
         Some("device::reset_bad_dims"),
         "the thread id the hook prints between name and verb"
     );
+    assert_eq!(
+        panicked_test("thread '<unnamed>' (13) panicked at x.rs:1:1:"),
+        Some("<unnamed>"),
+        "a worker with no name names no test, and nothing here invents one"
+    );
     assert_eq!(panicked_test("thread 'main' panicked at x.rs:1:1:"), None);
     assert_eq!(panicked_test("thread 'x' something else"), None);
-    assert_eq!(panicked_tests(stderr), ["device::reset_bad_dims"]);
+    assert_eq!(
+        panicked_tests(stderr),
+        ["device::reset_bad_dims", "device::concurrent_retargets"],
+        "a worker's report, thread id and all, names the test the worker is named after"
+    );
     let report = panic_report(stderr, "device::reset_bad_dims").unwrap();
     assert!(report.starts_with("thread 'device::reset_bad_dims' panicked"));
     assert!(report.ends_with("right: 1"), "{report}");

--- a/windows/d3d9/src/cursor.rs
+++ b/windows/d3d9/src/cursor.rs
@@ -77,6 +77,7 @@ unsafe extern "system" {
 #[link(name = "kernel32")]
 unsafe extern "system" {
     fn GetCurrentThreadId() -> u32;
+    fn GetLastError() -> u32;
 }
 
 // Safe wrappers around the Win32 calls used by this module — each Win32
@@ -185,6 +186,16 @@ fn delete_object(obj: *mut c_void) -> i32 {
     // SAFETY: DeleteObject accepts null + any GDI object handle; returns 0
     // on failure (caller logs).
     unsafe { DeleteObject(obj) }
+}
+
+/// The calling thread's Win32 last-error code.
+///
+/// Read right after the call that failed: every Win32 call, `DeleteObject`
+/// included, may overwrite it.
+fn last_error() -> u32 {
+    // SAFETY: GetLastError reads the calling thread's own error slot and
+    // takes no arguments.
+    unsafe { GetLastError() }
 }
 
 fn create_bitmap_packed(
@@ -1653,9 +1664,11 @@ fn create_cursor_from_bits(
         mask.as_ptr().cast::<c_void>(),
     );
     if color_bitmap.is_null() || mask_bitmap.is_null() {
+        let err = last_error();
         error!(
             target: LOG_TARGET,
-            "{what}: CreateBitmap failed (color={color_bitmap:p} mask={mask_bitmap:p}) {width}x{height}",
+            "{what}: CreateBitmap failed (color={color_bitmap:p} mask={mask_bitmap:p}) \
+             {width}x{height}, GetLastError={err:#x}",
         );
         if !color_bitmap.is_null() {
             delete_object(color_bitmap);
@@ -1673,11 +1686,15 @@ fn create_cursor_from_bits(
         hbm_color: color_bitmap,
     };
     let cursor = create_icon_indirect(&info);
+    let err = last_error();
     // CreateIconIndirect copies the bitmaps; we own the originals.
     delete_object(color_bitmap);
     delete_object(mask_bitmap);
     if cursor.is_null() {
-        error!(target: LOG_TARGET, "{what}: CreateIconIndirect returned null ({width}x{height})");
+        error!(
+            target: LOG_TARGET,
+            "{what}: CreateIconIndirect returned null ({width}x{height}, GetLastError={err:#x})"
+        );
         None
     } else {
         Some(cursor)

--- a/windows/tests/COVERAGE.md
+++ b/windows/tests/COVERAGE.md
@@ -37,10 +37,12 @@ pins it true for the stub itself.
 
 And a process that dies takes every test in flight with it, which libtest
 does not name: past one test thread it prints a test's name only once the
-test has finished. So a test names itself on stdout as it reaches the layer
+test has finished. So a test names itself on stderr as it reaches the layer
 ([`in_flight.rs`](src/in_flight.rs)), and the runner reports the names it has
 no outcome line for as the set that was running and runs only those again one
-at a time. A test that returns before it builds an interface names nothing,
+at a time. A worker thread a test spawns is named after the test through
+`spawn_scoped`, so its announcement and its panic report attribute to the
+test as well. A test that returns before it builds an interface names nothing,
 which is the right coverage: it never reached the code that could end the
 process.
 

--- a/windows/tests/src/in_flight.rs
+++ b/windows/tests/src/in_flight.rs
@@ -18,8 +18,22 @@
 //! runs a test there only when it cannot spawn a thread, and then the name
 //! would be nobody's. Once per thread, since a test may build more than one
 //! interface and libtest gives each test a thread of its own.
+//!
+//! A thread the test spawns itself carries no name of its own, so a device
+//! it creates would name nobody and a panic on it would read
+//! `thread '<unnamed>'`, which names no test either: the runner would have
+//! to run every test that was in flight again to find the culprit. Every
+//! worker of the suite is therefore spawned through [`spawn_scoped`], which
+//! gives it the spawning thread's name. That name is the test's libtest
+//! path on a thread libtest created, and on a worker it is the name that
+//! worker was given, so a worker of a worker is named after the test too.
+//! Each worker then announces once, the same name as its test, and the
+//! runner reads a name it has seen before as the one test.
 
-use std::{cell::Cell, thread};
+use std::{
+    cell::Cell,
+    thread::{self, Builder, Scope, ScopedJoinHandle},
+};
 
 /// The stderr marker; what follows it is the test's libtest path.
 const RUNNING: &str = "[e2e] running ";
@@ -39,4 +53,32 @@ pub fn announce() {
         return;
     };
     eprintln!("{RUNNING}{name}");
+}
+
+/// Spawn a scoped thread named after the current one.
+///
+/// The name is what a panic report and an announcement carry, so a worker
+/// spawned here fails and names itself as the test it works for rather
+/// than as `<unnamed>`. A thread with no name (the main thread of a binary
+/// that runs its tests there) spawns an unnamed worker, since there is no
+/// test to name.
+///
+/// # Panics
+///
+/// Panics when the thread cannot be spawned, which no test can recover
+/// from.
+pub fn spawn_scoped<'scope, 'env, F, T>(
+    scope: &'scope Scope<'scope, 'env>,
+    f: F,
+) -> ScopedJoinHandle<'scope, T>
+where
+    F: FnOnce() -> T + Send + 'scope,
+    T: Send + 'scope,
+{
+    let current = thread::current();
+    current
+        .name()
+        .map_or_else(Builder::new, |name| Builder::new().name(name.to_owned()))
+        .spawn_scoped(scope, f)
+        .expect("a test's worker thread can be spawned")
 }

--- a/windows/tests/src/lib.rs
+++ b/windows/tests/src/lib.rs
@@ -20,6 +20,7 @@ mod win32;
 pub use harness::{
     DrawIndexedUpParams, Harness, HarnessConfig, config_var, render_scale_is_identity,
 };
+pub use in_flight::spawn_scoped;
 pub use pixel::{Rgba8, assert_pixel_approx, assert_pixel_eq};
 pub use resource::{
     BufferLock, CubeTexture, IndexBuffer, LockedRect, PixelShader, Query, StateBlock, Surface,

--- a/windows/tests/tests/e2e/device.rs
+++ b/windows/tests/tests/e2e/device.rs
@@ -12,7 +12,7 @@ use mtld3d_core::display_mode::MAX_SERVED_SIZES;
 use mtld3d_tests::{
     Harness, HarnessConfig, TexturedVertex, WM_ACTIVATEAPP, WS_CAPTION, WS_EX_TOPMOST, WS_POPUP,
     WS_VISIBLE, WindowStyle, assert_pixel_eq, config_var, create_window, destroy_window,
-    enumerate_display_sizes, window_rect,
+    enumerate_display_sizes, spawn_scoped, window_rect,
 };
 use mtld3d_types::{
     D3D_OK, D3DCLEAR_TARGET, D3DCREATE_HARDWARE_VERTEXPROCESSING, D3DCREATE_NOWINDOWCHANGES,
@@ -1802,7 +1802,7 @@ fn concurrent_retargets_deliver_every_window_message_to_its_own_device() {
     let done = Barrier::new(WINDOWED_WORKERS + 1);
 
     std::thread::scope(|scope| {
-        let fullscreen = scope.spawn(|| {
+        let fullscreen = spawn_scoped(scope, || {
             let h = {
                 let _serial = one_at_a_time.lock().unwrap_or_else(PoisonError::into_inner);
                 Harness::new()
@@ -1817,7 +1817,7 @@ fn concurrent_retargets_deliver_every_window_message_to_its_own_device() {
         });
         let windowed: Vec<_> = (0..WINDOWED_WORKERS)
             .map(|_| {
-                scope.spawn(|| {
+                spawn_scoped(scope, || {
                     let (h, second, ours) = {
                         let _serial = one_at_a_time.lock().unwrap_or_else(PoisonError::into_inner);
                         let h = Harness::new();
@@ -1952,28 +1952,27 @@ fn releasing_a_fullscreen_device_ignores_a_resize_during_the_release() {
     // The stand-in for the window manager: a size the back buffer does not
     // have, sent from another thread so it queues until the release pumps.
     let hwnd = h.hwnd();
-    let armed = std::sync::Arc::new(std::sync::Barrier::new(2));
-    let sender = {
-        let armed = std::sync::Arc::clone(&armed);
-        std::thread::spawn(move || {
+    let armed = Barrier::new(2);
+    std::thread::scope(|scope| {
+        let sender = spawn_scoped(scope, || {
             armed.wait();
             let _ = mtld3d_tests::send_message(hwnd, WM_SIZE, 0, (0x1C8 << 16) | 0x258);
-        })
-    };
-    armed.wait();
-    // Long enough for the sender to reach its `SendMessage` and block there;
-    // a message that arrives after the release is pumped harmlessly below.
-    std::thread::sleep(std::time::Duration::from_millis(100));
+        });
+        armed.wait();
+        // Long enough for the sender to reach its `SendMessage` and block there;
+        // a message that arrives after the release is pumped harmlessly below.
+        std::thread::sleep(std::time::Duration::from_millis(100));
 
-    assert_eq!(
-        h.release_device(),
-        0,
-        "the harness held the only device reference"
-    );
-    assert!(h.pump(), "no WM_QUIT expected");
-    sender
-        .join()
-        .expect("the sender thread ends once its message is answered");
+        assert_eq!(
+            h.release_device(),
+            0,
+            "the harness held the only device reference"
+        );
+        assert!(h.pump(), "no WM_QUIT expected");
+        sender
+            .join()
+            .expect("the sender thread ends once its message is answered");
+    });
     let rect = h.window_rect();
     assert!(
         rect.right - rect.left > 0 && rect.bottom - rect.top > 0,

--- a/windows/tests/tests/e2e/multi_device.rs
+++ b/windows/tests/tests/e2e/multi_device.rs
@@ -15,7 +15,9 @@
 
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use mtld3d_tests::{Harness, HarnessConfig, SharedDevice, SharedQuery, assert_pixel_eq};
+use mtld3d_tests::{
+    Harness, HarnessConfig, SharedDevice, SharedQuery, assert_pixel_eq, spawn_scoped,
+};
 use mtld3d_types::{
     D3DCREATE_HARDWARE_VERTEXPROCESSING, D3DCREATE_MULTITHREADED, D3DGETDATA_FLUSH, D3DISSUE_BEGIN,
     D3DISSUE_END, D3DQUERYTYPE_OCCLUSION,
@@ -155,12 +157,12 @@ fn two_devices_on_two_threads_wait_for_their_own_frames() {
     let finished = AtomicU32::new(0);
 
     std::thread::scope(|scope| {
-        let first_worker = scope.spawn(|| {
+        let first_worker = spawn_scoped(scope, || {
             let results = present_and_flush(&first_shared, &first_shared_query, FRAMES);
             finished.fetch_add(1, Ordering::AcqRel);
             results
         });
-        let second_worker = scope.spawn(|| {
+        let second_worker = spawn_scoped(scope, || {
             let results = present_and_flush(&second_shared, &second_shared_query, FRAMES);
             finished.fetch_add(1, Ordering::AcqRel);
             results
@@ -269,12 +271,12 @@ fn two_scaled_devices_on_two_threads_read_back_their_own_pixels() {
     let finished = AtomicU32::new(0);
 
     std::thread::scope(|scope| {
-        let first_worker = scope.spawn(|| {
+        let first_worker = spawn_scoped(scope, || {
             let results = readback_own_colour(&first_shared, RED, FRAMES);
             finished.fetch_add(1, Ordering::AcqRel);
             results
         });
-        let second_worker = scope.spawn(|| {
+        let second_worker = spawn_scoped(scope, || {
             let results = readback_own_colour(&second_shared, GREEN, FRAMES);
             finished.fetch_add(1, Ordering::AcqRel);
             results

--- a/windows/tests/tests/e2e/multithreaded.rs
+++ b/windows/tests/tests/e2e/multithreaded.rs
@@ -6,7 +6,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use mtld3d_tests::{Harness, HarnessConfig, Vertex, assert_pixel_eq};
+use mtld3d_tests::{Harness, HarnessConfig, Vertex, assert_pixel_eq, spawn_scoped};
 use mtld3d_types::{
     D3D_OK, D3DCREATE_HARDWARE_VERTEXPROCESSING, D3DCREATE_MULTITHREADED, D3DCULL_CCW, D3DCULL_CW,
     D3DCULL_NONE, D3DFMT_A8R8G8B8, D3DFVF_DIFFUSE, D3DFVF_XYZ, D3DGETDATA_FLUSH, D3DISSUE_BEGIN,
@@ -92,7 +92,7 @@ fn two_threads_drive_one_multithreaded_device() {
     let words = [0u32; 12];
 
     std::thread::scope(|scope| {
-        let worker = scope.spawn(|| {
+        let worker = spawn_scoped(scope, || {
             let mut results = Vec::new();
             let mut clockwise = false;
             while !stop.load(Ordering::Acquire) {

--- a/windows/tests/tests/e2e/render_scale.rs
+++ b/windows/tests/tests/e2e/render_scale.rs
@@ -27,7 +27,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use mtld3d_tests::{
     Harness, HarnessConfig, PosColorVertex, RhwVertex, SharedDevice, TexturedVertex,
-    assert_pixel_eq,
+    assert_pixel_eq, spawn_scoped,
 };
 use mtld3d_types::{
     D3D_OK, D3DCLEAR_TARGET, D3DCLEAR_ZBUFFER, D3DCMP_LESS, D3DCMP_LESSEQUAL,
@@ -1223,12 +1223,12 @@ fn two_devices_at_different_scales_read_their_own_vpos() {
     let identity_shared = identity.shared();
     let finished = AtomicU32::new(0);
     std::thread::scope(|scope| {
-        let half_worker = scope.spawn(|| {
+        let half_worker = spawn_scoped(scope, || {
             let outcome = probe_own_quadrants(&half_shared, &quad, FRAMES);
             finished.fetch_add(1, Ordering::AcqRel);
             outcome
         });
-        let identity_worker = scope.spawn(|| {
+        let identity_worker = spawn_scoped(scope, || {
             let outcome = probe_own_quadrants(&identity_shared, &quad, FRAMES);
             finished.fetch_add(1, Ordering::AcqRel);
             outcome

--- a/windows/tests/tests/e2e/window_lifecycle.rs
+++ b/windows/tests/tests/e2e/window_lifecycle.rs
@@ -13,7 +13,7 @@
 //! the harness window's `WM_DESTROY` posts `WM_QUIT` to its thread's queue,
 //! so a thread that destroyed one window cannot render on the next.
 
-use mtld3d_tests::{Harness, HarnessConfig, WindowStyle};
+use mtld3d_tests::{Harness, HarnessConfig, WindowStyle, spawn_scoped};
 
 /// Lanes creating and destroying at once.
 const LANES: usize = 6;
@@ -29,10 +29,10 @@ const ROUNDS: usize = 25;
 fn devices_and_windows_come_and_go_on_several_threads_at_once() {
     std::thread::scope(|scope| {
         for _ in 0..LANES {
-            scope.spawn(|| {
+            spawn_scoped(scope, || {
                 for _ in 0..ROUNDS {
                     std::thread::scope(|round| {
-                        round.spawn(|| {
+                        spawn_scoped(round, || {
                             let h = Harness::create(&HarnessConfig {
                                 window_style: WindowStyle::Framed,
                                 ..HarnessConfig::default()


### PR DESCRIPTION
A worker panic in a concurrent end-to-end test cannot be attributed. When a `std::thread::scope` worker of `device::concurrent_retargets_deliver_every_window_message_to_its_own_device` or of `window_lifecycle` fails, the harness's panic hook ends the process and stderr shows `thread '<unnamed>' panicked at tests/tests/e2e/device.rs:...`. The runner's note then reads `nothing names the test it ended in; running those again one at a time`, and the run pays a serial round of every in-flight test (three processes for a filtered run instead of two, hundreds of re-run tests in a whole-suite one).

The runner attributes a dead process by two lines that both carry a thread name: the `thread '<name>' panicked at` line the default hook prints, and the `[e2e] running <name>` line a thread writes when it creates a device. libtest names a test's own thread after the test, but a thread the test spawns has no name, so a worker announces nothing and panics as `<unnamed>`. The two tests that create devices only on workers therefore never appear in the in-flight set and their panics name nobody.

The fix is a harness helper, `mtld3d_tests::spawn_scoped`, that spawns a scoped thread through `thread::Builder` with the current thread's name: on a libtest thread that is the test's path, on a worker it is the name it was given, so nested scopes inherit it. Every spawn in the e2e tests goes through it (the one bare `std::thread::spawn` moved into a scope). Because a test now announces once per thread, the runner's `announced()` dedupes names in first-seen order. `make audit` bans raw `.spawn(`, `.spawn_scoped(`, `thread::spawn(` and `thread::Builder` under `windows/tests/tests/e2e/`, with the new CONVENTIONS section "Every end-to-end test names itself"; COVERAGE.md's claim that the announcement goes to stdout is corrected to stderr. Alongside, `create_cursor_from_bits` reads `GetLastError` right after `CreateBitmap` and `CreateIconIndirect` fail, before the `DeleteObject` calls that overwrite it, and logs it in both error lines, which is the next discriminator for the `CreateIconIndirect returned null` of #476 (that null reproduced twice in a hundred legs of the #461 campaign without any diagnostics environment, so the issue stays open for it).

Alternatives considered: making `announce()` once per test name process-wide needs a set, and the test crate deliberately carries no `rustc_hash`, so the dedupe lives in the runner where it costs a scan over a handful of names. Naming workers inline with `thread::Builder` at every site would let the next test use `scope.spawn` again; the helper plus the audit rule makes the omission a gate failure. Having the runner charge `<unnamed>` panics to the tests whose announcements lack an outcome was rejected because several such tests can be in flight and the guess would be wrong.

Verification: `make check` green; `make test ISOLATED=1 JOBS=4 FAIL_FAST=0` green, both legs 480 passed in 4 processes. With a probe `assert!(false, "attribution probe")` inside a windowed worker, `make test-e2e-x86_64 ISOLATED=1 JOBS=4 FAIL_FAST=0 FILTER='device:: window_lifecycle::'` prints `FAIL e2e::device::concurrent_retargets_deliver_every_window_message_to_its_own_device` with the worker's `thread 'device::concurrent_retargets_...' (756) panicked at` line as its report, the note lists that test in flight, and the summary reads `49 passed, 1 failed; 2 processes` with no "nothing names the test" note; without the probe the same filter is `50 passed; 1 processes`. `scripts/audit.sh --file` on a scratch e2e file with `scope.spawn(` and `std::thread::spawn(` reports both lines under the new section and the helper's own file stays clean. A reviewer should look at the `(756)` thread id on the FAIL line (the id is the worker's, the name is the test's), at the kept stderr showing four announcements of the one test and zero `<unnamed>` lines, and at the `announced` unit test for the dedupe order.

Refs #476.
