### PR TITLE
Preserve main CI runs and shorten check feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,11 @@ permissions:
   contents: read
 
 concurrency:
-  # One bucket per ref, so a second push to a PR cancels the fan-out already
-  # grinding on the commit it superseded. Not on main: every commit there gets a
-  # complete, attributable result rather than a cancelled one. A probe-only
-  # dispatch has its own bucket, so it neither waits for nor displaces a full
-  # run of the same branch.
-  group: ci-${{ github.ref }}-${{ inputs.probe_only && 'probe' || 'full' }}
+  # PR updates share a group so a new head cancels the superseded run. Main
+  # uses one group per run: cancel-in-progress=false alone still lets a new
+  # pending run replace an older pending run. Keep every main result for
+  # comparison across commits. Probe-only dispatches have their own group.
+  group: ci-${{ github.ref }}-${{ inputs.probe_only && 'probe' || 'full' }}-${{ github.ref == 'refs/heads/main' && github.run_id || 'shared' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Everything a run depends on that is not in the tree is pinned here, so a green
@@ -80,10 +79,8 @@ env:
 # stage every test leg installs and runs from, so the suites fan out over
 # machines that carry no toolchain, the slow Intel image included, and no
 # compile happens twice. `check` runs every lint, doc and unit leg as steps of
-# one job, then builds the distribution bundle, since each of those is short and
-# a machine per leg cost more in setup than in work. A tag push runs none of
-# that and only `release`, which reads the result the same commit already got
-# on main.
+# one job, with the cheap checks first for earlier feedback. A tag push runs
+# only `release`, which reads the result the same commit already got on main.
 jobs:
   # Everything a test machine needs, built once on the fast image: both PE
   # arches, both unix `.so` builds, the e2e test binaries, and the e2e and
@@ -118,10 +115,7 @@ jobs:
   # is meant to show everything that is wrong at once, not the first thing.
   # `pe` gates the MSVC SDK and the Wine SDK: clippy and rustdoc run build
   # scripts, so snmalloc-sys and zstd-sys need the xwin headers and the
-  # archiver, and windows/shim's build script reads Wine's libwinecrt0.a. The
-  # bundle comes last: built the way a release is, at the default PROD=1, so
-  # the production profile's fat LTO is exercised here rather than first
-  # failing when a release is cut.
+  # archiver, and windows/shim's build script reads Wine's libwinecrt0.a.
   check:
     if: ${{ !inputs.probe_only && !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: macos-26
@@ -139,27 +133,24 @@ jobs:
       - name: audit
         if: ${{ !cancelled() }}
         run: make audit
-      - name: clippy-pe-i686
-        if: ${{ !cancelled() }}
-        run: make clippy-pe-i686
-      - name: clippy-pe-x86_64
-        if: ${{ !cancelled() }}
-        run: make clippy-pe-x86_64
-      - name: clippy-native
-        if: ${{ !cancelled() }}
-        run: make clippy-native
-      - name: doc-windows
-        if: ${{ !cancelled() }}
-        run: make doc-windows
       - name: doc-unix
         if: ${{ !cancelled() }}
         run: make doc-unix
+      - name: doc-windows
+        if: ${{ !cancelled() }}
+        run: make doc-windows
+      - name: clippy-pe-x86_64
+        if: ${{ !cancelled() }}
+        run: make clippy-pe-x86_64
+      - name: clippy-pe-i686
+        if: ${{ !cancelled() }}
+        run: make clippy-pe-i686
+      - name: clippy-native
+        if: ${{ !cancelled() }}
+        run: make clippy-native
       - name: test-unit
         if: ${{ !cancelled() }}
         run: make test-unit
-      - name: bundle
-        if: ${{ !cancelled() }}
-        run: make bundle
 
   # The end-to-end suite: the staged test binaries, run by the pinned Wine
   # against a Metal device, one leg per image and PE arch.
@@ -370,8 +361,7 @@ jobs:
   #
   # The tag has to agree with the version both workspaces carry, or the shipped
   # DLLs name a release nobody published: every binary stamps `git describe`,
-  # which is also why the bundle is built here, after the tag exists, rather
-  # than taken from the `check` job that ran before it.
+  # so the production bundle is built here, after the tag exists.
   #
   # It drafts and stops: the body it creates is empty because the notes are
   # written by hand, and the maintainer publishes. CONTRIBUTING.md carries the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,8 +292,11 @@ The description is what survives, and for anything non-trivial it carries:
 CI compiles on two machines and replays everywhere else. One job builds the
 stage (`make stage`: both PE arches, both unix `.so` builds, the e2e test
 binaries, the e2e and conformance runners for both host arches) and another
-runs every lint, doc and unit leg as steps of one job before building the
-bundle. The test machines carry no toolchain: they install the stage
+runs formatting and audit first, then documentation, Clippy and unit tests
+as steps of one job. Production bundles are built by the release job only.
+Every run on `main` has its own concurrency group so pending runs survive
+later pushes and every commit keeps its CI result. PR updates cancel the
+superseded run. The test machines carry no toolchain: they install the stage
 (`STAGE=<dir>`) and run the end-to-end and conformance suites on three
 images: the newest macOS on arm64, the oldest macOS mtld3d supports on arm64,
 and the Intel image, whose device has no unified memory and none of the


### PR DESCRIPTION
Rapid pushes to main can replace queued CI runs because they share one concurrency group, even with cancellation of running jobs disabled. Give each main run its own group so every commit retains a result for comparison. PR updates still cancel superseded runs, and probe dispatches remain separate.

Run formatting and audit first in check, followed by documentation, Clippy and unit tests. Remove its distribution bundle step, which took 4m08s in the latest successful run. The release job still builds the production bundle after verifying the tag and main CI. Ordinary CI no longer exercises production packaging. Update the workflow comments and CONTRIBUTING.md to match.

Keeping the existing group with cancel-in-progress disabled would still discard pending runs. A unique main run group avoids that queue limit.

Verification: make check passed (formatting, Clippy, audit and documentation); make ISOLATED=1 test passed with 1,105 Windows-workspace host tests, 292 Unix-workspace tests and 482 end-to-end tests on each of i686 and x86_64. Actionlint passed, with optional shellcheck and pyflakes integrations disabled. Workflow scenario checks cover three distinct main groups, PR supersession, probe separation, check-step order and retained release packaging.

Rules check: CONTRIBUTING.md gates ran green in an isolated worktree. CONVENTIONS.md: no statics, runtime config keys, dependencies, derives, lint suppressions or duplicated implementation. ARCHITECTURE.md: no wire fields, public API or runtime threading changes. Conformance is not needed for workflow and documentation changes.
