### PR TITLE
Log why a back buffer create fails and release its orphans

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,12 @@ while its sibling legs are green, re-run the failed jobs first (`gh run rerun
 <run-id> --failed`, which lands on a fresh machine) and read the command
 buffer errors in the artifact's log, since a hosted runner's GPU can fail that
 way with no hang line in the job log and nothing else tells it from a
-regression.
+regression. A `CreateBackbuffer` failure on the Intel image is read the same
+way: its unix line names the request and the device, and a sane request (the
+window's size, `BGRA8Unorm`, a sample count the device answered for) that
+`newTextureWithDescriptor` refused on that image's GPU, the paravirtual
+`AppleParavirtGPUMetal`, is the same runner fault, so re-run the failed jobs.
+A line naming a zero dimension or a null handle is the layer's own bug.
 
 Two things are worth knowing when a test process looks wrong. `d3d9.dll`
 terminates the process from its `DLL_PROCESS_DETACH` once a device exists

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -383,6 +383,7 @@ pub extern "C" fn destroy_command_queue_handler(args: *mut c_void) -> i32 {
 pub extern "C" fn create_backbuffer_handler(args: *mut c_void) -> i32 {
     // SAFETY: unix-call handler params; PE side passes *mut CreateBackbufferParams.
     let Some(mut params) = (unsafe { InPtrMut::<CreateBackbufferParams>::opt(args) }) else {
+        error!(target: LOG_TARGET, "CreateBackbuffer: null params pointer");
         return -1;
     };
     let params: &mut CreateBackbufferParams = &mut params;
@@ -393,7 +394,11 @@ pub extern "C" fn create_backbuffer_handler(args: *mut c_void) -> i32 {
         params.width,
         params.height,
     ) else {
-        error!(target: LOG_TARGET, "failed to create backbuffer");
+        error!(
+            target: LOG_TARGET,
+            "failed to create {}x{} backbuffer (samples={})",
+            params.width, params.height, params.sample_count
+        );
         return STATUS_UNSUCCESSFUL;
     };
     let msaa = metal::create_msaa_companion(
@@ -407,8 +412,15 @@ pub extern "C" fn create_backbuffer_handler(args: *mut c_void) -> i32 {
     if params.sample_count > 1 && msaa.is_none() {
         error!(
             target: LOG_TARGET,
-            "failed to create {}x multisampled backbuffer companion", params.sample_count
+            "failed to create the {}x multisampled companion of the {}x{} backbuffer; the \
+             single-sample texture is released again",
+            params.sample_count, params.width, params.height
         );
+        // Both handles are minted and neither has been handed back, so this
+        // side owns their only copies; the view goes first, since it holds a
+        // retain on its base.
+        metal::destroy_texture(srgb_handle);
+        metal::destroy_texture(handle.raw());
         return STATUS_UNSUCCESSFUL;
     }
     params.texture_handle = handle;
@@ -673,8 +685,14 @@ pub extern "C" fn create_color_target_handler(args: *mut c_void) -> i32 {
     if params.sample_count > 1 && msaa.is_none() {
         error!(
             target: LOG_TARGET,
-            "failed to create {}x multisampled color target companion", params.sample_count
+            "failed to create the {}x multisampled companion of the {}x{} {:?} color target; \
+             the single-sample texture is released again",
+            params.sample_count, params.width, params.height, params.pixel_format
         );
+        // Same ownership as the back buffer's companion failure above: both
+        // minted handles are still this side's only copies.
+        metal::destroy_texture(srgb_handle);
+        metal::destroy_texture(handle.raw());
         return STATUS_UNSUCCESSFUL;
     }
     params.texture_handle = handle;

--- a/unix/unix/src/metal/texture.rs
+++ b/unix/unix/src/metal/texture.rs
@@ -67,14 +67,22 @@ pub fn create_backbuffer(
     // process. `MAX_TEXTURE_DIM` is the Metal 2D limit on the supported GPUs.
     const MAX_TEXTURE_DIM: u32 = 16384;
     if width == 0 || height == 0 || width > MAX_TEXTURE_DIM || height > MAX_TEXTURE_DIM {
+        log::error!(
+            target: crate::LOG_TARGET,
+            "create_backbuffer: {width}x{height} is outside the 1..={MAX_TEXTURE_DIM} Metal \
+             accepts per dimension; refused",
+        );
         return None;
     }
-    let device = device_handle.into_retained()?;
+    let Some(device) = device_handle.into_retained() else {
+        log::error!(target: crate::LOG_TARGET, "create_backbuffer: null device handle");
+        return None;
+    };
     let texture = create_color_texture(
         &device,
         width,
         height,
-        MTLPixelFormat::BGRA8Unorm,
+        PixelFormat::Bgra8Unorm,
         "mtld3d-backbuffer",
     )?;
     clear_texture_black(queue_handle, &texture);
@@ -127,7 +135,7 @@ fn texture_usage(
     usage
 }
 
-/// The sRGB twin view of a colour texture, or 0 when the format has no twin.
+/// The sRGB twin view of a colour texture, or 0 when it has none.
 ///
 /// The base texture's usage allows the view (see [`texture_usage`]), and the
 /// view inherits that usage, which keeps a render target's twin
@@ -135,6 +143,12 @@ fn texture_usage(
 /// handle is handed out with, so the two views differ only in transfer
 /// function; a render target is always handed out unswizzled, since Metal
 /// forbids rendering through a channel swizzle.
+///
+/// 0 means either that the format has no sRGB counterpart or that Metal
+/// declined the view. The PE side treats both alike: a target without a twin
+/// has `D3DRS_SRGBWRITEENABLE` applied in the pixel shader, ahead of the
+/// blender, so the second case is a fidelity loss, not a failure, and is
+/// warned about once here.
 fn srgb_twin_view(
     texture: &ProtocolObject<dyn MTLTexture>,
     format: PixelFormat,
@@ -157,11 +171,18 @@ fn srgb_twin_view(
             swizzle,
         )
     };
-    view.map_or(0, |view| {
-        let srgb_label = objc2_foundation::NSString::from_str(&format!("{label}-srgb"));
-        view.setLabel(Some(&srgb_label));
-        mint(view)
-    })
+    let Some(view) = view else {
+        mtld3d_shared::log_once_warn!(
+            target: crate::LOG_TARGET,
+            "{label}: Metal declined the {srgb_format:?} view of a {format:?} texture; \
+             D3DRS_SRGBWRITEENABLE on this target encodes in the pixel shader, before the \
+             blender",
+        );
+        return 0;
+    };
+    let srgb_label = objc2_foundation::NSString::from_str(&format!("{label}-srgb"));
+    view.setLabel(Some(&srgb_label));
+    mint(view)
 }
 
 /// Clear a freshly created render target to opaque black.
@@ -270,13 +291,8 @@ pub fn create_color_target(
     pixel_format: PixelFormat,
 ) -> Option<(MetalHandle<MTLTextureKind>, u64)> {
     let device = device_handle.into_retained()?;
-    let texture = create_color_texture(
-        &device,
-        width,
-        height,
-        mtl_pixel_format(pixel_format),
-        "mtld3d-color-target",
-    )?;
+    let texture =
+        create_color_texture(&device, width, height, pixel_format, "mtld3d-color-target")?;
     let srgb_handle = srgb_twin_view(
         &texture,
         pixel_format,
@@ -313,7 +329,7 @@ pub fn create_upscale_target(
         device,
         width,
         height,
-        mtl_pixel_format(pixel_format),
+        pixel_format,
         "mtld3d-upscale-scratch",
     )?;
     // SAFETY: `Retained::into_raw` transfers the retain; `MetalHandle::new`
@@ -333,14 +349,14 @@ fn create_color_texture(
     device: &ProtocolObject<dyn MTLDevice>,
     width: u32,
     height: u32,
-    mtl_format: objc2_metal::MTLPixelFormat,
+    pixel_format: PixelFormat,
     label: &str,
 ) -> Option<Retained<ProtocolObject<dyn MTLTexture>>> {
     // SAFETY: objc2 typed binding; class-method constructor on
     // `MTLTextureDescriptor` returns a freshly autoreleased descriptor.
     let desc = unsafe {
         MTLTextureDescriptor::texture2DDescriptorWithPixelFormat_width_height_mipmapped(
-            mtl_format,
+            mtl_pixel_format(pixel_format),
             width as usize,
             height as usize,
             false,
@@ -349,10 +365,43 @@ fn create_color_texture(
     desc.setUsage(texture_usage(device, true, true));
     desc.setStorageMode(MTLStorageMode::Private);
 
-    let texture = device.newTextureWithDescriptor(&desc)?;
+    let Some(texture) = device.newTextureWithDescriptor(&desc) else {
+        log_texture_refused(device, &desc, pixel_format, label);
+        return None;
+    };
     let label = objc2_foundation::NSString::from_str(label);
     texture.setLabel(Some(&label));
     Some(texture)
+}
+
+/// Report a texture descriptor the device returned nil for.
+///
+/// `newTextureWithDescriptor:` gives no reason, so the line carries both
+/// sides of the refusal: the descriptor as it was submitted, and the device's
+/// identity and memory figures. Together they separate a request the layer
+/// got wrong from a sane one the device could not serve, which is the
+/// difference between a bug here and an exhausted or paravirtualized GPU.
+fn log_texture_refused(
+    device: &ProtocolObject<dyn MTLDevice>,
+    desc: &MTLTextureDescriptor,
+    pixel_format: PixelFormat,
+    label: &str,
+) {
+    log::error!(
+        target: crate::LOG_TARGET,
+        "{label}: newTextureWithDescriptor returned nil for {}x{} {pixel_format:?} samples={} \
+         usage={:#x} storage={} on '{}' (allocated {} B, recommended working set {} B, unified \
+         memory: {})",
+        desc.width(),
+        desc.height(),
+        desc.sampleCount(),
+        desc.usage().0,
+        desc.storageMode().0,
+        device.name(),
+        device.currentAllocatedSize(),
+        device.recommendedMaxWorkingSetSize(),
+        device.hasUnifiedMemory(),
+    );
 }
 
 /// Creates the multisampled companion of a single-sample render target.
@@ -384,7 +433,10 @@ pub fn create_msaa_companion(
     if sample_count <= 1 {
         return None;
     }
-    let device = device_handle.into_retained()?;
+    let Some(device) = device_handle.into_retained() else {
+        log::error!(target: crate::LOG_TARGET, "{label}: null device handle");
+        return None;
+    };
     let mtl_format = mtl_pixel_format(pixel_format);
     // SAFETY: objc2 typed binding; class-method constructor on
     // `MTLTextureDescriptor` returns a freshly autoreleased descriptor.
@@ -403,7 +455,10 @@ pub fn create_msaa_companion(
     desc.setUsage(texture_usage(&device, true, true));
     desc.setStorageMode(MTLStorageMode::Private);
 
-    let texture = device.newTextureWithDescriptor(&desc)?;
+    let Some(texture) = device.newTextureWithDescriptor(&desc) else {
+        log_texture_refused(&device, &desc, pixel_format, label);
+        return None;
+    };
     let ns_label = objc2_foundation::NSString::from_str(label);
     texture.setLabel(Some(&ns_label));
     let srgb_handle = srgb_twin_view(&texture, pixel_format, 1, 1, IDENTITY_SWIZZLE, label);

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -2605,7 +2605,12 @@ impl DeviceInner {
         if status != 0 || bb_params.texture_handle.is_null() {
             error!(
                 target: LOG_TARGET,
-                "apply_auto_resize: CreateBackbuffer failed (0x{status:08X}) — device unusable",
+                "apply_auto_resize: CreateBackbuffer failed (0x{status:08X}) for \
+                 {new_width}x{new_height} (render {}x{}) samples={} fmt={}; device unusable",
+                bb_params.width,
+                bb_params.height,
+                bb_params.sample_count,
+                self.present_params.back_buffer_format,
             );
             self.set_backbuffer_handle(MetalHandle::NULL, MetalHandle::NULL);
             self.set_backbuffer_msaa_handle(MetalHandle::NULL, MetalHandle::NULL);
@@ -4301,7 +4306,17 @@ fn reset_recreate_resources(
     };
     let status = unix_call(&mut bb_params);
     if status != 0 || bb_params.texture_handle.is_null() {
-        error!(target: LOG_TARGET, "Reset: CreateBackbuffer failed (0x{status:08X}) — device unusable");
+        error!(
+            target: LOG_TARGET,
+            "Reset: CreateBackbuffer failed (0x{status:08X}) for {}x{} (render {}x{}) samples={} \
+             fmt={}; device unusable",
+            pp.back_buffer_width,
+            pp.back_buffer_height,
+            bb_params.width,
+            bb_params.height,
+            bb_params.sample_count,
+            pp.back_buffer_format,
+        );
         dev.set_backbuffer_handle(MetalHandle::NULL, MetalHandle::NULL);
         dev.set_backbuffer_msaa_handle(MetalHandle::NULL, MetalHandle::NULL);
         dev.set_depth_stencil_handle(MetalHandle::NULL);

--- a/windows/d3d9/src/direct3d9.rs
+++ b/windows/d3d9/src/direct3d9.rs
@@ -1173,22 +1173,42 @@ unsafe extern "system" {
 /// Client-area pixel dimensions of `hwnd`, or `None` when the call fails or the rect is empty.
 ///
 /// The single `GetClientRect` boundary is concentrated here so the call site
-/// stays unsafe-free.
+/// stays unsafe-free. A null window is the caller's own case (no window to
+/// read) and passes silently; the two other ways to `None`, a window user32
+/// cannot read and a window with no client area, are warned about once per
+/// window, since either leaves the requested size standing where the caller
+/// expected the window's.
 fn client_rect_dims(hwnd: *mut c_void) -> Option<(u32, u32)> {
     if hwnd.is_null() {
         return None;
     }
+    let window = hwnd as usize as u64;
     let mut rect = Rect::EMPTY;
     // SAFETY: GetClientRect accepts any HWND and writes a RECT through the
     // out pointer; `rect` is an owned local, so non-null + aligned + writable
     // holds. A bad HWND yields a zero return, handled below.
     let ok = unsafe { GetClientRect(hwnd, &raw mut rect) };
     if ok == 0 {
+        mtld3d_shared::log_once_warn_by!(
+            target: LOG_TARGET,
+            key: window,
+            "GetClientRect({window:#x}) failed: the window is gone or not this process's; the \
+             requested back-buffer size stands",
+        );
         return None;
     }
-    let w = u32::try_from(rect.width()).ok()?;
-    let h = u32::try_from(rect.height()).ok()?;
-    (w != 0 && h != 0).then_some((w, h))
+    let w = u32::try_from(rect.width()).unwrap_or(0);
+    let h = u32::try_from(rect.height()).unwrap_or(0);
+    if w == 0 || h == 0 {
+        mtld3d_shared::log_once_warn_by!(
+            target: LOG_TARGET,
+            key: window,
+            "window {window:#x} has an empty client area ({w}x{h}); the requested back-buffer \
+             size stands",
+        );
+        return None;
+    }
+    Some((w, h))
 }
 
 /// `true` when `width`x`height` is a mode `EnumAdapterModes` serves.
@@ -1490,7 +1510,16 @@ extern "system" fn d3d9_create_device(
     };
     let status = unix_call(&mut bb_params);
     if status != 0 {
-        error!(target: LOG_TARGET, "CreateBackbuffer failed (0x{status:08X})");
+        error!(
+            target: LOG_TARGET,
+            "CreateBackbuffer failed (0x{status:08X}) for {}x{} (render {}x{}) samples={} fmt={}",
+            pp.back_buffer_width,
+            pp.back_buffer_height,
+            bb_params.width,
+            bb_params.height,
+            bb_params.sample_count,
+            pp.back_buffer_format,
+        );
         destroy_partial_device(
             &cq_params,
             layer_params.view_handle,


### PR DESCRIPTION
On the Intel CI image (runs 34041227587 and 34049263634) a windowed Reset in the concurrent retarget test failed with three lines in the layer log: `ERROR mtld3d::unix: failed to create backbuffer`, then `Reset: CreateBackbuffer failed (0xC0000001) ... device unusable`, then `windowed Reset onto window 0x... failed: 0x8876086C`. Nothing in the artifacts says what was asked for or which step refused it, so the run could be classified neither as a runner fault nor as a regression.

The root cause is conjecture, because every branch was silent: the paravirtual GPU on that image (`AppleParavirtGPUMetal`) returned nil from `newTextureWithDescriptor` for a sane BGRA8 back buffer. `create_backbuffer` returns `None` from three places without a line (the dimension check, a null device handle, the nil texture), `create_msaa_companion` has the same shape, `srgb_twin_view` hands back 0 silently, the handler's null-params return is silent, and the PE side logs only the NTSTATUS. `client_rect_dims` folds a failed `GetClientRect` and an empty rect into one `None`. On top of that, a companion failure returned after the single-sample texture and its sRGB view had already been minted into `LIVE_TEXTURES`, orphaning both; the colour-target handler had the same orphan.

Every `None` branch on the unix side now logs at error level. The nil-texture line, shared by the colour creators and the multisampled companion, names the descriptor as submitted (dimensions, wire pixel format, sample count, usage bits, storage mode) and the device's name, current allocation, recommended working set and unified-memory flag, which separates a request the layer got wrong from one the device could not serve. A declined sRGB view warns once and states the consequence (sRGB writes to that target encode in the pixel shader). Both handlers release the minted single-sample texture and its view through `destroy_texture` when the companion fails, so the ledger stays exact. The three PE failure sites name the requested and render dimensions, sample count and back-buffer format beside the status, and `client_rect_dims` warns once per window for a failed `GetClientRect` and for an empty client area. `CONTRIBUTING.md` says how to classify the new line on the Intel image.

Alternatives considered: keeping the descriptor line at the callers instead of in `create_color_texture` would have needed three copies and missed the colour-target path. Logging the device figures once at device creation would not show the allocation at the moment of refusal, which is the number that matters for an exhausted device. Passing the failure reason back over the wire as a new field was rejected: it changes the wire format for a diagnostic the log already carries.

Verification: `make check` green. `make test ISOLATED=1 JOBS=4 FAIL_FAST=0` on both architectures, 480/480 with 4 processes each, and the same under `INTEL=1`. With `create_color_texture` temporarily refusing the back buffer, `device::reset_resize_grows_backbuffer` logs `mtld3d-backbuffer: newTextureWithDescriptor returned nil for 800x600 Bgra8Unorm samples=1 usage=0x5 storage=2 on 'Apple M5 Max' (allocated 1228800 B, recommended working set 55662788608 B, unified memory: true)` followed by `Reset: CreateBackbuffer failed (0xC0000001) for 800x600 (render 800x600) samples=1 fmt=22; device unusable`. With the companion temporarily refused, a ledger trace over `msaa::` drops by exactly two at every failure and no `is not a live texture handle` warning appears. Both probes were removed and the filters re-run green.

Refs #477.
