### PR TITLE
Wait for the resolve to retire before copying out of it on the paravirtual device

### DIFF
--- a/unix/conformance/CONFORMANCE.md
+++ b/unix/conformance/CONFORMANCE.md
@@ -923,11 +923,16 @@ The paravirtual device hands a later encoder of the same command buffer the
 content the resolve target held before the resolve (measured in the
 workflow's probe job, with and without an encoder in between); Apple GPUs
 see the resolve. The draws are therefore tested against the target's clear
-rather than the resolved scene. A device fault in Metal's ordering guarantee
-that no layer-side change short of a submit per resolve would mask, so
-`expected`; a real Intel/AMD Mac is expected to read zero here. 17330 reads
-its full count on one run and zero on the next, since the resolve sometimes
-lands before the load after all; `flaky`, pinned at the higher count.
+rather than the resolved scene. A device fault in Metal's ordering
+guarantee, and a submit boundary alone does not mask it either: a copy in
+the next command buffer can still read the pre-resolve content. The layer
+therefore waits for the resolving command buffer to complete before it
+copies out of a resolve target on this device (`RESOLVE_NEEDS_RETIRE` in
+`DeviceCapsFlags`), the wait a readback pays anyway; these two sites read
+through a draw, not a copy, so they stay `expected`, and a real Intel/AMD
+Mac is expected to read zero here. 17330 reads its full count on one run
+and zero on the next, since the resolve sometimes lands before the load
+after all; `flaky`, pinned at the higher count.
 
 ### visual.c/test_multisample_mismatch
 Sites: 20880=expected 20883=expected 20959=expected 20962=expected

--- a/unix/shared/src/mtl.rs
+++ b/unix/shared/src/mtl.rs
@@ -700,6 +700,17 @@ bitflags! {
         const SAMPLE_COUNT_4 = 1 << 4;
         /// `supportsTextureSampleCount:8` answered yes.
         const SAMPLE_COUNT_8 = 1 << 5;
+        /// A copy out of a resolve target must wait for the resolving command buffer to complete.
+        ///
+        /// Metal orders one queue's command buffers, so a copy that follows
+        /// a multisample resolve reads the resolved content. The
+        /// paravirtualized device a CI runner exposes does not honour that
+        /// across a command-buffer boundary: the copy can read what the
+        /// target held before the resolve. Metal has no query for it, so
+        /// the unix side answers from the device's name, and the encoder
+        /// waits for the last submitted command buffer before it copies
+        /// out of a resolve target when this is set.
+        const RESOLVE_NEEDS_RETIRE = 1 << 6;
     }
 }
 

--- a/unix/unix/src/metal/device.rs
+++ b/unix/unix/src/metal/device.rs
@@ -102,6 +102,10 @@ pub fn default_device_info() -> Option<(String, u64, DeviceCapsFlags)> {
         DeviceCapsFlags::SAMPLE_COUNT_8,
         device.supportsTextureSampleCount(8),
     );
+    caps.set(
+        DeviceCapsFlags::RESOLVE_NEEDS_RETIRE,
+        resolve_needs_retire(&device),
+    );
     Some((name, registry_id, caps))
 }
 
@@ -133,6 +137,18 @@ pub fn supports_sampler_mirror_clamp(device: &ProtocolObject<dyn MTLDevice>) -> 
 /// its name instead.
 fn is_paravirtual(device: &ProtocolObject<dyn MTLDevice>) -> bool {
     device.name().to_string().contains("Paravirtual")
+}
+
+/// True when a copy out of a resolve target has to wait for the resolve's command buffer.
+///
+/// Every real GPU orders the command buffers of one queue, so a copy in a
+/// later command buffer reads the resolved content. The paravirtualized
+/// device can hand that copy the content the target held before the
+/// resolve, so the encoder waits for the resolving command buffer to
+/// complete first on it. Metal offers no query for the fault, so the
+/// device's name is the whole predicate.
+fn resolve_needs_retire(device: &ProtocolObject<dyn MTLDevice>) -> bool {
+    is_paravirtual(device)
 }
 
 /// True when the device belongs to Metal's Apple GPU family.

--- a/windows/core/src/gpu_caps.rs
+++ b/windows/core/src/gpu_caps.rs
@@ -12,6 +12,8 @@
 //!
 //! See `storage_policy` for the consumer fns.
 
