### PR TITLE
Keep API profiling counters alive through final Release

### DIFF
--- a/windows/core/src/perf.rs
+++ b/windows/core/src/perf.rs
@@ -9,7 +9,7 @@
 //! Structure:
 //! * `ApiCategory` + `ApiTimer`  — RAII guard that buckets TSC cycles
 //!   by COM vtable category on every D3D9 entry point.
-//! * `ApiPerfState` — embedded on `DeviceInner` (the API thread).
+//! * `ApiPerfStorage` owns the API thread's `ApiPerfState`.
 //!   Every counter the API thread bumps lands here.
 //! * `FramePerfPayload` — embedded on `FrameData`. Copy of the
 //!   API-thread counters that crosses the API→encoder channel.
@@ -24,12 +24,12 @@
 //!   spikes from sustained cost).
 //!
 //! Nothing in this module touches COM, `raw-dylib`, or `DeviceInner`.
-//! `ApiTimer` holds an `*mut ApiPerfState` so d3d9 is the only side
-//! that knows about `DeviceInner` — callers compute the perf pointer
-//! from their device pointer at construction time.
+//! Enabled `ApiTimer`s retain the counter storage independently of the
+//! device, including when a nested final Release destroys `DeviceInner`.
 
+use std::ops::DerefMut;
 #[cfg(perf_tracking)]
-use std::{fmt::Write as _, sync::LazyLock};
+use std::{cell::RefCell, fmt::Write as _, rc::Rc, sync::LazyLock};
 
 #[cfg(perf_tracking)]
 use log::{info, trace};
@@ -66,6 +66,12 @@ use super::passes::{ColorLoad, DepthLoad};
 /// switch — `mtld3d::d3d9::passes=trace` — so the default
 /// `RUST_LOG=info` never sees either.
 pub const SUMMARY_INTERVAL_SECS: u64 = 5;
+
+#[cfg(not(perf_tracking))]
+const _: () = {
+    assert!(size_of::<ApiPerfStorage>() == 0);
+    assert!(size_of::<ApiTimer>() == 0);
+};
 
 /// Perf telemetry has its own `log` target so the 5-second summary can be silenced.
 ///
@@ -305,6 +311,65 @@ pub enum OpSubDetail {
     BDraw,
 }
 
+/// Counter storage retained by the device and every enabled API timer.
+///
+/// The device may be destroyed inside a nested Release. The last timer
+/// owns the counters until its writeback finishes. Access stays under the
+/// device's API lock, and borrows never span nested entry points.
+pub struct ApiPerfStorage {
+    #[cfg(perf_tracking)]
+    state: Rc<RefCell<ApiPerfState>>,
+    #[cfg(not(perf_tracking))]
+    state: ApiPerfState,
+}
+
+impl Default for ApiPerfStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ApiPerfStorage {
+    #[cfg(perf_tracking)]
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            state: Rc::new(RefCell::new(ApiPerfState::new())),
+        }
+    }
+
+    #[cfg(not(perf_tracking))]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            state: ApiPerfState::new(),
+        }
+    }
+
+    /// Borrow counters only for the update, never across a nested API call.
+    pub fn state_mut(&mut self) -> impl DerefMut<Target = ApiPerfState> + '_ {
+        #[cfg(perf_tracking)]
+        {
+            self.state.borrow_mut()
+        }
+        #[cfg(not(perf_tracking))]
+        {
+            &mut self.state
+        }
+    }
+
+    /// Stable backing for subtimers nested inside an owning API timer.
+    #[cfg(perf_tracking)]
+    pub fn as_ptr(&mut self) -> *mut ApiPerfState {
+        self.state.as_ptr()
+    }
+
+    #[cfg(not(perf_tracking))]
+    pub const fn as_ptr(&mut self) -> *mut ApiPerfState {
+        core::ptr::null_mut()
+    }
+}
+
 /// RAII guard that measures TSC cycles spent inside a D3D9 COM vtable entry point.
 ///
 /// Adds the cycles to the owning device's `ApiPerfState`.
