### PR TITLE
Propagate e2e executable discovery failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,9 @@ jobs:
       - name: test-isolation
         if: ${{ !cancelled() }}
         run: make test-isolation
+      - name: test-e2e-discovery
+        if: ${{ !cancelled() }}
+        run: make test-e2e-discovery
       - name: doc-unix
         if: ${{ !cancelled() }}
         run: make doc-unix

--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ TAG          ?= $(shell git describe --tags --exact-match 2>/dev/null)
 	conformance-baseline-scale-i686 conformance-baseline-scale-x86_64 \
 	conformance-baseline-intel-i686 conformance-baseline-intel-x86_64 \
 	conformance-isolate fmt fmt-check clippy clippy-pe-i686 clippy-pe-x86_64 \
-	clippy-native audit test-isolation doc doc-windows doc-unix check clean upgrade \
+	clippy-native audit test-isolation test-e2e-discovery doc doc-windows doc-unix check clean upgrade \
 	upgrade-incompat setup setup-rust setup-nextest setup-dev setup-xwin \
 	setup-rosetta \
 	xwin-dir fetch
@@ -584,8 +584,8 @@ stage: all
 	$(call clone_tree,$(OUT_unix_x64)/mtld3d.so.dSYM,$(STAGE_DIR)/$(UNIX_WINEDIR_x64)/mtld3d.so.dSYM)
 	cp -c $(OUT_unix_arm64)/mtld3d.so $(STAGE_DIR)/$(UNIX_WINEDIR_arm64)/
 	$(call clone_tree,$(OUT_unix_arm64)/mtld3d.so.dSYM,$(STAGE_DIR)/$(UNIX_WINEDIR_arm64)/mtld3d.so.dSYM)
-	cp -c $(call E2E_EXES,$(PE_i386)) $(STAGE_DIR)/tests/i686/
-	cp -c $(call E2E_EXES,$(PE_x64)) $(STAGE_DIR)/tests/x86_64/
+	$(call E2E_EXES_ASSIGN,$(call E2E_EXES,$(PE_i386))); cp -c $$exes $(STAGE_DIR)/tests/i686/
+	$(call E2E_EXES_ASSIGN,$(call E2E_EXES,$(PE_x64))); cp -c $$exes $(STAGE_DIR)/tests/x86_64/
 	cd unix && cargo +$(RUST_STABLE) build --profile $(PROFILE) -p mtld3d-e2e --target $(UNIX_TARGET_x64)
 	cd unix && cargo +$(RUST_STABLE) build --profile $(PROFILE) -p mtld3d-e2e --target $(UNIX_TARGET_arm64)
 	cp -c unix/target/$(UNIX_TARGET_x64)/$(PROFILE)/mtld3d-e2e $(STAGE_DIR)/e2e/x86_64/
