### PR TITLE
Keep ISOLATED=1 Wine paths private

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,9 @@ jobs:
       - name: audit
         if: ${{ !cancelled() }}
         run: make audit
+      - name: test-isolation
+        if: ${{ !cancelled() }}
+        run: make test-isolation
       - name: doc-unix
         if: ${{ !cancelled() }}
         run: make doc-unix

--- a/Makefile
+++ b/Makefile
@@ -48,16 +48,18 @@ ISOLATED_REGISTRY := $(patsubst %,%/mtld3d-isolated-roots,$(shell git rev-parse 
 ISOLATED_CLEANING := $(if $(MAKECMDGOALS),$(if $(filter-out clean-isolated clean-isolated-orphans,$(MAKECMDGOALS)),,1))
 
 ifeq ($(ISOLATED),1)
+ISOLATED_SDK_SOURCE := $(WINE_SDK)
 ISOLATED_PREFIX_SOURCE := $(or $(WINEPREFIX),$(HOME)/.wine)
 ifneq ($(ISOLATED_CLEANING),1)
-$(shell [ -d $(ISOLATED_ROOT)/sdk ] || $(call clone_tree,$(WINE_SDK),$(ISOLATED_ROOT)/sdk))
+$(shell [ -d $(ISOLATED_ROOT)/sdk ] || $(call clone_tree,$(ISOLATED_SDK_SOURCE),$(ISOLATED_ROOT)/sdk))
 $(shell [ -d $(ISOLATED_ROOT)/prefix ] || [ ! -d $(ISOLATED_PREFIX_SOURCE) ] || $(call clone_tree,$(ISOLATED_PREFIX_SOURCE),$(ISOLATED_ROOT)/prefix))
 $(if $(ISOLATED_REGISTRY),$(shell grep -qxF '$(CURDIR)' '$(ISOLATED_REGISTRY)' 2>/dev/null || echo '$(CURDIR)' >> '$(ISOLATED_REGISTRY)'))
 endif
-WINE_SDK := $(ISOLATED_ROOT)/sdk
-WINE_INSTALL_DIR := $(ISOLATED_ROOT)/sdk
-export WINEPREFIX := $(ISOLATED_ROOT)/prefix
-$(info ==> ISOLATED=1: Wine SDK, install dir and prefix under $(ISOLATED_ROOT))
+override WINE_SDK := $(ISOLATED_ROOT)/sdk
+override WINE_INSTALL_DIR := $(ISOLATED_ROOT)/sdk
+override WINEPREFIX := $(ISOLATED_ROOT)/prefix
+export WINEPREFIX
+$(info ==> ISOLATED=1: WINE_SDK=$(WINE_SDK) WINE_INSTALL_DIR=$(WINE_INSTALL_DIR) WINEPREFIX=$(WINEPREFIX))
 endif
 export WINE_SDK
 
@@ -317,7 +319,7 @@ TAG          ?= $(shell git describe --tags --exact-match 2>/dev/null)
 	conformance-baseline-scale-i686 conformance-baseline-scale-x86_64 \
 	conformance-baseline-intel-i686 conformance-baseline-intel-x86_64 \
 	conformance-isolate fmt fmt-check clippy clippy-pe-i686 clippy-pe-x86_64 \
-	clippy-native audit doc doc-windows doc-unix check clean upgrade \
+	clippy-native audit test-isolation doc doc-windows doc-unix check clean upgrade \
 	upgrade-incompat setup setup-rust setup-nextest setup-dev setup-xwin \
 	setup-rosetta \
 	xwin-dir fetch
@@ -967,6 +969,9 @@ clippy-native:
 audit:
 	./scripts/audit.sh
 
+test-isolation:
+	python3 scripts/test-isolation.py
+
 # rustdoc's own lints, which no other target sees: broken and private intra-doc
 # links, malformed HTML in doc comments. `audit` gates the *shape* of a doc block
 # and clippy gates its prose; only rustdoc knows whether its links resolve.
@@ -983,14 +988,15 @@ doc-unix:
 	cd unix && cargo +$(RUST_STABLE) doc --no-deps $(DENY_WARNINGS)
 
 # One command to run before every commit: formatting, the full clippy sweep, the
-# conventions audit, and the doc build. fmt-check first (fast, fails early on
-# drift); clippy reuses the target above; audit is pure grep; doc last. Each leg
-# is also its own target, so CI runs them as parallel jobs instead of this
-# sequence.
+# conventions audit, the Makefile isolation regression, and the doc build.
+# fmt-check first (fast, fails early on drift); clippy reuses the target above;
+# audit and test-isolation are fast; doc stays last. Each leg is also its own
+# target, so CI runs them as parallel jobs instead of this sequence.
 check:
 	$(MAKE) fmt-check
 	$(MAKE) clippy
 	$(MAKE) audit
+	$(MAKE) test-isolation
 	$(MAKE) doc
 
 clean:

--- a/scripts/test-isolation.py
+++ b/scripts/test-isolation.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Check production Makefile path resolution without building or installing."""
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+MAKEFILE = Path(__file__).resolve().parent.parent / "Makefile"
+FIELDS = ("WINE_SDK", "WINE_INSTALL_DIR", "WINEPREFIX", "WINE",
+          "WINEBUILD", "WINESERVER", "INSTALL_DIRS", "TEST_PREFIX")
+
+
+class IsolationTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="mtld3d-isolation-")
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name).resolve()
+        self.work = self.root / "work"
+        self.work.mkdir()
+        self.sources = {
+            "WINE_SDK": str(self.root / "sdk-source"),
+            "WINE_INSTALL_DIR": str(self.root / "install-source"),
+            "WINEPREFIX": str(self.root / "prefix-source"),
+        }
+        for name, directory in self.sources.items():
+            source = Path(directory)
+            source.mkdir()
+            (source / "sentinel").write_text(name)
+        self.wrapper = self.work / "inspect.mk"
+        self.wrapper.write_text(
+            f"include {MAKEFILE}\n"
+            ".PHONY: inspect recurse\n"
+            "inspect:\n"
+            "\t@printf '%s\\n' "
+            + " ".join(f"'resolved:{name}=$({name})'" for name in FIELDS)
+            + "\nrecurse: inspect\n"
+            "\t+$(MAKE) --no-print-directory -f $(firstword $(MAKEFILE_LIST)) inspect\n"
+        )
+        self.environment = os.environ.copy()
+        for name in ("MAKEFLAGS", "MFLAGS", "GNUMAKEFLAGS", "MAKEOVERRIDES",
+                     "MAKELEVEL", "ISOLATED", *self.sources):
+            self.environment.pop(name, None)
+        self.environment.update(self.sources)
+
+    def run_make(self, *arguments):
+        isolation_root = self.work / ".wine-isolated"
+        result = subprocess.run(
+            ["make", "--no-print-directory", "-f", str(self.wrapper),
+             f"ISOLATED_ROOT={isolation_root}", "ISOLATED_REGISTRY=",
+             "BUILD_ID=isolation-test", "SDK_UNIX_ARCH=x64", *arguments],
+            cwd=MAKEFILE.parent, env=self.environment, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        return result.stdout
+
+    def assert_paths(self, output, isolated, copies=1):
+        sdk = str(self.work / ".wine-isolated/sdk") if isolated else self.sources["WINE_SDK"]
+        prefix = str(self.work / ".wine-isolated/prefix") if isolated else self.sources["WINEPREFIX"]
+        install = sdk if isolated else self.sources["WINE_INSTALL_DIR"]
+        expected = dict(WINE_SDK=sdk, WINE_INSTALL_DIR=install, WINEPREFIX=prefix,
+                        WINE=f"{sdk}/bin/wine", WINEBUILD=f"{sdk}/bin/winebuild",
+                        WINESERVER=f"{sdk}/bin/wineserver", TEST_PREFIX=prefix,
+                        INSTALL_DIRS=" ".join(sorted({sdk, install})))
+        actual = [line for line in output.splitlines() if line.startswith("resolved:")]
+        self.assertEqual(actual, [f"resolved:{name}={expected[name]}" for name in FIELDS] * copies,
+                         output)
+        if isolated:
+            banner = (f"==> ISOLATED=1: WINE_SDK={sdk} WINE_INSTALL_DIR={install} "
+                      f"WINEPREFIX={prefix}")
+            actual_banners = [line for line in output.splitlines()
+                              if line.startswith("==> ISOLATED=1:")]
+            self.assertEqual(actual_banners, [banner] * copies, output)
+            for directory, source in (("sdk", "WINE_SDK"), ("prefix", "WINEPREFIX")):
+                self.assertEqual((self.work / ".wine-isolated" / directory / "sentinel").read_text(),
+                                 source)
+        else:
+            self.assertFalse((self.work / ".wine-isolated").exists())
+        for name, directory in self.sources.items():
+            self.assertEqual(list(Path(directory).iterdir()), [Path(directory) / "sentinel"])
+            self.assertEqual((Path(directory) / "sentinel").read_text(), name)
+
+    def test_environment_inputs(self):
+        self.assert_paths(self.run_make("ISOLATED=1", "inspect"), True)
+
+    def test_command_line_inputs_and_recursive_make(self):
+        arguments = [f"{name}={value}" for name, value in self.sources.items()]
+        self.assert_paths(self.run_make("ISOLATED=1", *arguments, "recurse"), True, copies=2)
+
+    def test_environment_override_mode(self):
+        self.assert_paths(self.run_make("-e", "ISOLATED=1", "recurse"), True, copies=2)
+
+    def test_nonisolated_paths_are_preserved(self):
+        self.assert_paths(self.run_make("inspect"), False)
+
+    def test_cleaner_only_goals_do_not_clone(self):
+        arguments = [f"{name}={value}" for name, value in self.sources.items()]
+        for goals in (("clean-isolated",), ("clean-isolated-orphans",),
+                      ("clean-isolated", "clean-isolated-orphans")):
+            with self.subTest(goals=goals):
+                self.run_make("-n", "ISOLATED=1", *arguments, *goals)
+                self.assertFalse((self.work / ".wine-isolated").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`ISOLATED=1` could still install into a shared Wine SDK when `WINE_SDK` was passed as a make command-line assignment. GNU make gives command-line variables and environment variables under `-e` precedence over ordinary Makefile assignments, so the banner claimed isolation while the read-only reproduction resolved `WINE=/review/shared-sdk/bin/wine` and `INSTALL_DIRS=/review/shared-install /review/shared-sdk`.

Capture the SDK and prefix clone sources before remapping, then use override assignments for `WINE_SDK`, `WINE_INSTALL_DIR`, and `WINEPREFIX`. The isolation banner now prints each resolved destination. A non-installing regression includes the production Makefile and covers environment inputs, command-line inputs, `-e`, recursive make propagation, cleaner-only goals, and clone-source sentinels. It runs through `make check` and the CI check job.

I considered rejecting command-line inputs. Keeping them as clone sources preserves existing invocations while enforcing private destinations whenever `ISOLATED=1` is selected.

Rules check: against `CONTRIBUTING.md`, `docs/CONVENTIONS.md`, and `docs/ARCHITECTURE.md`, this changes Makefile and CI tooling only. It introduces no static, runtime config key, wire field, dependency, derive, lint suppression, duplicated production path logic, COM contract, rendering behavior, or threading change. The regression imports the production Makefile and uses temporary source trees rather than restating its path logic.

Verification:

- The pre-change read-only probe retained command-line destinations while its environment-input control resolved private paths. The regression now passes all five cases.
- `make fmt`
- `make check`, including `audit: clean (306 files)` and 5 passing isolation tests
- `make ISOLATED=1 test`: 1,105 Windows host tests and 294 Unix host tests passed; i686 and x86_64 each ran all four e2e executables and passed 487 of 487 tests in 4 processes. Every reported Wine SDK, install directory, prefix, and Wine executable was under this worktree's `.wine-isolated` root.

Conformance was not run because this changes Makefile and CI tooling only, with no render, state, shader, or shared-crate code.

Closes #509