+use mtld3d_shared::mtl::DeviceCapsFlags;
+
 /// The linear-texture row alignment a Mac2 (Intel/AMD) device reports for `BGRA8Unorm`.
 ///
 /// Apple-family devices report 16. `intel.linearAlign256` raises a smaller
@@ -33,6 +35,12 @@ pub struct GpuCaps {
     /// 16 on Apple Silicon, 256 on Mac2 (AMD/Intel). Used as the floor
     /// for blit-staging `bytes_per_row`.
     pub min_linear_texture_align: u32,
+    /// The device's boolean answers from the `GetDeviceInfo` thunk.
+    ///
+    /// The encoder consults one of them, `RESOLVE_NEEDS_RETIRE`, through
+    /// [`Self::resolve_needs_retire`]; the caps advertisement reads the
+    /// rest from its own process-wide copy of the same answer.
+    pub device_caps: DeviceCapsFlags,
 }
 
 impl GpuCaps {
@@ -44,7 +52,21 @@ impl GpuCaps {
         Self {
             unified_memory: true,
             min_linear_texture_align: 16,
+            device_caps: DeviceCapsFlags::empty(),
         }
+    }
+
+    /// Whether a copy out of a resolve target waits for the resolving command buffer.
+    ///
+    /// Metal orders the command buffers of one queue, so the answer is no on
+    /// every real GPU; the paravirtualized device answers yes because it can
+    /// hand a later command buffer's copy the content the target held before
+    /// the resolve. The forced Intel answers leave it alone: they describe an
+    /// Intel/AMD Mac, whose GPU orders its queue.
+    #[must_use]
+    pub const fn resolve_needs_retire(self) -> bool {
+        self.device_caps
+            .contains(DeviceCapsFlags::RESOLVE_NEEDS_RETIRE)
     }
 
     /// Apply the `intel.managedMemory` and `intel.linearAlign256` answers over the device's.
@@ -66,6 +88,7 @@ impl GpuCaps {
         Self {
             unified_memory: self.unified_memory && !managed_memory,
             min_linear_texture_align,
+            device_caps: self.device_caps,
         }
     }
 }

--- a/windows/core/src/gpu_caps/tests.rs
+++ b/windows/core/src/gpu_caps/tests.rs
@@ -10,6 +10,10 @@
 //! nothing else, a device already at that answer is left alone, a larger device alignment is
 //! kept, and no overrides mean no change. Nothing D3D9-visible proves a forced override took, so
 //! these are the only place the fold itself is checked.
+//!
+//! The resolve-retire tests pin `resolve_needs_retire` to the `RESOLVE_NEEDS_RETIRE` bit of the
+//! device's answer and pin the overrides to leaving it alone: the forced Intel answers describe
+//! an Intel/AMD Mac, whose GPU orders its queue, so they must not turn the wait on.
 
 use super::*;
 