@@ -798,11 +798,24 @@ E2E_FLAGS := --jobs $(JOBS) --timeout $(TIMEOUT) $(if $(filter 0,$(FAIL_FAST))$(
 
 # The test binaries of one PE arch, from cargo's own account of what it built:
 # `cargo test --no-run` prints one JSON message per artifact, and the test
-# targets are the only ones with an executable. A glob over `deps/` would also
-# pick up the stale hashes of earlier builds. Expanded inside a recipe, where
-# the `$$(...)` is the shell's. From a stage the binaries are the staged ones.
+# targets are the only ones with an executable. The JSON is held until Cargo
+# succeeds, so a partial artifact list from a failed build never reaches a
+# consumer. A glob over `deps/` would also pick up the stale hashes of earlier
+# builds. Expanded inside a recipe, where the `$$(...)` is the shell's. From a
+# stage the binaries are the staged ones.
+define E2E_EXES_BUILD
+cd windows && cargo +$(RUST_STABLE) test --no-run -p mtld3d-tests --target $(1) --message-format=json-render-diagnostics
+endef
 define E2E_EXES
-$$(cd windows && cargo +$(RUST_STABLE) test --no-run -p mtld3d-tests --target $(1) --message-format=json-render-diagnostics | sed -n 's/^.*"executable":"\([^"]*\.exe\)".*/\1/p')
+$$(output=$$(mktemp "$${TMPDIR:-/tmp}/mtld3d-e2e-exes.XXXXXX") || exit; \
+	$(call E2E_EXES_BUILD,$(1)) > "$$output"; result_code=$$?; \
+	if [ "$$result_code" -eq 0 ]; then \
+		sed -n 's/^.*"executable":"\([^"]*\.exe\)".*/\1/p' "$$output"; result_code=$$?; \
+	fi; \
+	rm -f "$$output"; exit "$$result_code")
+endef
+define E2E_EXES_ASSIGN
+exes="$(1)" || exit $$?
 endef
 E2E_EXES_i686   = $(if $(STAGE),$(STAGE)/tests/i686/*.exe,$(call E2E_EXES,$(PE_i386)))
 E2E_EXES_x86_64 = $(if $(STAGE),$(STAGE)/tests/x86_64/*.exe,$(call E2E_EXES,$(PE_x64)))
@@ -815,12 +828,12 @@ E2E_RUNNER     := $(if $(STAGE),$(STAGE)/e2e/$(HOST_ARCH)/mtld3d-e2e,cargo +$(RU
 
 test-e2e-i686: install-windows-i686 install-unix-$(SDK_UNIX_ARCH)
 	$(MAKE) configure-test-prefix
-	exes="$(E2E_EXES_i686)"; cd $(E2E_RUNNER_DIR) && $(MTLD3D_TEST_ENV) \
+	$(call E2E_EXES_ASSIGN,$(E2E_EXES_i686)); cd $(E2E_RUNNER_DIR) && $(MTLD3D_TEST_ENV) \
 		$(E2E_RUNNER) --wine $(WINE) $(E2E_FLAGS) -- $$exes
 
 test-e2e-x86_64: install-windows-x86_64 install-unix-$(SDK_UNIX_ARCH)
 	$(MAKE) configure-test-prefix
-	exes="$(E2E_EXES_x86_64)"; cd $(E2E_RUNNER_DIR) && $(MTLD3D_TEST_ENV) \
+	$(call E2E_EXES_ASSIGN,$(E2E_EXES_x86_64)); cd $(E2E_RUNNER_DIR) && $(MTLD3D_TEST_ENV) \
 		$(E2E_RUNNER) --wine $(WINE) $(E2E_FLAGS) -- $$exes
 
 # d3d9 conformance (NOT part of `make test`): run Wine's upstream d3d9 test exe
@@ -972,6 +985,9 @@ audit:
 test-isolation:
 	python3 scripts/test-isolation.py
 
+test-e2e-discovery:
+	python3 scripts/test-e2e-discovery.py
+
 # rustdoc's own lints, which no other target sees: broken and private intra-doc
 # links, malformed HTML in doc comments. `audit` gates the *shape* of a doc block
 # and clippy gates its prose; only rustdoc knows whether its links resolve.
@@ -988,15 +1004,16 @@ doc-unix:
 	cd unix && cargo +$(RUST_STABLE) doc --no-deps $(DENY_WARNINGS)
 
 # One command to run before every commit: formatting, the full clippy sweep, the
-# conventions audit, the Makefile isolation regression, and the doc build.
-# fmt-check first (fast, fails early on drift); clippy reuses the target above;
-# audit and test-isolation are fast; doc stays last. Each leg is also its own
-# target, so CI runs them as parallel jobs instead of this sequence.
+# conventions audit, the Makefile regressions, and the doc build. fmt-check first
+# (fast, fails early on drift); clippy reuses the target above; audit and the
+# Makefile regressions are fast; doc stays last. Each leg is also its own target,
+# so CI runs them as parallel jobs instead of this sequence.
 check:
 	$(MAKE) fmt-check
 	$(MAKE) clippy
 	$(MAKE) audit
 	$(MAKE) test-isolation
+	$(MAKE) test-e2e-discovery
 	$(MAKE) doc
 
 clean:

--- a/scripts/test-e2e-discovery.py
+++ b/scripts/test-e2e-discovery.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Check that failed e2e executable discovery stops every consumer."""
+
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import tempfile
+import unittest
+
+
+MAKEFILE = Path(__file__).resolve().parent.parent / "Makefile"
+PE_TARGETS = {
+    "i686": "i686-pc-windows-msvc",
+    "x86_64": "x86_64-pc-windows-msvc",
+}
+
+
+class E2eDiscoveryTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="mtld3d-e2e-discovery-")
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name).resolve()
+        self.wine_sdk = self.root / "wine-sdk"
+        self.wine_sdk.mkdir()
+        self.test_exes = {
+            arch: self.root / f"{target}.exe" for arch, target in PE_TARGETS.items()
+        }
+        for test_exe in self.test_exes.values():
+            test_exe.touch()
+        self.fake_build = self.root / "fake-build"
+        self.fake_build.write_text(
+            "#!/bin/sh\n"
+            "target=$1\n"
+            "previous=\n"
+            "for argument in \"$@\"; do\n"
+            "    if [ \"$previous\" = --target ]; then target=$argument; break; fi\n"
+            "    previous=$argument\n"
+            "done\n"
+            f"printf '{{\"reason\":\"compiler-artifact\",\"executable\":\"%s/%s.exe\"}}\\n' "
+            f"{shlex.quote(str(self.root))} \"$target\"\n"
+            "[ \"$target\" != \"$FAIL_TARGET\" ] || exit 23\n"
+        )
+        self.fake_build.chmod(0o755)
+        (self.root / "cargo").symlink_to(self.fake_build)
+        self.environment = os.environ.copy()
+        for name in ("MAKEFLAGS", "MFLAGS", "GNUMAKEFLAGS", "MAKEOVERRIDES", "MAKELEVEL"):
+            self.environment.pop(name, None)
+        self.environment["PATH"] = f"{self.root}{os.pathsep}{self.environment['PATH']}"
+
+    def run_make(self, *arguments, fail_target):
+        environment = self.environment.copy()
+        environment["FAIL_TARGET"] = fail_target
+        result = subprocess.run(
+            [
+                "make",
+                "--no-print-directory",
+                "-f",
+                str(MAKEFILE),
+                f"WINE_SDK={self.wine_sdk}",
+                "BUILD_ID=e2e-discovery-test",
+                f"E2E_EXES_BUILD={self.fake_build} $(1)",
+                *arguments,
+            ],
+            cwd=MAKEFILE.parent,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=30,
+        )
+        return result
+
+    def assert_discovery_failed(self, result):
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("Error 23", result.stdout)
+
+    def test_partial_output_does_not_reach_either_runner(self):
+        for arch, target in PE_TARGETS.items():
+            with self.subTest(arch=arch):
+                runner_marker = self.root / f"runner-{arch}-ran"
+                runner = self.root / f"runner-{arch}"
+                runner.write_text(f"#!/bin/sh\ntouch {shlex.quote(str(runner_marker))}\n")
+                runner.chmod(0o755)
+                result = self.run_make(
+                    "-o",
+                    f"install-windows-{arch}",
+                    "-o",
+                    "install-unix-x64",
+                    "MAKE=true",
+                    "SDK_UNIX_ARCH=x64",
+                    f"E2E_RUNNER={runner}",
+                    "E2E_RUNNER_DIR=.",
+                    f"test-e2e-{arch}",
+                    fail_target=target,
+                )
+                self.assertFalse(runner_marker.exists(), result.stdout)
+                self.assert_discovery_failed(result)
+
+    def test_partial_output_is_not_staged(self):
+        outputs = self.root / "outputs"
+        out_i386 = outputs / "i386"
+        out_x64 = outputs / "x86_64"
+        out_unix_x64 = outputs / "unix-x64"
+        out_unix_arm64 = outputs / "unix-arm64"
+        for directory in (out_i386, out_x64, out_unix_x64, out_unix_arm64):
+            directory.mkdir(parents=True)
+        for directory in (out_i386, out_x64):
+            for name in ("mtld3d.dll", "mtld3d.pdb", "mtld3d.fake.dll", "d3d9.dll", "d3d9.pdb"):
+                (directory / name).touch()
+        for directory in (out_unix_x64, out_unix_arm64):
+            (directory / "mtld3d.so").touch()
+            (directory / "mtld3d.so.dSYM").mkdir()
+        for failed_arch, failed_target in PE_TARGETS.items():
+            with self.subTest(failed_arch=failed_arch):
+                stage_dir = self.root / f"stage-{failed_arch}"
+                result = self.run_make(
+                    "-o",
+                    "all",
+                    f"OUT_i386={out_i386}",
+                    f"OUT_x64={out_x64}",
+                    f"OUT_unix_x64={out_unix_x64}",
+                    f"OUT_unix_arm64={out_unix_arm64}",
+                    f"STAGE_DIR={stage_dir}",
+                    f"STAGE_OUT={self.root / f'stage-{failed_arch}.tar'}",
+                    "stage",
+                    fail_target=failed_target,
+                )
+                for arch, test_exe in self.test_exes.items():
+                    staged = stage_dir / f"tests/{arch}" / test_exe.name
+                    if arch == "i686" and failed_arch == "x86_64":
+                        self.assertTrue(staged.exists())
+                    else:
+                        self.assertFalse(staged.exists(), result.stdout)
+                self.assert_discovery_failed(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A failed e2e compilation could still invoke the runner with a partial executable list or copy that partial list into the CI stage. A filtered run could then report zero tests and exit successfully, while an unfiltered run could omit the main e2e binary and pass the remaining binaries.

Executable discovery piped Cargo's JSON into `sed`, so the command substitution returned `sed`'s successful status after Cargo failed. The surrounding assignment and staging copy did not check discovery separately, which let both consumers continue.

Discovery now buffers Cargo's JSON, emits executable paths only after Cargo succeeds, and returns Cargo's original failure status. A shared checked assignment stops both runner recipes and both staging copies before they consume a failed discovery. The regression invokes the production Makefile recipes with a fake Cargo that emits one executable and exits 23. It covers both PE runner targets, a first-architecture staging failure, and an x86_64 staging failure after i686 succeeds. CI runs the regression as its own check-job step.

Using `set -o pipefail` around the existing pipeline was considered, but the Makefile recipes run under `/bin/sh` and cannot assume that non-POSIX option. Buffering also prevents partial executable paths from reaching a consumer, independent of pipeline behavior.

Verification after rebasing: `make fmt`; `make check`; `make test-isolation`; `make test-e2e-discovery`. The same discovery regression against the pre-fix Makefile executed both runners and staged each failed architecture's partial executable. In worker runtime verification before the final rebase, `make ISOLATED=1 test` passed every then-current i686 test in four processes. Its x86_64 leg discovered all four executables, then reproduced #476: `CreateIconIndirect` returned null for the 64x64 scaled cursor with `GetLastError=0x578`, and `SetCursorProperties` returned `D3DERR_INVALIDCALL` for the 32x32 scratch source inside `device::concurrent_retargets_deliver_every_window_message_to_its_own_device`. This was the cursor setup assertion, not #529's minimum fullscreen-trip assertion. A complete unchanged x86_64 rerun passed every then-current test in four processes, including that test. Final verification on the rebased candidate also passed `make check` and the full `make ISOLATED=1 test`, including both PE architectures and all four executable discoveries per architecture.

Conformance was not run because this changes Makefile failure propagation and its regression only. It does not change render, state, shader, shared-crate, or runtime behavior.

Rules check: this is one build-harness change with a before-and-after regression as required by `CONTRIBUTING.md`. It introduces no statics, config keys, wire fields, dependencies, derives, lint suppressions, ABI duplication, or runtime fallback under `docs/CONVENTIONS.md`. It does not change the PE/Unix boundary, threading, object lifetime, Metal behavior, or any other contract in `docs/ARCHITECTURE.md`.

Closes #525
