### PR TITLE
Retire committed work when CPU frame submission fails

### DIFF
--- a/unix/shared/src/params.rs
+++ b/unix/shared/src/params.rs
@@ -913,11 +913,13 @@ pub struct SubmitFrameParams {
     /// `coherent_seq_ptr`, which tracks full-frame (draw) retirement for
     /// VB/IB.
     pub upload_coherent_seq_ptr: u64, // in: *const AtomicU64 (PE heap, stable)
-    /// Highest submit seq whose command buffer the GPU aborted.
+    /// Highest submit seq whose CPU encoding or GPU execution failed.
     ///
     /// Both completion handlers `fetch_max` `submit_seq` into
     /// `*(failed_submit_seq_ptr as *const AtomicU64)` when the command
-    /// buffer reaches `MTLCommandBufferStatus::Error`. Deliberately a
+    /// buffer reaches `MTLCommandBufferStatus::Error`. A CPU encoding
+    /// failure records the sequence and drains all committed draw/upload
+    /// buffers and their handlers before advancing retirement. Deliberately a
     /// second counter rather than a gate on `coherent_seq`: an aborted
     /// command buffer *is* finished with its source memory, so withholding
     /// the retirement bump would pin every seq-gated queue behind a seq

--- a/unix/shared/src/params.rs
+++ b/unix/shared/src/params.rs
@@ -918,9 +918,10 @@ pub struct SubmitFrameParams {
     /// Both completion handlers `fetch_max` `submit_seq` into
     /// `*(failed_submit_seq_ptr as *const AtomicU64)` when the command
     /// buffer reaches `MTLCommandBufferStatus::Error`. A CPU encoding
-    /// failure records the sequence and drains all committed draw/upload
-    /// buffers and their handlers before advancing retirement. Deliberately a
-    /// second counter rather than a gate on `coherent_seq`: an aborted
+    /// failure first drains all committed draw/upload buffers and their
+    /// handlers, then records the failed sequence before advancing retirement
+    /// to that sequence. Deliberately a second counter rather than a gate on
+    /// `coherent_seq`: an aborted
     /// command buffer *is* finished with its source memory, so withholding
     /// the retirement bump would pin every seq-gated queue behind a seq
     /// that never retires and deadlock `wait_for_gpu_retire`. Retirement

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -66,9 +66,9 @@ unsafe impl Sync for PendingCmdBuf {}
 
 /// Registry of in-flight `MTLCommandBuffer`s keyed by `(device, submit_seq)`.
 ///
-/// The device half of the key is the frame's `coherent_seq_ptr`, the
-/// PE-side counter the buffer's completion advances: one per device, and
-/// the same value on every submit and every wait of that device. Every
+/// The first half of the key is the draw or upload `coherent_seq_ptr`, the
+/// PE-side counter the buffer's completion advances. Draw and upload
+/// counters have distinct addresses, stable across the device's submissions. Every
 /// device mints its own `submit_seq` from one, so without it two live
 /// devices would share a key space, replace each other's entries and wait
 /// on each other's buffers; and the in-order argument behind
@@ -86,12 +86,17 @@ static PENDING_CMDBUFS: Mutex<BTreeMap<(u64, u64), PendingCmdBuf>> = Mutex::new(
 
 /// The entry for the smallest seq at or past `target` on one device.
 ///
+/// If the target has no successor, the latest earlier entry still needs waiting.
 /// Entries of other devices never answer: the range stays inside `device`'s
 /// half of the key space.
-fn first_pending<V>(map: &BTreeMap<(u64, u64), V>, device: u64, target: u64) -> Option<&V> {
+fn first_pending<V>(
+    map: &BTreeMap<(u64, u64), V>,
+    device: u64,
+    target: u64,
+) -> Option<(&(u64, u64), &V)> {
     map.range((device, target)..=(device, u64::MAX))
         .next()
-        .map(|(_, value)| value)
+        .or_else(|| map.range((device, 0)..=(device, target)).next_back())
 }
 
 /// Log sub-target of the presented-cadence probe.
@@ -190,15 +195,13 @@ fn register_presented_probe(
     unsafe { drawable.addPresentedHandler(RcBlock::as_ptr(&handler)) };
 }
 
-/// Block until `coherent_seq >= target_seq` by calling `waitUntilCompleted`.
+/// Wait for a submitted sequence, or the latest earlier work if that sequence is missing.
 ///
-/// The wait targets the registered cmdbuf for the smallest in-flight seq
-/// ≥ target on the device `coherent_seq_ptr` belongs to. Metal's queue is
-/// in-order, so waiting on that one implicitly waits on every earlier one
-/// of the same device too. After the wait we `fetch_max` the
-/// atomic ourselves: the completion handler may not have fired yet (it
-/// runs on Metal's own dispatch queue), and our caller needs to observe
-/// `coherent_seq >= target_seq` on return.
+/// The wait targets the registered buffer for the smallest in-flight seq
+/// at or beyond the target on this device, falling back to its latest earlier
+/// buffer. Metal executes the queue in order. `waitUntilCompleted` also waits
+/// for the buffer's completion handlers. Only the sequence actually waited
+/// for is published: a missing target is not evidence of GPU retirement.
 ///
 /// Bumping `coherent_seq` by hand is also why this has to inspect the
 /// status: a command buffer the GPU killed is finished, so the bump is
@@ -221,12 +224,11 @@ pub fn wait_for_gpu_retire(target_seq: u64, coherent_seq_ptr: u64, failed_submit
         // handler removes from the same map and would deadlock if we
         // held the lock across the kernel sleep.
         let map = PENDING_CMDBUFS.lock().unwrap();
-        first_pending(&map, coherent_seq_ptr, target_seq).map(|cb| cb.0.clone())
+        first_pending(&map, coherent_seq_ptr, target_seq).map(|(&(_, seq), cb)| (seq, cb.0.clone()))
     };
-    let Some(cmdbuf) = cmdbuf else {
-        // Either the handler raced ahead of us (already removed) or
-        // the caller passed a target the encoder never submitted.
-        // Either way, re-check the atomic and trust it.
+    let Some((retired_seq, cmdbuf)) = cmdbuf else {
+        // No registered work remains for this counter. A CPU submission
+        // failure drains both counters before publishing its missing seq.
         return;
     };
     mtld3d_shared::crumb!("gpuretirebeg", target_seq, atomic.load(Ordering::Acquire));
@@ -235,7 +237,7 @@ pub fn wait_for_gpu_retire(target_seq: u64, coherent_seq_ptr: u64, failed_submit
     // Record the abort before the retirement bump: both stores are
     // `Release`, so a PE-side `Acquire` load of `coherent_seq` that sees
     // this seq is guaranteed to see the failure too.
-    if let Some((code, desc)) = record_failed_submit(&cmdbuf, target_seq, failed_submit_seq_ptr) {
+    if let Some((code, desc)) = record_failed_submit(&cmdbuf, retired_seq, failed_submit_seq_ptr) {
         mtld3d_shared::crumb!("gpuretirecberr", target_seq);
         mtld3d_shared::log_once_warn_by!(
             target: LOG_TARGET,
@@ -244,7 +246,7 @@ pub fn wait_for_gpu_retire(target_seq: u64, coherent_seq_ptr: u64, failed_submit
              GPU (code {code}: {desc}); everything it carried was discarded",
         );
     }
-    atomic.fetch_max(target_seq, Ordering::Release);
+    atomic.fetch_max(retired_seq, Ordering::Release);
 }
 
 /// `fetch_max` an aborted command buffer's seq into the PE-side failed-submit counter.
@@ -315,6 +317,61 @@ impl core::fmt::Display for BlitSite {
 /// with its own attachments and load actions, optionally blits the
 /// backbuffer to the drawable, and commits.
 pub fn submit_frame(params: &mut SubmitFrameParams) -> bool {
+    submit_frame_with(params, encode_frame)
+}
+
+/// Keep CPU encoding failures inside the same retirement boundary as GPU failures.
+fn submit_frame_with(
+    params: &mut SubmitFrameParams,
+    encode: impl FnOnce(&mut SubmitFrameParams) -> bool,
+) -> bool {
+    let success = encode(params);
+    if !success {
+        retire_failed_submit(params);
+    }
+    success
+}
+
+/// Retire every committed buffer before publishing a failed CPU submission as finished.
+fn retire_failed_submit(params: &SubmitFrameParams) {
+    // SubmitFrame is serialized per device. Nothing can insert a later buffer
+    // for either counter while this call drains the failed frame's work.
+    for counter in [params.coherent_seq_ptr, params.upload_coherent_seq_ptr] {
+        loop {
+            let pending = PENDING_CMDBUFS
+                .lock()
+                .unwrap()
+                .range((counter, 0)..=(counter, params.submit_seq))
+                .next()
+                .map(|(&key, cb)| (key, cb.0.clone()));
+            let Some((key, cb)) = pending else {
+                break;
+            };
+            // This waits for completion handlers too, protecting the PE sink
+            // atomics as well as the backing pages read by the GPU.
+            cb.waitUntilCompleted();
+            let _ = record_failed_submit(&cb, key.1, params.failed_submit_seq_ptr);
+            let _ = PENDING_CMDBUFS.lock().unwrap().remove(&key);
+        }
+    }
+    // Recovery can inspect failed_seq before retirement and abandon retries.
+    // Publish the CPU failure only after its committed work is no longer live.
+    advance_counter(params.failed_submit_seq_ptr, params.submit_seq);
+    advance_counter(params.upload_coherent_seq_ptr, params.submit_seq);
+    advance_counter(params.coherent_seq_ptr, params.submit_seq);
+}
+
+/// Publish a sequence into one of the stable PE-side retirement counters.
+fn advance_counter(pointer: u64, seq: u64) {
+    if pointer != 0 {
+        // SAFETY: SubmitFrame carries stable PE AtomicU64 pointers kept live
+        // through this call and every registered command buffer's completion.
+        let counter = unsafe { &*(pointer as *const AtomicU64) };
+        counter.fetch_max(seq, Ordering::Release);
+    }
+}
+
+fn encode_frame(params: &mut SubmitFrameParams) -> bool {
     params.drawable_wait_ns = 0;
     mtld3d_shared::crumb!("submit:enter", params.queue_handle.raw(), params.pass_count);
     mtld3d_shared::crumb!("submit:queueret", params.queue_handle.raw());
@@ -711,12 +768,11 @@ pub fn submit_frame(params: &mut SubmitFrameParams) -> bool {
 /// before the draw CB, the uploads still finish before any same-frame
 /// draw samples them.
 ///
-/// Deliberately NOT registered in `PENDING_CMDBUFS`: nothing ever waits
-/// on an upload seq via `wait_for_gpu_retire`, and the draw CB retiring
-/// (which *is* registered, under the same `submit_seq`) already implies
-/// this earlier-committed CB retired — registering it too would put two
-/// command buffers under one key. Returns `false` if command-buffer
-/// creation or blit encoding failed.
+/// Registered under the upload counter's address, so a draw buffer at the
+/// same sequence has a distinct key. CPU failure can leave this buffer
+/// committed without a draw buffer, and must wait for it and its handler
+/// before releasing the PE backing or either callback sink.
+/// Returns `false` if command-buffer creation or blit encoding failed.
 fn submit_upload_cmd_buf(
     queue: &ProtocolObject<dyn MTLCommandQueue>,
     blits: &[BlitCommand],
@@ -774,11 +830,19 @@ fn submit_upload_cmd_buf(
                 let atomic = unsafe { &*(atomic_ptr as *const AtomicU64) };
                 atomic.fetch_max(seq, Ordering::Release);
                 mtld3d_shared::crumb!("submit:upretire", seq);
+                let _ = PENDING_CMDBUFS
+                    .lock()
+                    .unwrap()
+                    .remove(&(upload_coherent_seq_ptr, seq));
             },
         );
         // SAFETY: objc2 typed binding; Metal copies the block on
         // `addCompletedHandler`, so the local `handler` may drop after.
         unsafe { upload_cb.addCompletedHandler(RcBlock::as_ptr(&handler)) };
+        PENDING_CMDBUFS.lock().unwrap().insert(
+            (upload_coherent_seq_ptr, seq),
+            PendingCmdBuf(upload_cb.clone()),
+        );
     }
     mtld3d_shared::crumb!("submit:upcommit");
     upload_cb.commit();

--- a/unix/unix/src/metal/command/tests.rs
+++ b/unix/unix/src/metal/command/tests.rs
@@ -19,15 +19,32 @@
 //! smallest registered seq at or past the target on the waiting device, and never with
 //! another device's entry, however the seqs of the two interleave.
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        mpsc,
+    },
+    thread,
+    time::Duration,
+};
 
-use mtld3d_shared::mtl::{BlockLayout, PixelFormat};
-use objc2_metal::MTLPixelFormat;
+use mtld3d_shared::{
+    MetalHandle, SubmitFrameParams,
+    mtl::{BlockLayout, PixelFormat},
+};
+use objc2::{rc::Retained, runtime::ProtocolObject};
+use objc2_metal::{
+    MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue, MTLCreateSystemDefaultDevice,
+    MTLDevice, MTLPixelFormat, MTLSharedEvent,
+};
 
 use super::{
-    CopyBufferEndpoint, CopyEndpoint, CopyRegion, CopyRejectReason, PresentGeometry, PresentRoute,
-    SETTLED_PRESENTS, copy_buffer_to_texture_reject, copy_texture_reject,
-    copy_texture_to_buffer_reject, first_pending, geometry_settled, present_route,
+    CopyBufferEndpoint, CopyEndpoint, CopyRegion, CopyRejectReason, PENDING_CMDBUFS, PendingCmdBuf,
+    PresentGeometry, PresentRoute, SETTLED_PRESENTS, copy_buffer_to_texture_reject,
+    copy_texture_reject, copy_texture_to_buffer_reject, first_pending, geometry_settled,
+    present_route, submit_frame_with, submit_upload_cmd_buf, wait_for_gpu_retire,
 };
 
 /// Two device identities that sort either side of each other's seqs.
@@ -48,11 +65,26 @@ fn a_wait_answers_with_its_own_devices_next_seq() {
     ]
     .into_iter()
     .collect();
-    assert_eq!(first_pending(&map, DEVICE_A, 5), Some(&15));
-    assert_eq!(first_pending(&map, DEVICE_A, 6), Some(&17));
-    assert_eq!(first_pending(&map, DEVICE_A, 7), Some(&17));
-    assert_eq!(first_pending(&map, DEVICE_A, 8), None);
-    assert_eq!(first_pending(&map, DEVICE_B, 6), Some(&26));
+    assert_eq!(
+        first_pending(&map, DEVICE_A, 5).map(|(_, value)| value),
+        Some(&15)
+    );
+    assert_eq!(
+        first_pending(&map, DEVICE_A, 6).map(|(_, value)| value),
+        Some(&17)
+    );
+    assert_eq!(
+        first_pending(&map, DEVICE_A, 7).map(|(_, value)| value),
+        Some(&17)
+    );
+    assert_eq!(
+        first_pending(&map, DEVICE_A, 8).map(|(_, value)| value),
+        Some(&17)
+    );
+    assert_eq!(
+        first_pending(&map, DEVICE_B, 6).map(|(_, value)| value),
+        Some(&26)
+    );
 }
 
 /// Another device's entries never answer a wait, whatever seqs it holds.
@@ -61,8 +93,14 @@ fn another_devices_entries_never_answer_a_wait() {
     let map: BTreeMap<(u64, u64), u32> = (1..=10).map(|seq| ((DEVICE_B, seq), 20)).collect();
     assert_eq!(first_pending(&map, DEVICE_A, 1), None);
     assert_eq!(first_pending(&map, DEVICE_A, 0), None);
-    assert_eq!(first_pending(&map, DEVICE_B, 3), Some(&20));
-    assert_eq!(first_pending(&map, DEVICE_B, 11), None);
+    assert_eq!(
+        first_pending(&map, DEVICE_B, 3).map(|(_, value)| value),
+        Some(&20)
+    );
+    assert_eq!(
+        first_pending(&map, DEVICE_B, 11).map(|(_, value)| value),
+        Some(&20)
+    );
 }
 
 /// Matching extents take the blit whether or not `MetalFX` exists.
@@ -638,4 +676,192 @@ fn a_readback_reports_the_ends_the_other_way_round() {
         ),
         Some(CopyRejectReason::DestinationBufferTooShort)
     );
+}
+
+/// A missing final sequence still waits for earlier committed GPU work.
+#[test]
+fn missing_final_submit_waits_for_earlier_work() {
+    let queue = test_queue();
+    let event = queue.device().newSharedEvent().expect("shared event");
+    let cb = queue.commandBuffer().expect("command buffer");
+    cb.encodeWaitForEvent_value(ProtocolObject::from_ref(&*event), 1);
+    let coherent = AtomicU64::new(0);
+    let failed = AtomicU64::new(0);
+    let counter = atomic_address(&coherent);
+    PENDING_CMDBUFS
+        .lock()
+        .unwrap()
+        .insert((counter, 1), PendingCmdBuf(cb.clone()));
+    cb.commit();
+    let (done, watchdog) = release_event_after_wait(event);
+    wait_for_gpu_retire(2, counter, atomic_address(&failed));
+    let status_at_return = cb.status();
+    let retired_at_return = coherent.load(Ordering::Acquire);
+    let _ = done.send(());
+    watchdog.join().unwrap();
+    cb.waitUntilCompleted();
+    PENDING_CMDBUFS.lock().unwrap().remove(&(counter, 1));
+    assert_eq!(status_at_return, MTLCommandBufferStatus::Completed);
+    assert_eq!(
+        retired_at_return, 1,
+        "the missing sequence was not submitted"
+    );
+}
+
+/// Both failure positions protect committed work and publish failure before retirement.
+#[test]
+fn cpu_submit_failure_drains_draw_and_upload_handlers() {
+    cpu_submit_failure_drain(false);
+}
+
+#[test]
+fn cpu_submit_failure_after_upload_commit_drains_handlers() {
+    cpu_submit_failure_drain(true);
+}
+
+fn cpu_submit_failure_drain(upload_committed: bool) {
+    let queue = test_queue();
+    let event = queue.device().newSharedEvent().expect("shared event");
+    let cb = queue.commandBuffer().expect("command buffer");
+    if !upload_committed {
+        cb.encodeWaitForEvent_value(ProtocolObject::from_ref(&*event), 1);
+    }
+    let coherent = AtomicU64::new(0);
+    let upload = AtomicU64::new(0);
+    let failed = AtomicU64::new(0);
+    let draw_counter = atomic_address(&coherent);
+    let upload_counter = atomic_address(&upload);
+    let handler_done = Arc::new(AtomicBool::new(false));
+    let handler_flag = Arc::clone(&handler_done);
+    let handler = block2::RcBlock::new(
+        move |_cb: core::ptr::NonNull<ProtocolObject<dyn MTLCommandBuffer>>| {
+            handler_flag.store(true, Ordering::Release);
+        },
+    );
+    // SAFETY: Metal retains the block, whose only capture owns its atomic.
+    unsafe { cb.addCompletedHandler(block2::RcBlock::as_ptr(&handler)) };
+    PENDING_CMDBUFS
+        .lock()
+        .unwrap()
+        .insert((draw_counter, 1), PendingCmdBuf(cb.clone()));
+    cb.commit();
+    if upload_committed {
+        cb.waitUntilCompleted();
+    }
+    // In the upload case only the upload is parked. Waiting for the older
+    // draw alone cannot satisfy the lifetime assertion.
+    let upload_gate = queue.commandBuffer().expect("upload gate");
+    if upload_committed {
+        upload_gate.encodeWaitForEvent_value(ProtocolObject::from_ref(&*event), 1);
+    }
+    upload_gate.commit();
+    let mut params = test_submit_params(&queue, &coherent, &upload, &failed);
+    let (done, watchdog) = release_event_after_wait(event);
+    let mut committed_upload = None;
+    let success = submit_frame_with(&mut params, |params| {
+        if upload_committed {
+            assert!(submit_upload_cmd_buf(
+                &queue,
+                &[],
+                false,
+                params.submit_seq,
+                upload_counter,
+                params.failed_submit_seq_ptr
+            ));
+            // The upload at seq 2 is parked behind its own gate. Register
+            // a draw at the same seq to prove the counter identities do not collide.
+            PENDING_CMDBUFS
+                .lock()
+                .unwrap()
+                .insert((draw_counter, 2), PendingCmdBuf(cb.clone()));
+            let pending = PENDING_CMDBUFS.lock().unwrap();
+            assert!(pending.contains_key(&(draw_counter, 2)));
+            committed_upload = pending.get(&(upload_counter, 2)).map(|cb| cb.0.clone());
+            drop(pending);
+            assert!(committed_upload.is_some());
+        }
+        false
+    });
+    let upload_status_at_return = committed_upload.as_ref().map(|cb| cb.status());
+    let status_at_return = cb.status();
+    let handler_at_return = handler_done.load(Ordering::Acquire);
+    let counters_at_return = (
+        coherent.load(Ordering::Acquire),
+        upload.load(Ordering::Acquire),
+        failed.load(Ordering::Acquire),
+    );
+    let _ = done.send(());
+    watchdog.join().unwrap();
+    cb.waitUntilCompleted();
+    // Cleanup precedes assertions so the pre-fix reproduction frees no live sink.
+    let pending_upload = PENDING_CMDBUFS
+        .lock()
+        .unwrap()
+        .get(&(upload_counter, 2))
+        .map(|cb| cb.0.clone());
+    if let Some(upload_cb) = pending_upload {
+        upload_cb.waitUntilCompleted();
+    }
+    upload_gate.waitUntilCompleted();
+    PENDING_CMDBUFS
+        .lock()
+        .unwrap()
+        .retain(|&(counter, _), _| counter != draw_counter && counter != upload_counter);
+    assert!(!success);
+    assert_eq!(status_at_return, MTLCommandBufferStatus::Completed);
+    assert!(handler_at_return, "callback sinks must be unused on return");
+    if upload_committed {
+        assert_eq!(
+            upload_status_at_return,
+            Some(MTLCommandBufferStatus::Completed)
+        );
+    }
+    assert_eq!(counters_at_return, (2, 2, 2));
+}
+
+fn test_queue() -> Retained<ProtocolObject<dyn MTLCommandQueue>> {
+    let device = MTLCreateSystemDefaultDevice().expect("Metal device");
+    device.newCommandQueue().expect("command queue")
+}
+
+fn atomic_address(value: &AtomicU64) -> u64 {
+    core::ptr::from_ref(value) as u64
+}
+
+fn test_submit_params(
+    queue: &ProtocolObject<dyn MTLCommandQueue>,
+    coherent: &AtomicU64,
+    upload: &AtomicU64,
+    failed: &AtomicU64,
+) -> SubmitFrameParams {
+    SubmitFrameParams {
+        // SAFETY: the caller's retained queue stays alive throughout the submission.
+        queue_handle: unsafe { MetalHandle::new(core::ptr::from_ref(queue) as u64) },
+        blit_commands_ptr: 0,
+        blit_command_count: 0,
+        blit_commands_need_encoder: 0,
+        passes_ptr: 0,
+        pass_count: 0,
+        pad1: 0,
+        present_layer: MetalHandle::NULL,
+        present_texture: MetalHandle::NULL,
+        submit_seq: 2,
+        coherent_seq_ptr: atomic_address(coherent),
+        upload_coherent_seq_ptr: atomic_address(upload),
+        failed_submit_seq_ptr: atomic_address(failed),
+        drawable_wait_ns: 0,
+        present_view: MetalHandle::NULL,
+    }
+}
+
+/// The watchdog also releases immediately when a broken wait returns early.
+fn release_event_after_wait(
+    event: Retained<ProtocolObject<dyn MTLSharedEvent>>,
+) -> (mpsc::Sender<()>, thread::JoinHandle<()>) {
+    let (done, waiting) = mpsc::channel();
+    let watchdog = thread::spawn(move || {
+        let _ = waiting.recv_timeout(Duration::from_millis(100));
+        event.setSignaledValue(1);
+    });
+    (done, watchdog)
 }

--- a/windows/core/src/upload_recovery.rs
+++ b/windows/core/src/upload_recovery.rs
@@ -255,7 +255,7 @@ impl<T> UploadRecoveryQueue<T> {
 
     /// Take every queued entry, leaving the queue empty.
     ///
-    /// Reset and shutdown call this after the GPU has gone idle: the
+    /// Shutdown calls this after the GPU has gone idle: the
     /// payloads own Metal wrappers and PE-heap backings the caller must
     /// tear down in its own destroy-then-drop order.
     pub fn drain_all(&mut self) -> Vec<PendingUpload<T>> {

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -8173,22 +8173,24 @@ impl FrameEncoder {
         held
     }
 
-    /// Block until `coherent_seq >= current_submit_seq`.
+    /// Wait for committed work through the current submission.
     ///
-    /// Parks on the unix-side `WaitForGpuRetire` thunk, which calls Metal's
-    /// `MTLCommandBuffer::waitUntilCompleted` on the registered cmdbuf for
-    /// `current_submit_seq`. Skips immediately when the encoder hasn't yet
-    /// been given a `coherent_seq` pointer or hasn't submitted any frame —
-    /// both states arrive together in `begin_frame`.
+    /// Delegates to the unix-side retirement wait. If the current sequence
+    /// has no registered buffer, the wait falls back to earlier committed
+    /// work without publishing the missing sequence as retired. CPU submission
+    /// failure separately drains committed work before retiring its sequence.
+    /// Skips when the encoder has no retirement counter or current sequence.
     fn wait_for_gpu_idle(&self) {
         self.wait_for_gpu_retire(self.current_submit_seq);
     }
 
-    /// Block until `coherent_seq >= target_seq`.
+    /// Wait for a submitted sequence, falling back to earlier committed work.
     ///
-    /// A target of 0 names no frame, and a target the encoder never
-    /// submitted is answered by the atomic alone on the unix side, so
-    /// neither waits.
+    /// A target of 0 names no frame. The unix side also skips an already
+    /// retired target; otherwise it waits for the smallest registered sequence
+    /// at or beyond the target, or the latest earlier entry if none exists.
+    /// Only the sequence actually waited for is published, so a missing target
+    /// may remain above the retirement counter when this call returns.
     fn wait_for_gpu_retire(&self, target_seq: u64) {
         if self.coherent_seq_ptr == 0 || target_seq == 0 {
             return;

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -7998,7 +7998,25 @@ impl FrameEncoder {
         //    Texture-kind retention entries merge into the `textures`
         //    Vec collected from the live cache above.
         mtld3d_shared::crumb!("phase:SdDrain");
-        let held = self.drain_retention_and_wait(&mut buffers, &mut textures);
+        let mut held = self.drain_retention_and_wait(&mut buffers, &mut textures);
+        // Shutdown has no future frame to replay uploads into. Reset keeps
+        // these queues because its resource caches survive, and a failed
+        // final flush still owes their copies at the next begin_frame.
+        for entry in self.pending_stage_uploads.drain_all() {
+            let retry = entry.into_payload();
+            if !retry.transient.is_null() {
+                buffers.push(retry.transient.raw());
+            }
+            self.perf.bump_vbib_retained_sub(retry.page_box.len());
+            self.sub_retained_bytes(retry.page_box.len());
+            held.pageboxes.push(retry.page_box);
+        }
+        // Texture jobs own only a clone of the texture's staging Arc; park
+        // it with the other staging keepalives so it outlives the bulk
+        // destroy of the `MTLBuffer`s that wrap those pages.
+        for entry in self.pending_texture_uploads.drain_all() {
+            held.staging_arcs.push(entry.into_payload().arc);
+        }
 
         // 3. Bulk destroys for live caches. Pipelines reference functions,
         //    which reference libraries — destroy leaf-first.
@@ -8108,25 +8126,6 @@ impl FrameEncoder {
         textures: &mut Vec<u64>,
     ) -> HeldBackings {
         let mut held = HeldBackings::default();
-        // Un-acknowledged uploads go the same way as retention: the GPU is
-        // about to be idle, so there is nothing left to replay into. Their
-        // bytes leave the shared retention total here, which is the only
-        // place besides `settle_stage_uploads` that subtracts them.
-        for entry in self.pending_stage_uploads.drain_all() {
-            let retry = entry.into_payload();
-            if !retry.transient.is_null() {
-                buffers.push(retry.transient.raw());
-            }
-            self.perf.bump_vbib_retained_sub(retry.page_box.len());
-            self.sub_retained_bytes(retry.page_box.len());
-            held.pageboxes.push(retry.page_box);
-        }
-        // Texture jobs own only a clone of the texture's staging Arc; park
-        // it with the other staging keepalives so it outlives the bulk
-        // destroy of the `MTLBuffer`s that wrap those pages.
-        for entry in self.pending_texture_uploads.drain_all() {
-            held.staging_arcs.push(entry.into_payload().arc);
-        }
         while let Some(entry) = self.pending_resource_retention.pop_front() {
             if entry.handle != 0 {
                 match entry.kind {


### PR DESCRIPTION
A failed command-buffer or encoder allocation could leave Reset or device destruction treating a missing final submission as idle while earlier GPU work still read PE-owned pages. Uploads from that submission could also be discarded without reaching the GPU because only GPU failures reached the recovery counter.

Route CPU encoding failures through a drain of every registered draw and upload buffer for the device before publishing the failed sequence and retirement. Uploads use their own retirement-counter address in the existing registry, so an upload committed before draw encoding fails remains reachable without colliding with the draw entry. A wait for an absent sequence also waits the latest earlier entry and publishes only the sequence it actually waited for. Preserve pending upload recovery across Reset, whose resource caches survive, and drain it unconditionally at shutdown.

Native Metal tests park work behind a shared event before and after upload commit, including an upload-only wait after the older draw has completed. Restoring the previous failure behavior makes all three lifetime regressions return with a command buffer still Committed; the fix waits until Completed. Isolated fault-injection probes exercise resizing Reset and final destruction before and after upload commit on both PE architectures. Restoring the original Reset cleanup independently makes the surviving texture read transparent black instead of red. The injected build also checks the staged-upload retained-byte subtraction at destruction. Fault instrumentation remains outside the submitted change.

Rules check: CONTRIBUTING.md, docs/CONVENTIONS.md and docs/ARCHITECTURE.md reviewed. The change reuses the existing registry, preserves per-device submit serialization and completion-sink lifetimes, and keeps native tests in command/tests.rs. It adds no static, config key, environment variable, wire field, dependency, derive, lint suppression, shader change or duplicated registry. Verification: make fmt, make check (formatting, clippy, audit and documentation), isolated make test (1,402 native tests and 487 end-to-end tests per PE architecture), and full isolated conformance passed. The first conformance attempt missed one WM_DISPLAYCHANGE notification at device.c:4410; an unchanged rerun passed both architectures. Other display tests were active during the first run, but interference was not established. No baseline change.

Closes #490