@@ -53,6 +57,7 @@ fn overrides_are_idempotent_on_a_mac2_device() {
     let mac2 = GpuCaps {
         unified_memory: false,
         min_linear_texture_align: 256,
+        device_caps: DeviceCapsFlags::empty(),
     };
     let caps = mac2.with_intel_overrides(true, true);
     assert!(!caps.unified_memory);
@@ -64,7 +69,35 @@ fn linear_align256_keeps_a_larger_device_alignment() {
     let wide = GpuCaps {
         unified_memory: true,
         min_linear_texture_align: 512,
+        device_caps: DeviceCapsFlags::empty(),
     };
     let caps = wide.with_intel_overrides(false, true);
     assert_eq!(caps.min_linear_texture_align, 512);
+}
+
+#[test]
+fn resolve_retire_follows_the_device_bit() {
+    assert!(!GpuCaps::apple_silicon_default().resolve_needs_retire());
+    let paravirtual = GpuCaps {
+        device_caps: DeviceCapsFlags::RESOLVE_NEEDS_RETIRE | DeviceCapsFlags::SAMPLE_COUNT_4,
+        ..GpuCaps::apple_silicon_default()
+    };
+    assert!(paravirtual.resolve_needs_retire());
+    let other_bits = GpuCaps {
+        device_caps: DeviceCapsFlags::SAMPLER_BORDER | DeviceCapsFlags::SAMPLE_COUNT_4,
+        ..GpuCaps::apple_silicon_default()
+    };
+    assert!(!other_bits.resolve_needs_retire());
+}
+
+#[test]
+fn intel_overrides_leave_resolve_retire_alone() {
+    let caps = GpuCaps::apple_silicon_default().with_intel_overrides(true, true);
+    assert!(!caps.resolve_needs_retire());
+    let paravirtual = GpuCaps {
+        device_caps: DeviceCapsFlags::RESOLVE_NEEDS_RETIRE,
+        ..GpuCaps::apple_silicon_default()
+    }
+    .with_intel_overrides(true, true);
+    assert!(paravirtual.resolve_needs_retire());
 }

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -7432,6 +7432,12 @@ fn emit_stretch_rect_blit(
     // SAFETY: `src_handle` came from the encoder's texture cache or from a
     // surface's retained handle, both of which are `MTLTexture` handles.
     enc.note_msaa_read(unsafe { MetalHandle::<MTLTextureKind>::new(src_handle) });
+    // A source with a multisampled companion is a resolve target, and a
+    // resolve the last submission stored into it must have completed before
+    // this copy reads it on a device that does not order that itself.
+    if !src_info.msaa.is_null() {
+        enc.wait_for_resolve_retire();
+    }
     let dst_handle = match &dst_info.kind {
         StretchKind::Texture(info) => enc.get_or_create_texture(info),
         StretchKind::Backbuffer(h) | StretchKind::DepthStencil(h) => h.raw(),

--- a/windows/d3d9/src/direct3d9.rs
+++ b/windows/d3d9/src/direct3d9.rs
@@ -1743,6 +1743,7 @@ fn spawn_encoder_and_prewarm(
     let gpu_caps = mtld3d_core::gpu_caps::GpuCaps {
         unified_memory: cq.unified_memory != 0,
         min_linear_texture_align: cq.min_linear_texture_align,
+        device_caps: device_caps_flags(),
     }
     .with_intel_overrides(cfg.managed_memory, cfg.linear_align256);
     let encoder = EncoderThread::spawn(gpu_caps, Arc::clone(cfg));

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -8163,15 +8163,43 @@ impl FrameEncoder {
     /// been given a `coherent_seq` pointer or hasn't submitted any frame —
     /// both states arrive together in `begin_frame`.
     fn wait_for_gpu_idle(&self) {
-        if self.coherent_seq_ptr == 0 || self.current_submit_seq == 0 {
+        self.wait_for_gpu_retire(self.current_submit_seq);
+    }
+
+    /// Block until `coherent_seq >= target_seq`.
+    ///
+    /// A target of 0 names no frame, and a target the encoder never
+    /// submitted is answered by the atomic alone on the unix side, so
+    /// neither waits.
+    fn wait_for_gpu_retire(&self, target_seq: u64) {
+        if self.coherent_seq_ptr == 0 || target_seq == 0 {
             return;
         }
         let mut params = WaitForGpuRetireParams {
-            target_seq: self.current_submit_seq,
+            target_seq,
             coherent_seq_ptr: self.coherent_seq_ptr,
             failed_submit_seq_ptr: self.failed_seq_ptr,
         };
         let _ = unix_call(&mut params);
+    }
+
+    /// Hold a copy out of a resolve target until the resolving command buffer has completed.
+    ///
+    /// A no-op unless the device answered `RESOLVE_NEEDS_RETIRE`. There, a
+    /// copy that reads a multisample resolve target from a later command
+    /// buffer can see the content the target held before the resolve, so
+    /// the copy waits for every command buffer submitted so far. The ops of
+    /// a frame run before that frame is submitted, so the last submitted
+    /// command buffer is the one before `current_submit_seq`; the submit
+    /// thread is drained first so that buffer is committed and registered
+    /// for the wait. A resolve recorded in the frame being built is ordered
+    /// by the pass list itself, through `note_msaa_read`.
+    pub fn wait_for_resolve_retire(&mut self) {
+        if !self.gpu_caps.resolve_needs_retire() {
+            return;
+        }
+        self.drain_submit_thread();
+        self.wait_for_gpu_retire(self.current_submit_seq.saturating_sub(1));
     }
 }
 

--- a/windows/tests/tests/e2e/msaa.rs
+++ b/windows/tests/tests/e2e/msaa.rs
@@ -483,7 +483,7 @@ fn depth_test_holds_on_a_multisampled_target() {
     let row = back_buffer_row(&h);
     assert!(
         count_intermediate(&row) > 0,
-        "the depth-tested 4x edge still resolves"
+        "the depth-tested 4x edge still resolves: {row:02X?}"
     );
     assert_pixel_eq(
         row[INSIDE_X as usize],


### PR DESCRIPTION
`msaa::depth_test_holds_on_a_multisampled_target` fails on the `macos-15-intel` i686 leg in about half of the main runs, at `msaa.rs:484`, `count_intermediate(&row) > 0` ("the depth-tested 4x edge still resolves"). The other fourteen msaa tests pass on the same legs, the layer log has no `pipeline creation failed` or `CreateDepthTexture failed` line, and the `dropping depth for this pass` warning in it is the once-per-process line that `a_single_sampled_depth_surface_drops_beside_a_multisampled_target` provokes on purpose just before.

The strongest surviving explanation is the documented paravirtual resolve fault reaching across a command-buffer boundary. The test's `back_buffer_row` does `StretchRect(backbuffer -> single-sampled RT)`, then `GetRenderTargetData`. The resolve is not the StretchRect: the multisampled companion is the pass attachment and the resolve into the single-sample twin is the `StoreAndMultisampleResolve` store of the Present's last pass. The StretchRect op runs in the next frame, reads the twin, and `note_msaa_read` walks only that submission's passes, so it finds nothing; the copy is a plain blit in the trailing blit list. `GetRenderTargetData` then forces a flush (commit, not completion) and reads back with its own completion wait. So the layout is command buffer N (the resolve), N+1 (the copy out of the twin), N+2 (the readback). Metal orders one queue's command buffers, so a correct device copies the resolved twin; `CONFORMANCE.md` already records that this device hands a later encoder the content a resolve target held before the resolve, sometimes, and the same fault one command buffer later gives exactly a black row half the time. Four alternatives were ruled out from the two artifacts: a pipeline or depth-texture creation failure (no such line in the log); the depth-attachment drop (the warning is the sibling test's, once per process, and this test creates a 4x depth surface that binds); a whole-leg GPU failure on the runner (every other test in the process reads back correctly, and the failure is intermittent within one leg); and a race in the layer's own submission ordering (the flush commits N before N+1 is built, and the readback's wait already covers N+2).

The fix is one wait on the encoder thread, on this device only. The unix side answers a new `DeviceCapsFlags::RESOLVE_NEEDS_RETIRE` bit from the device name, beside the two sampler predicates that already sniff it; the PE side carries it on `GpuCaps` through the existing cached `GetDeviceInfo` answer. `emit_stretch_rect_blit`, when the source has a multisampled companion (it is a resolve target), calls `FrameEncoder::wait_for_resolve_retire`, which drains the submit thread so the previous frame is committed and then waits for that frame's command buffer to complete before the copy is queued. It is the same wait a readback pays anyway, and every other device pays a flags test. The failing assertion now prints the row, as its three siblings do, and the conformance entry for `multisampled_depth_buffer_test` no longer claims that a submit per resolve would mask the fault; its two sites read through a draw, not a copy, and stay `expected`.

Alternatives considered. A submit per resolve: the evidence shows a command-buffer boundary alone does not order the copy after the resolve on this device, which is why the previous sentence in `CONFORMANCE.md` was wrong. Waiting on the API thread: it would serialize the game's thread on the GPU for every StretchRect out of a multisampled surface, and the op already runs on the encoder thread where the previous submission's seq is known. Gating the test on the device: it would hide a real device fault on the one image whose job is to run the Intel paths, and the fix costs nothing elsewhere.

Verification: `make check`, `make test-unit` (two new `gpu_caps` tests pin that the bit is read and that the forced Intel overrides leave it alone), `make test-e2e-x86_64` and `make test-e2e-i686` with `ISOLATED=1 JOBS=4 FAIL_FAST=0` (482 passed, 4 processes each), and the i686 leg under `INTEL=1` (482 passed; the flag stays off there, since the device is not paravirtual). With the bit forced on and a temporary log line at the wait site, the msaa filter on x86_64 showed one wait per StretchRect from a resolve target (11 in the file) and, for the failing test alone, exactly `seq=2 waits for seq=1`; both temporaries were removed and the filter re-run green. This Apple GPU never sets the flag, so the local legs prove no regression only; the Intel i686 leg on main is the real check, at a baseline of about one failure in two runs, so one green run is weak evidence and the row in the message is what the next occurrence will show.

Refs #510