@@ -313,19 +378,19 @@ pub enum OpSubDetail {
 /// return path (happy, early-INVALIDCALL, panic unwind) without
 /// per-return-site bookkeeping.
 ///
-/// Null `perf_ptr` *or* perf-tracking disabled both skip the rdtsc and
-/// writeback — standalone resources (e.g. backbuffer surfaces from
+/// Absent storage or disabled perf tracking skips retention, rdtsc and
+/// writeback. Standalone resources (e.g. backbuffer surfaces from
 /// `GetBackBuffer`) stay safe, and the per-call cost is one Relaxed
 /// load + branch when the user isn't running with
-/// `RUST_LOG=mtld3d::perf=debug`.
+/// `RUST_LOG=mtld3d::perf=info`.
 ///
-/// Under `cfg(not(perf_tracking))` this collapses to a unit struct with no
-/// `Drop` — the entire timer disappears at compile time via LLVM DCE on
+/// Under `cfg(not(perf_tracking))` this collapses to a unit struct with an
+/// empty `Drop`. The entire timer disappears at compile time via LLVM DCE on
 /// every `let _timer = device_timer(...)` call site.
 #[cfg(perf_tracking)]
 pub struct ApiTimer {
     start: u64,
-    perf_ptr: *mut ApiPerfState,
+    state: Option<Rc<RefCell<ApiPerfState>>>,
     category: ApiCategory,
     /// Set on `Device`-category timers built via `start_device`.
     ///
@@ -353,7 +418,6 @@ pub struct ApiTimer {
     /// interval into both top-level buckets. Each bucket accrues only its
     /// own *self* time. See [`ApiPerfState::active_child_cycles`].
     saved_child_cycles: u64,
-    enabled: bool,
 }
 
 #[cfg(not(perf_tracking))]
@@ -368,16 +432,11 @@ impl ApiTimer {
     /// (returns 0) when disabled.
     #[cfg(perf_tracking)]
     #[inline]
-    fn enter_scope(perf_ptr: *mut ApiPerfState, enabled: bool) -> u64 {
-        if !enabled {
+    fn enter_scope(state: Option<&Rc<RefCell<ApiPerfState>>>) -> u64 {
+        let Some(state) = state else {
             return 0;
-        }
-        // SAFETY: access is exclusive (D3D9 objects are single-threaded, or
-        // serialised by the device `ApiLock` under `D3DCREATE_MULTITHREADED`);
-        // this transient `&mut` never overlaps another live borrow, since
-        // parent timers touch the perf state only inside their own
-        // `start`/`Drop`, which are strictly nested around this call.
-        let perf = unsafe { &mut *perf_ptr };
+        };
+        let mut perf = state.borrow_mut();
         let saved = perf.active_child_cycles;
         perf.active_child_cycles = 0;
         perf.timer_depth = perf.timer_depth.saturating_add(1);
@@ -385,26 +444,31 @@ impl ApiTimer {
     }
 
     #[cfg(perf_tracking)]
-    pub fn start(perf_ptr: *mut ApiPerfState, category: ApiCategory) -> Self {
-        let enabled = !perf_ptr.is_null() && perf_enabled();
-        let saved_child_cycles = Self::enter_scope(perf_ptr, enabled);
-        let start = if enabled { rdtsc() } else { 0 };
+    #[must_use]
+    pub fn start(storage: Option<&ApiPerfStorage>, category: ApiCategory) -> Self {
+        Self::new(storage.filter(|_| perf_enabled()), category)
+    }
+
+    #[cfg(perf_tracking)]
+    fn new(storage: Option<&ApiPerfStorage>, category: ApiCategory) -> Self {
+        let state = storage.map(|s| Rc::clone(&s.state));
+        let saved_child_cycles = Self::enter_scope(state.as_ref());
+        let start = if state.is_some() { rdtsc() } else { 0 };
         Self {
             start,
-            perf_ptr,
+            state,
             category,
             device_sub: None,
             bind_sub: None,
             surface_sub: None,
             saved_child_cycles,
-            enabled,
         }
     }
 
     #[cfg(not(perf_tracking))]
     #[inline]
     #[must_use]
-    pub const fn start(_perf_ptr: *mut ApiPerfState, _category: ApiCategory) -> Self {
+    pub const fn start(_storage: Option<&ApiPerfStorage>, _category: ApiCategory) -> Self {
         Self
     }
 
@@ -414,26 +478,17 @@ impl ApiTimer {
     /// `Device` bucket and the matching sub-bucket under a single
     /// `rdtsc()` delta. Used by every `IDirect3DDevice9` vtable thunk.
     #[cfg(perf_tracking)]
-    pub fn start_device(perf_ptr: *mut ApiPerfState, sub: DeviceSubCategory) -> Self {
-        let enabled = !perf_ptr.is_null() && perf_enabled();
-        let saved_child_cycles = Self::enter_scope(perf_ptr, enabled);
-        let start = if enabled { rdtsc() } else { 0 };
-        Self {
-            start,
-            perf_ptr,
-            category: ApiCategory::Device,
-            device_sub: Some(sub),
-            bind_sub: None,
-            surface_sub: None,
-            saved_child_cycles,
-            enabled,
-        }
+    #[must_use]
+    pub fn start_device(storage: Option<&ApiPerfStorage>, sub: DeviceSubCategory) -> Self {
+        let mut timer = Self::start(storage, ApiCategory::Device);
+        timer.device_sub = Some(sub);
+        timer
     }
 
     #[cfg(not(perf_tracking))]
     #[inline]
     #[must_use]
-    pub const fn start_device(_perf_ptr: *mut ApiPerfState, _sub: DeviceSubCategory) -> Self {
+    pub const fn start_device(_storage: Option<&ApiPerfStorage>, _sub: DeviceSubCategory) -> Self {
         Self
     }
 
@@ -445,26 +500,17 @@ impl ApiTimer {
     /// Used by `IDirect3DDevice9::Set*` / `Get*` thunks whose
     /// `DeviceSubCategory` would otherwise be `Bind`.
     #[cfg(perf_tracking)]
-    pub fn start_bind(perf_ptr: *mut ApiPerfState, sub: BindSubCategory) -> Self {
-        let enabled = !perf_ptr.is_null() && perf_enabled();
-        let saved_child_cycles = Self::enter_scope(perf_ptr, enabled);
-        let start = if enabled { rdtsc() } else { 0 };
-        Self {
-            start,
-            perf_ptr,
-            category: ApiCategory::Device,
-            device_sub: Some(DeviceSubCategory::Bind),
-            bind_sub: Some(sub),
-            surface_sub: None,
-            saved_child_cycles,
-            enabled,
-        }
+    #[must_use]
+    pub fn start_bind(storage: Option<&ApiPerfStorage>, sub: BindSubCategory) -> Self {
+        let mut timer = Self::start_device(storage, DeviceSubCategory::Bind);
+        timer.bind_sub = Some(sub);
+        timer
     }
 
     #[cfg(not(perf_tracking))]
     #[inline]
     #[must_use]
-    pub const fn start_bind(_perf_ptr: *mut ApiPerfState, _sub: BindSubCategory) -> Self {
+    pub const fn start_bind(_storage: Option<&ApiPerfStorage>, _sub: BindSubCategory) -> Self {
         Self
     }
 
@@ -474,26 +520,20 @@ impl ApiTimer {
     /// bucket AND `surface_sub_cycles[sub]` in one pass. Used by every
     /// `IDirect3DSurface9` vtable thunk (via `surf_timer`).
     #[cfg(perf_tracking)]
-    pub fn start_surface(perf_ptr: *mut ApiPerfState, sub: SurfaceSubCategory) -> Self {
-        let enabled = !perf_ptr.is_null() && perf_enabled();
-        let saved_child_cycles = Self::enter_scope(perf_ptr, enabled);
-        let start = if enabled { rdtsc() } else { 0 };
-        Self {
-            start,
-            perf_ptr,
-            category: ApiCategory::Surface,
-            device_sub: None,
-            bind_sub: None,
-            surface_sub: Some(sub),
-            saved_child_cycles,
-            enabled,
-        }
+    #[must_use]
+    pub fn start_surface(storage: Option<&ApiPerfStorage>, sub: SurfaceSubCategory) -> Self {
+        let mut timer = Self::start(storage, ApiCategory::Surface);
+        timer.surface_sub = Some(sub);
+        timer
     }
 
     #[cfg(not(perf_tracking))]
     #[inline]
     #[must_use]
-    pub const fn start_surface(_perf_ptr: *mut ApiPerfState, _sub: SurfaceSubCategory) -> Self {
+    pub const fn start_surface(
+        _storage: Option<&ApiPerfStorage>,
+        _sub: SurfaceSubCategory,
+    ) -> Self {
         Self
     }
 }
@@ -528,15 +568,11 @@ const fn exclusive_exit(elapsed: u64, children: u64, saved: u64, depth: u32) -> 
 #[cfg(perf_tracking)]
 impl Drop for ApiTimer {
     fn drop(&mut self) {
-        if !self.enabled {
+        let Some(state) = &self.state else {
             return;
-        }
+        };
         let elapsed = rdtsc() - self.start;
-        // SAFETY: the owning extern fn holds the timer for its own
-        // duration; the COM object (and therefore the `ApiPerfState`
-        // it points into) cannot be freed while the game is inside
-        // one of its methods.
-        let perf = unsafe { &mut *self.perf_ptr };
+        let mut perf = state.borrow_mut();
         // Exclusive (self) time: subtract the cycles consumed by nested
         // timers (delegated D3D9 entry points) so their interval lands
         // in their own bucket, not double-counted into ours too. Then
@@ -1035,7 +1071,7 @@ impl EncoderFrameCounters {
     }
 }
 
-/// Per-frame API-thread state. Embedded on `DeviceInner`.
+/// Per-frame API-thread counters owned by [`ApiPerfStorage`].
 ///
 /// Under `cfg(not(perf_tracking))` this collapses to a unit struct; all
 /// `bump_*` / `add_*` / `*_cycles_ptr` methods become `const fn` no-ops

--- a/windows/core/src/perf/tests.rs
+++ b/windows/core/src/perf/tests.rs
@@ -322,11 +322,13 @@ fn summary_golden_layout() {
         "\n",
         "Resources (textures)  — same layout as VB/IB; n/a rows omitted\n",
         "rename      2                                                   API: fresh staging Arc on contended LockRect\n",
-        "  discards  1                                                   API: rename, no preserve (DISCARD or D3DUSAGE_DYNAMIC)\n",
-        "  preserve  1                       peak/frame 1                API: rename + sync memcpy (non-DISCARD non-DYNAMIC contended)\n",
-        "uploads     2                                                   encoder: total texture uploads (raw + padded)\n",
+        "  discards  1                                                   API: rename, no preserve (whole-level DISCARD on a DEFAULT-pool texture)\n",
+        "  preserve  1                       peak/frame 1                API: rename + sync memcpy (whole-level non-DISCARD contended, or an unaligned compressed rect)\n",
+        "in-place    0                                                   API: contended partial Lock handed back live (kept divergence; no rename, no stall)\n",
+        "uploads     2                                                   encoder: total texture uploads (raw + padded + pass)\n",
         "  raw       2                                                   encoder: blit; source = cached bytesNoCopy wrapper (cheap)\n",
-        "  padded    0                                                   encoder: blit; source repacked into transient buffer (alloc + memcpy + extra unix_call)\n",
+        "  padded    0                                                   encoder: blit; source repacked on the CPU into a transient buffer (alloc + memcpy + extra unix_call)\n",
+        "  pass      0                                                   encoder: render pass; staging read by a fragment function (16-bit widening, sub-alignment pitch)\n",
         "reorder     1                                                   encoder: MTLTexture rename-at-overlap (upload hit a texture sampled earlier this frame)\n",
         "destroys    1                                                   encoder: MTLTexture freed + texture-staging MTLBuffer wrappers freed (rename + padded + texture release)\n",
         "retention   depth= 0.0  0 KB avg    peak 0 KB                   encoder: blit source staging Arcs (separate from VB/IB retention; MTLTexture handles in destroys)\n",
@@ -358,8 +360,8 @@ fn summary_golden_layout() {
         "  size      72 KB avg               peak 72 KB                  high-water-reserved Vec<Op> capacity per frame (peak_ops_count)\n",
         "  realloc   32 KB avg               peak 32 KB                  Vec<Op> doubling memcpy on push_op (target ≈ 0 with peak_ops_count reserve)\n",
         "cmd_vec                                                         encoder→unix: Vec<Command> shipped via SubmitCommandBuffer; unix dispatches each Command to a Metal encoder\n",
-        "  size      64 KB avg               peak 64 KB                  pool-resident Vec<Command> capacity across frames (recycled, not freed)\n",
-        "  realloc   192 KB avg              peak 192 KB                 Vec<Command> doubling memcpy on emit_command (target ≈ 0 with Pass::commands pool)\n",
+        "  size      64 KB avg               peak 64 KB                  submitted payload Vec<Command> capacity (excludes idle pool and other payloads)\n",
+        "  realloc   192 KB avg              peak 192 KB                 Vec<Command> potential growth copies on emit_command (excludes initial allocations)\n",
         "pagebox     alloc=17  4.8 MB        free=15  4.6 MB             window totals of PageBox allocs/frees reaching the global allocator (fresh pages fault on first touch)\n",
         "  uncached  1 (5.9%)                peak 1/frame                allocs over 1 MiB: past snmalloc's per-thread budget, so commit in / decommit out every time\n",
         "faults      minflt=4200  majflt=3   4200.0 min/frame            process-wide getrusage delta this window (all threads); zero-fill faults on fresh pages land here",
@@ -517,6 +519,7 @@ fn sample_window() -> PerfWindow {
             texture_renames: 2,
             texture_discards: 1,
             texture_preserve_cpu: 1,
+            texture_write_in_place_contended: 0,
             // AddDirtyRect probe fixture: 4 calls, 3 with a usable
             // sub-region; area sum 10000 bp ⇒ mean coverage 25% of the mip.
             texture_add_dirty_calls: 4,
@@ -571,6 +574,7 @@ fn sample_window() -> PerfWindow {
             vbib_mid_pass_reorders: 0,
             texture_blit_uploads: 2,
             texture_blit_padded_uploads: 0,
+            texture_expand_uploads: 0,
             texture_gpu_renames: 1,
             op_cycles: 1_400_000,
             // Decompose op_cyc 1.40M into the nine phases (six draw phases sum
@@ -742,4 +746,83 @@ fn exclusive_exit_saturates_when_children_exceed_elapsed() {
     // parent's measured span; self_time clamps to 0, never wraps.
     let (self_time, _) = exclusive_exit(10, 25, 0, 1);
     assert_eq!(self_time, 0);
+}
+
+/// A final Release may destroy its device inside a child Release's timer.
+#[test]
+fn api_timer_storage_outlives_nested_device_release() {
+    let mut storage = ApiPerfStorage::new();
+    let weak = Rc::downgrade(&storage.state);
+    let outer = ApiTimer::new(Some(&storage), ApiCategory::Texture);
+    let inner = ApiTimer::new(Some(&storage), ApiCategory::Device);
+    storage.state_mut().bump_texture_rename();
+    assert_eq!(storage.state.borrow().timer_depth, 2);
+    drop(storage);
+    assert_eq!(weak.strong_count(), 2);
+    drop(inner);
+    {
+        let retained = weak.upgrade().expect("outer timer owns the state");
+        let state = retained.borrow();
+        assert_eq!(state.timer_depth, 1);
+        assert_eq!(state.counters.texture_renames, 1);
+        assert_eq!(
+            state.counters.api_call_counts_by_category[ApiCategory::Device as usize],
+            1
+        );
+    }
+    drop(outer);
+    assert!(weak.upgrade().is_none(), "last timer frees counter storage");
+}
+
+#[test]
+fn api_timer_storage_outlives_direct_device_release() {
+    let storage = ApiPerfStorage::new();
+    let weak = Rc::downgrade(&storage.state);
+    let timer = ApiTimer::new(Some(&storage), ApiCategory::Device);
+    drop(storage);
+    assert_eq!(weak.strong_count(), 1);
+    drop(timer);
+    assert!(weak.upgrade().is_none());
+}
+
+#[test]
+fn api_timer_nested_writeback_balances_depth_and_counts() {
+    let storage = ApiPerfStorage::new();
+    let outer = ApiTimer::new(Some(&storage), ApiCategory::Surface);
+    let inner = ApiTimer::new(Some(&storage), ApiCategory::Texture);
+    drop(inner);
+    drop(outer);
+    let state = storage.state.borrow();
+    assert_eq!(state.timer_depth, 0);
+    assert_eq!(state.active_child_cycles, 0);
+    assert_eq!(
+        state.counters.api_call_counts_by_category[ApiCategory::Surface as usize],
+        1
+    );
+    assert_eq!(
+        state.counters.api_call_counts_by_category[ApiCategory::Texture as usize],
+        1
+    );
+}
+
+#[test]
+fn api_timer_disabled_does_not_retain_storage() {
+    // Unit tests install no logger, so the runtime gate remains disabled.
+    assert!(!perf_enabled());
+    let storage = ApiPerfStorage::new();
+    let weak = Rc::downgrade(&storage.state);
+    let timer = ApiTimer::start_device(Some(&storage), DeviceSubCategory::Misc);
+    assert_eq!(storage.state.borrow().timer_depth, 0);
+    assert_eq!(weak.strong_count(), 1);
+    drop(storage);
+    assert!(weak.upgrade().is_none());
+    drop(timer);
+}
+
+#[test]
+fn api_perf_storage_without_timers_is_reclaimed() {
+    let storage = ApiPerfStorage::new();
+    let weak = Rc::downgrade(&storage.state);
+    drop(storage);
+    assert!(weak.upgrade().is_none());
 }

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -1,4 +1,4 @@
-use core::{ffi::c_void, mem::MaybeUninit, ptr::NonNull};
+use core::{ffi::c_void, mem::MaybeUninit, ops::DerefMut, ptr::NonNull};
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
@@ -27,8 +27,8 @@ use mtld3d_core::{
     page_box::PageBox,
     passes::ExtraColorSlot,
     perf::{
-        ApiPerfState, ApiTimer, BindSubCategory, CycleAddTimer, CycleSetTimer, DeviceSubCategory,
-        KeysGate,
+        ApiPerfState, ApiPerfStorage, ApiTimer, BindSubCategory, CycleAddTimer, CycleSetTimer,
+        DeviceSubCategory, KeysGate,
     },
     readback::{ReadbackDestination, ReadbackReject, ReadbackSource},
     streams::validate_stream_freq,
@@ -522,7 +522,7 @@ pub struct DeviceInner {
     /// Per-category timer buckets, Lock / texture counters, prev-present TSC.
     /// See `mtld3d_core::perf` for the field list. Drained into
     /// `FrameData::perf` at `Present`.
-    perf: ApiPerfState,
+    perf: ApiPerfStorage,
     /// Retention pipeline for VB/IB `PageBox`es whose in-flight frame hasn't yet retired.
     ///
     /// API thread pushes on Lock-rename and Release; drained into `FrameData`
@@ -1476,7 +1476,7 @@ impl DeviceInner {
         // encoder-side `cmd_vec` row.
         let op_vec_capacity_bytes = frame.op_vec_capacity_bytes();
         let op_vec_realloc_bytes = frame.take_op_vec_realloc_bytes();
-        self.perf.drain_into_payload(frame.perf_mut());
+        self.perf.state_mut().drain_into_payload(frame.perf_mut());
         frame
             .perf_mut()
             .set_op_vec_metrics(op_vec_capacity_bytes, op_vec_realloc_bytes);
@@ -1779,13 +1779,13 @@ impl DeviceInner {
         // retention-cap check below (which exists to bound allocations).
         let pool = &*crate::page_box_pool::PAGEBOX_POOL;
         if let Some(b) = pool.acquire(logical_len) {
-            self.perf.bump_vbib_pool_hit();
+            self.perf.state_mut().bump_vbib_pool_hit();
             return b;
         }
         if pool.enabled() {
             // Misses count only while the pool is on, so the A/B baseline
             // arm reads hit=0 miss=0 rather than all-miss.
-            self.perf.bump_vbib_pool_miss();
+            self.perf.state_mut().bump_vbib_pool_miss();
         }
         // Before allocating, if live VB/IB retention is at the cap, drain
         // retired backings (cheap) and, if still over, force a mid-frame
@@ -1795,12 +1795,12 @@ impl DeviceInner {
             let retained =
                 self.vbib_retained_bytes.load(Ordering::Acquire) + self.pending_retention_bytes;
             if retained >= self.retention_cap_bytes {
-                self.perf.bump_retention_cap_drain();
+                self.perf.state_mut().bump_retention_cap_drain();
                 self.drain_retention_now();
                 let after =
                     self.vbib_retained_bytes.load(Ordering::Acquire) + self.pending_retention_bytes;
                 if after >= self.retention_cap_bytes {
-                    self.perf.bump_retention_cap_submit();
+                    self.perf.state_mut().bump_retention_cap_submit();
                     self.mid_frame_submit_for_retention();
                 }
             }
@@ -1835,32 +1835,32 @@ impl DeviceInner {
         self.mem_watch_present();
     }
 
-    pub const fn perf_mut(&mut self) -> &mut ApiPerfState {
-        &mut self.perf
+    pub fn perf_mut(&mut self) -> impl DerefMut<Target = ApiPerfState> + '_ {
+        self.perf.state_mut()
     }
 
-    /// Raw pointer to the embedded `ApiPerfState`.
+    /// Borrow the storage while constructing a timer that retains it.
     ///
-    /// For `ApiTimer::start` at the top of every COM vtable fn. SAFETY at
-    /// the call site: the timer is dropped before the fn returns and the COM
-    /// object holds a ref to `DeviceInner` for its entire lifetime.
-    pub const fn perf_ptr(&mut self) -> *mut ApiPerfState {
-        &raw mut self.perf
+    /// # Safety
+    /// A non-null device must be live for the returned borrow, with its API
+    /// lock held when multithreaded. No counter borrow may span the timer.
+    pub unsafe fn perf_storage_of<'a>(dev: *mut Self) -> Option<&'a ApiPerfStorage> {
+        // SAFETY: the caller guarantees the device's lifetime and API lock.
+        unsafe { dev.as_ref() }.map(|dev| &dev.perf)
     }
 
     /// Null-tolerant wrapper: returns `null_mut()` for a null device.
     ///
-    /// Else the embedded `ApiPerfState` pointer. Used by every resource
-    /// `*_timer` helper (`vb_timer`, `tex_timer`, …) that may see a null
-    /// `device_inner` on standalone surfaces.
+    /// The subtimer finishes before the enclosing API timer, which retains
+    /// the separately allocated counter state in a PERF build.
     pub fn perf_ptr_of(dev: *mut Self) -> *mut ApiPerfState {
         if dev.is_null() {
             core::ptr::null_mut()
         } else {
             // SAFETY: caller guarantees a non-null valid device pointer
-            // for the duration of the timer (same contract as
-            // `from_ptr`).
-            unsafe { (*dev).perf_ptr() }
+            // while obtaining the counter pointer. The enclosing API timer
+            // retains its storage until the subtimer has finished.
+            unsafe { (*dev).perf.as_ptr() }
         }
     }
 
@@ -2811,7 +2811,7 @@ impl Direct3DDevice9 {
             outstanding_reset_blockers: AtomicU32::new(0),
             // Start at 1 so `current_seq - 1` never underflows.
             current_seq: 1,
-            perf: ApiPerfState::new(),
+            perf: ApiPerfStorage::new(),
             vbib_retention_pending: Vec::new(),
             pending_retention_bytes: 0,
             retention_cap_bytes: info.config.vbib_retention_cap_bytes,
@@ -3234,11 +3234,11 @@ pub fn device_api_lock(this: *mut c_void) -> ApiGuard {
 #[inline]
 pub fn device_timer(this: *mut c_void, sub: DeviceSubCategory) -> ApiTimer {
     // SAFETY: vtable thunk; `this` is *mut Direct3DDevice9 per IDirect3DDevice9 ABI.
-    let perf_ptr = (unsafe { InPtr::<Direct3DDevice9>::opt(this) })
-        .map_or(core::ptr::null_mut(), |obj| {
-            DeviceInner::perf_ptr_of(obj.inner)
-        });
-    ApiTimer::start_device(perf_ptr, sub)
+    let storage = (unsafe { InPtr::<Direct3DDevice9>::opt(this) }).and_then(|obj| {
+        // SAFETY: the entry point holds the API lock and the device is live at timer entry.
+        unsafe { DeviceInner::perf_storage_of(obj.inner) }
+    });
+    ApiTimer::start_device(storage, sub)
 }
 
 /// Same shape as `device_timer` but for entry points whose `DeviceSubCategory` would be `Bind`.
@@ -3250,11 +3250,11 @@ pub fn device_timer(this: *mut c_void, sub: DeviceSubCategory) -> ApiTimer {
 #[inline]
 fn bind_timer(this: *mut c_void, sub: BindSubCategory) -> ApiTimer {
     // SAFETY: vtable thunk; `this` is *mut Direct3DDevice9 per IDirect3DDevice9 ABI.
-    let perf_ptr = (unsafe { InPtr::<Direct3DDevice9>::opt(this) })
-        .map_or(core::ptr::null_mut(), |obj| {
-            DeviceInner::perf_ptr_of(obj.inner)
-        });
-    ApiTimer::start_bind(perf_ptr, sub)
+    let storage = (unsafe { InPtr::<Direct3DDevice9>::opt(this) }).and_then(|obj| {
+        // SAFETY: the entry point holds the API lock and the device is live at timer entry.
+        unsafe { DeviceInner::perf_storage_of(obj.inner) }
+    });
+    ApiTimer::start_bind(storage, sub)
 }
 
 /// Pointer the Draw-internal `CycleAddTimer` for the snapshot phase writes into.
@@ -3268,8 +3268,8 @@ fn draw_snapshot_ptr(perf_ptr: *mut ApiPerfState) -> *mut u64 {
         return core::ptr::null_mut();
     }
     // SAFETY: caller obtained `perf_ptr` from `DeviceInner::perf_ptr_of`,
-    // which yields a `*mut ApiPerfState` pointing into the live device's
-    // embedded state for the duration of the COM call.
+    // which yields separately allocated counter storage retained by the
+    // enclosing API timer for the duration of the COM call.
     unsafe { (*perf_ptr).draw_snapshot_cycles_ptr() }
 }
 

--- a/windows/d3d9/src/index_buffer.rs
+++ b/windows/d3d9/src/index_buffer.rs
@@ -268,11 +268,11 @@ impl Direct3DIndexBuffer9 {
 fn ib_timer(this: *mut c_void) -> mtld3d_core::perf::ApiTimer {
     use mtld3d_core::perf::{ApiCategory, ApiTimer};
     // SAFETY: vtable thunk; `this` is *mut Direct3DIndexBuffer9 per ABI.
-    let perf_ptr = (unsafe { InPtr::<Direct3DIndexBuffer9>::opt(this) })
-        .map_or(core::ptr::null_mut(), |obj| {
-            crate::device::DeviceInner::perf_ptr_of(obj.inner().device_inner)
-        });
-    ApiTimer::start(perf_ptr, ApiCategory::IndexBuffer)
+    let storage = (unsafe { InPtr::<Direct3DIndexBuffer9>::opt(this) }).and_then(|obj| {
+        // SAFETY: the entry point holds the API lock and the device is live at timer entry.
+        unsafe { crate::device::DeviceInner::perf_storage_of(obj.inner().device_inner) }
+    });
+    ApiTimer::start(storage, ApiCategory::IndexBuffer)
 }
 
 extern "system" fn ib_query_interface(

--- a/windows/d3d9/src/pixel_shader.rs
+++ b/windows/d3d9/src/pixel_shader.rs
@@ -133,11 +133,11 @@ struct PixelShaderInner {
 fn ps_timer(this: *mut c_void) -> mtld3d_core::perf::ApiTimer {
     use mtld3d_core::perf::{ApiCategory, ApiTimer};
     // SAFETY: vtable thunk; `this` is *mut Direct3DPixelShader9 per ABI.
-    let perf_ptr = (unsafe { InPtr::<Direct3DPixelShader9>::opt(this) })
-        .map_or(core::ptr::null_mut(), |obj| {
-            crate::device::DeviceInner::perf_ptr_of(obj.inner().device_inner)
-        });
-    ApiTimer::start(perf_ptr, ApiCategory::PixelShader)
+    let storage = (unsafe { InPtr::<Direct3DPixelShader9>::opt(this) }).and_then(|obj| {
+        // SAFETY: the entry point holds the API lock and the device is live at timer entry.
+        unsafe { crate::device::DeviceInner::perf_storage_of(obj.inner().device_inner) }
+    });
+    ApiTimer::start(storage, ApiCategory::PixelShader)
 }
 
 extern "system" fn ps_query_interface(

--- a/windows/d3d9/src/query.rs
+++ b/windows/d3d9/src/query.rs
@@ -98,11 +98,11 @@ struct QueryInner {
 fn query_timer(this: *mut c_void) -> mtld3d_core::perf::ApiTimer {
     use mtld3d_core::perf::{ApiCategory, ApiTimer};
     // SAFETY: vtable thunk; `this` is *mut Direct3DQuery9 per IDirect3DQuery9 ABI.
-    let perf_ptr = (unsafe { InPtr::<Direct3DQuery9>::opt(this) })
-        .map_or(core::ptr::null_mut(), |obj| {
-            crate::device::DeviceInner::perf_ptr_of(obj.inner().device_inner)
-        });
-    ApiTimer::start(perf_ptr, ApiCategory::Query)
+    let storage = (unsafe { InPtr::<Direct3DQuery9>::opt(this) }).and_then(|obj| {
+        // SAFETY: the entry point holds the API lock and the device is live at timer entry.
+        unsafe { crate::device::DeviceInner::perf_storage_of(obj.inner().device_inner) }
+    });
+    ApiTimer::start(storage, ApiCategory::Query)
 }
 
 extern "system" fn query_query_interface(

--- a/windows/d3d9/src/state_block.rs
+++ b/windows/d3d9/src/state_block.rs
@@ -777,10 +777,9 @@ fn capture_sampler_states(dev: &DeviceInner) -> [[u32; SAMPLER_STATE_COUNT]; STA
 fn sb_timer(this: *mut c_void) -> mtld3d_core::perf::ApiTimer {
     use mtld3d_core::perf::{ApiCategory, ApiTimer};
     // SAFETY: vtable thunk; `this` is *mut Direct3DStateBlock9 per the
-    // IDirect3DStateBlock9 ABI. `opt` filters null, forwarding a null
-    // `perf_ptr` instead of dereferencing.
+    // IDirect3DStateBlock9 ABI. `opt` filters null without touching storage.
     let Some(obj) = (unsafe { InPtr::<Direct3DStateBlock9>::opt(this) }) else {
-        return ApiTimer::start(core::ptr::null_mut(), ApiCategory::StateBlock);
+        return ApiTimer::start(None, ApiCategory::StateBlock);
     };
     // SAFETY: `obj.inner` was installed by `new`/`from_recording` as a
     // `Box::into_raw` and lives until `sb_release` at refcount zero.
@@ -793,7 +792,8 @@ fn sb_timer(this: *mut c_void) -> mtld3d_core::perf::ApiTimer {
         unsafe { (*sb_inner.device).inner_ptr() }
     };
     ApiTimer::start(
-        crate::device::DeviceInner::perf_ptr_of(dev_ptr),
+        // SAFETY: the entry point holds the API lock and the device is live at timer entry.
+        unsafe { crate::device::DeviceInner::perf_storage_of(dev_ptr) },
         ApiCategory::StateBlock,
     )
 }

--- a/windows/d3d9/src/surface.rs
+++ b/windows/d3d9/src/surface.rs
@@ -1443,11 +1443,11 @@ impl SurfaceInner {
 fn surf_timer(this: *mut c_void, sub: SurfaceSubCategory) -> mtld3d_core::perf::ApiTimer {
     use mtld3d_core::perf::ApiTimer;
     // SAFETY: vtable thunk; `this` is *mut Direct3DSurface9 per IDirect3DSurface9 ABI.
-    let perf_ptr = (unsafe { InPtr::<Direct3DSurface9>::opt(this) })
-        .map_or(core::ptr::null_mut(), |obj| {
-            crate::device::DeviceInner::perf_ptr_of(obj.inner().device_inner)
-        });
-    ApiTimer::start_surface(perf_ptr, sub)
+    let storage = (unsafe { InPtr::<Direct3DSurface9>::opt(this) }).and_then(|obj| {
+        // SAFETY: the entry point holds the API lock and the device is live at timer entry.
+        unsafe { crate::device::DeviceInner::perf_storage_of(obj.inner().device_inner) }
+    });
+    ApiTimer::start_surface(storage, sub)
 }
 
 extern "system" fn surface_query_interface(

--- a/windows/d3d9/src/texture.rs
+++ b/windows/d3d9/src/texture.rs
@@ -2240,7 +2240,7 @@ impl TextureInner {
                     unsafe { core::ptr::copy_nonoverlapping(old.as_ptr(), dst, mip_len) };
                 }
                 if device_inner != 0 {
-                    let perf = DeviceInner::from_ptr(device_inner).perf_mut();
+                    let mut perf = DeviceInner::from_ptr(device_inner).perf_mut();
                     match preserve {
                         PreserveKind::None => perf.bump_texture_discard(),
                         PreserveKind::Cpu => perf.bump_texture_preserve_cpu(),
@@ -3074,11 +3074,11 @@ impl Direct3DTexture9 {
 fn tex_timer(this: *mut c_void) -> mtld3d_core::perf::ApiTimer {
     use mtld3d_core::perf::{ApiCategory, ApiTimer};
     // SAFETY: vtable thunk; `this` is *mut Direct3DTexture9 per IDirect3DTexture9 ABI.
-    let perf_ptr = (unsafe { InPtr::<Direct3DTexture9>::opt(this) })
-        .map_or(core::ptr::null_mut(), |obj| {
-            DeviceInner::perf_ptr_of(obj.inner().device_inner as *mut DeviceInner)
-        });
-    ApiTimer::start(perf_ptr, ApiCategory::Texture)
+    let storage = (unsafe { InPtr::<Direct3DTexture9>::opt(this) }).and_then(|obj| {
+        // SAFETY: the entry point holds the API lock and the device is live at timer entry.
+        unsafe { DeviceInner::perf_storage_of(obj.inner().device_inner as *mut DeviceInner) }
+    });
+    ApiTimer::start(storage, ApiCategory::Texture)
 }
 
 extern "system" fn texture_query_interface(

--- a/windows/d3d9/src/vertex_buffer.rs
+++ b/windows/d3d9/src/vertex_buffer.rs
@@ -350,11 +350,11 @@ impl Direct3DVertexBuffer9 {
 fn vb_timer(this: *mut c_void) -> mtld3d_core::perf::ApiTimer {
     use mtld3d_core::perf::{ApiCategory, ApiTimer};
     // SAFETY: vtable thunk; `this` is *mut Direct3DVertexBuffer9 per ABI.
-    let perf_ptr = (unsafe { InPtr::<Direct3DVertexBuffer9>::opt(this) })
-        .map_or(core::ptr::null_mut(), |obj| {
-            crate::device::DeviceInner::perf_ptr_of(obj.inner().device_inner)
-        });
-    ApiTimer::start(perf_ptr, ApiCategory::VertexBuffer)
+    let storage = (unsafe { InPtr::<Direct3DVertexBuffer9>::opt(this) }).and_then(|obj| {
+        // SAFETY: the entry point holds the API lock and the device is live at timer entry.
+        unsafe { crate::device::DeviceInner::perf_storage_of(obj.inner().device_inner) }
+    });
+    ApiTimer::start(storage, ApiCategory::VertexBuffer)
 }
 
 extern "system" fn vb_query_interface(

--- a/windows/d3d9/src/vertex_decl.rs
+++ b/windows/d3d9/src/vertex_decl.rs
@@ -112,11 +112,11 @@ impl Direct3DVertexDeclaration9 {
 fn vdecl_timer(this: *mut c_void) -> mtld3d_core::perf::ApiTimer {
     use mtld3d_core::perf::{ApiCategory, ApiTimer};
     // SAFETY: vtable thunk; `this` is *mut Direct3DVertexDeclaration9 per ABI.
-    let perf_ptr = (unsafe { InPtr::<Direct3DVertexDeclaration9>::opt(this) })
-        .map_or(core::ptr::null_mut(), |obj| {
-            crate::device::DeviceInner::perf_ptr_of(obj.inner().device_inner)
-        });
-    ApiTimer::start(perf_ptr, ApiCategory::VertexDecl)
+    let storage = (unsafe { InPtr::<Direct3DVertexDeclaration9>::opt(this) }).and_then(|obj| {
+        // SAFETY: the entry point holds the API lock and the device is live at timer entry.
+        unsafe { crate::device::DeviceInner::perf_storage_of(obj.inner().device_inner) }
+    });
+    ApiTimer::start(storage, ApiCategory::VertexDecl)
 }
 
 extern "system" fn vd_query_interface(

--- a/windows/d3d9/src/vertex_shader.rs
+++ b/windows/d3d9/src/vertex_shader.rs
@@ -148,11 +148,11 @@ struct VertexShaderInner {
 fn vs_timer(this: *mut c_void) -> mtld3d_core::perf::ApiTimer {
     use mtld3d_core::perf::{ApiCategory, ApiTimer};
     // SAFETY: vtable thunk; `this` is *mut Direct3DVertexShader9 per ABI.
-    let perf_ptr = (unsafe { InPtr::<Direct3DVertexShader9>::opt(this) })
-        .map_or(core::ptr::null_mut(), |obj| {
-            crate::device::DeviceInner::perf_ptr_of(obj.inner().device_inner)
-        });
-    ApiTimer::start(perf_ptr, ApiCategory::VertexShader)
+    let storage = (unsafe { InPtr::<Direct3DVertexShader9>::opt(this) }).and_then(|obj| {
+        // SAFETY: the entry point holds the API lock and the device is live at timer entry.
+        unsafe { crate::device::DeviceInner::perf_storage_of(obj.inner().device_inner) }
+    });
+    ApiTimer::start(storage, ApiCategory::VertexShader)
 }
 
 extern "system" fn vs_query_interface(


### PR DESCRIPTION
With API profiling enabled, final device Release frees DeviceInner before its function-scoped ApiTimer writes back to the embedded counters. A resource Release that destroys the device leaves its enclosing timer dangling too. A temporary destruction assertion reproduced both paths: `ApiPerfState destroyed with active timers`, with depths 1 and 2 respectively. This is instrumented lifetime evidence, not an observed uninstrumented game crash.

Give the counters a PERF-only Rc<RefCell<ApiPerfState>> owner and let each enabled timer retain it until writeback finishes. Counter borrows stay inside individual updates so nested API entry points can reenter. The device still dies at its final Release; only the diagnostic allocation survives until the last timer leaves. The existing API lock serializes access, including timer destruction. Runtime-disabled timers retain nothing, and compile-time assertions keep non-PERF storage and timers zero-sized.

Dropping only the direct device timer before destruction would leave enclosing resource timers dangling. Leaking the counters would avoid that access but grow memory with every device. Shared counter ownership covers both paths and reclaims storage after the final writeback.

Verification

`make check` passes, including formatting, clippy, audit and rustdoc. `make ISOLATED=1 test` passes 1105 Windows host tests, 294 Unix host tests, and 487/487 e2e tests on each PE architecture, with four processes per architecture.

`make PERF=1 check` and `RUST_LOG=mtld3d=info make PERF=1 ISOLATED=1 test` pass: 1126 Windows host tests, 294 Unix host tests, and 487/487 e2e tests on each PE architecture, with four processes per architecture. The direct release, nested release and two multithreaded controls also pass with `RUST_LOG=mtld3d=warn` on the PERF build, four tests per architecture.

Five host tests cover direct and nested owner destruction, nested accounting, runtime-disabled non-retention, and owner-only reclamation. Existing resource_misc and multithreaded e2e cases cover direct final Release, nested final resource Release, reentrant state application, and callers on two threads. The existing PERF golden fixture also needed two omitted counter fields initialized to zero and its expected text brought into agreement with the current formatter; production summary text is unchanged.

Rules check

CONTRIBUTING.md: one diagnostic lifetime fix, deterministic before evidence and host ownership regression tests, with actual COM release paths exercised by the existing e2e suite. Conformance is not needed: only API diagnostic storage and COM timer construction change, with no render/state/shader behavior or shared-crate changes.

CONVENTIONS.md: ownership and counter logic stay in core, tests stay in perf/tests.rs, and d3d9 changes are COM wiring and short counter borrows. No new statics, config keys, wire fields, dependencies, derives, lint suppressions, or duplicate helpers. Standard Rc/RefCell replaces the API timer's unchecked counter pointer. Non-PERF construction remains const and zero-sized. Formatting, clippy, audit and rustdoc are checked by make check in both configurations.

ARCHITECTURE.md: every timer still drops under the existing device API lock. Draw and query subtimers finish before their owning API timer; encoder and frame storage are unchanged. Counter ownership does not cross into encoder/submit work or alter device ownership, the PE/Unix contract, cache keys, or render state. The enabled diagnostic path adds non-atomic reference counting and short RefCell borrows; no performance improvement is claimed.

Closes #501
