### PR TITLE
Distinguish skipped occlusion assertions from stale conformance pins

### DIFF
--- a/unix/conformance/CONFORMANCE.md
+++ b/unix/conformance/CONFORMANCE.md
@@ -144,6 +144,15 @@ regression can hide in. The fix for a stale baseline is `make
 conformance-baseline` plus the matching triage edit here, not a code hunt. The
 `flaky` and `ceiling` classes are the two tolerances (see below).
 
+A recognized upstream skip is an absent measurement, not a passing assertion.
+The runner retains the skip line separately from failures and reports the
+bypassed assertion as `SKIPPED`, without requiring a re-record. This applies
+only to the reviewed source location and message below, in a completed
+subtest with no failure at the affected assertion. Other missing failures
+still gate as stale, and crashes and counts above the pin still gate.
+Baseline recording retains an explicitly skipped assertion's prior count and
+reports that retention; it never invents a count when no prior pin exists.
+
 Metal validation is the third verdict, and it is independent of the counts: a
 leg that logged any `metal-validation:` line exits non-zero even when every
 site holds its pin, because API misuse is invisible to a pass/fail count. A
@@ -702,6 +711,16 @@ overdraw layers would need an encoder per draw under active queries,
 destroying pass batching; the kept optimization is single-encoder pass
 batching, so this is `expected`. Real-game occlusion (a bounding box tested
 against a populated depth buffer, read as zero/non-zero) is unaffected.
+
+Wine first times 1,000 query BEGIN/END pairs. If that loop takes more than
+70 ms, device.c:6706 prints `Tests skipped: Test loop took too long (...)`,
+ending with `skipping large query tests.`, and jumps to cleanup before 6780.
+An Intel CI run measured 100 ms and took that branch. The scanner recognizes
+that exact site and message shape, including the elapsed time above 70 ms,
+as evidence that 6780 did not run. The mapping must be reviewed with the
+baseline's source locations when Wine changes. The classification remains
+`expected` and its count stays pinned at one: `ceiling` would also tolerate
+an assertion that ran and passed, which this observation does not establish.
 
 ### device.c/test_lockrect_invalid
 Sites: 8664=expected 8682=expected 8701=expected

--- a/unix/conformance/src/diff.rs
+++ b/unix/conformance/src/diff.rs
@@ -72,6 +72,12 @@ pub fn diff(
                 let in_baseline = base.is_some_and(|b| b.sites.contains_key(site));
                 let bc = base.and_then(|b| b.sites.get(site)).copied().unwrap_or(0);
                 let cc = cur.sites.get(site).copied().unwrap_or(0);
+                if let Some(reason) = cur.skipped_reason(site) {
+                    details.push(format!(
+                        "  {site}  SKIPPED (baseline count {bc} retained): {reason}"
+                    ));
+                    continue;
+                }
                 // A site a human pinned `flaky` fails non-deterministically on the
                 // identical binary; its count is not load-bearing, so a delta in
                 // *either* direction is a tolerated flutter, not a verdict — it

--- a/unix/conformance/src/diff/tests.rs
+++ b/unix/conformance/src/diff/tests.rs
@@ -15,6 +15,9 @@ use crate::{
     triage::DocSite,
 };
 
+const OCCLUSION_SKIP: &str = "device.c:6706: Tests skipped: Test loop took too long (100 ms), skipping large query tests.\r\n";
+const DEVICE_SUMMARY: &str = "00dc:device: 58913 tests executed (75 marked as todo, 0 as flaky, 786 failures), 21 skipped.\r\n";
+
 fn key() -> (Leg, Subtest) {
     (
         Leg {
@@ -239,4 +242,95 @@ fn baseline_site_without_a_class_entry_is_flagged_untriaged() {
     let report = diff(&base, &classes, &cur);
     assert!(!report.regressed);
     assert!(report.text.contains("untriaged"), "{}", report.text);
+}
+
+#[test]
+fn observed_occlusion_skip_is_not_a_passing_assertion() {
+    let base = baseline_with(&[(6780, 1)], false);
+    let classes = classes_with(&[(6780, Classification::Expected)]);
+    let output = format!("{OCCLUSION_SKIP}{DEVICE_SUMMARY}");
+    let cur = BTreeMap::from([(key(), crate::scan::parse_subtest_output(&output, false))]);
+    let report = diff(&base, &classes, &cur);
+    assert!(!report.regressed, "{}", report.text);
+    assert!(!report.stale, "{}", report.text);
+    assert!(
+        report.text.contains("device.c:6780  SKIPPED"),
+        "{}",
+        report.text
+    );
+    assert!(
+        report.text.contains(OCCLUSION_SKIP.trim()),
+        "{}",
+        report.text
+    );
+
+    let passed = BTreeMap::from([(
+        key(),
+        crate::scan::parse_subtest_output(DEVICE_SUMMARY, false),
+    )]);
+    assert!(diff(&base, &classes, &passed).stale);
+}
+
+#[test]
+fn occlusion_skip_requires_the_reviewed_site_and_message() {
+    let base = baseline_with(&[(6780, 1)], false);
+    let classes = classes_with(&[(6780, Classification::Expected)]);
+    for skip in [
+        OCCLUSION_SKIP.replace("6706", "6707"),
+        OCCLUSION_SKIP.replace("device.c", "visual.c"),
+        OCCLUSION_SKIP.replace("large query tests", "other tests"),
+        OCCLUSION_SKIP.replace("100 ms", "70 ms"),
+        OCCLUSION_SKIP.replace("100 ms", "unknown ms"),
+        OCCLUSION_SKIP.replace("Tests skipped", "Test marked todo"),
+    ] {
+        let output = format!("{skip}{DEVICE_SUMMARY}");
+        let cur = BTreeMap::from([(key(), crate::scan::parse_subtest_output(&output, false))]);
+        let report = diff(&base, &classes, &cur);
+        assert!(report.stale, "{output}\n{}", report.text);
+        assert!(!report.text.contains("SKIPPED"), "{}", report.text);
+    }
+}
+
+#[test]
+fn occlusion_skip_does_not_excuse_other_missing_or_failing_sites() {
+    let base = baseline_with(&[(6780, 1), (5975, 1)], false);
+    let classes = classes_with(&[
+        (6780, Classification::Expected),
+        (5975, Classification::Expected),
+    ]);
+    let output = format!("{OCCLUSION_SKIP}{DEVICE_SUMMARY}");
+    let cur = BTreeMap::from([(key(), crate::scan::parse_subtest_output(&output, false))]);
+    let report = diff(&base, &classes, &cur);
+    assert!(report.stale, "{}", report.text);
+    assert!(
+        report
+            .text
+            .contains("device.c:5975  1 -> 0  STALE BASELINE")
+    );
+
+    let output = format!(
+        "{output}device.c:5975: Test failed: Got unexpected result.\n\
+        device.c:6780: Test failed: Got unexpected query result.\n\
+        device.c:6780: Test failed: Got unexpected query result.\n"
+    );
+    let cur = BTreeMap::from([(key(), crate::scan::parse_subtest_output(&output, false))]);
+    let report = diff(&base, &classes, &cur);
+    assert!(report.regressed, "{}", report.text);
+    assert!(!report.text.contains("SKIPPED"), "{}", report.text);
+}
+
+#[test]
+fn occlusion_skip_does_not_hide_a_truncated_or_signaled_subtest() {
+    let base = baseline_with(&[(6780, 1)], false);
+    let classes = classes_with(&[(6780, Classification::Expected)]);
+    for (output, signaled) in [
+        (OCCLUSION_SKIP.to_owned(), false),
+        (format!("{OCCLUSION_SKIP}{DEVICE_SUMMARY}"), true),
+    ] {
+        let cur = BTreeMap::from([(key(), crate::scan::parse_subtest_output(&output, signaled))]);
+        let report = diff(&base, &classes, &cur);
+        assert!(report.regressed, "{}", report.text);
+        assert!(report.stale, "{}", report.text);
+        assert!(!report.text.contains("SKIPPED"), "{}", report.text);
+    }
 }

--- a/unix/conformance/src/main.rs
+++ b/unix/conformance/src/main.rs
@@ -129,6 +129,9 @@ fn real_main() -> Result<ExitCode, String> {
         for site in &summary.new_sites {
             println!("  new: {site} - add to its CONFORMANCE.md cluster with a rationale");
         }
+        for site in &summary.skipped_sites {
+            println!("  skipped: {site} - kept prior count; assertion not run");
+        }
         for site in &summary.dropped_sites {
             let cluster = classes
                 .get(site)

--- a/unix/conformance/src/merge.rs
+++ b/unix/conformance/src/merge.rs
@@ -28,6 +28,8 @@ pub struct MergeSummary {
     /// Each of these still has a CONFORMANCE.md cluster entry that must be
     /// removed for `make test` to go green again.
     pub dropped_sites: Vec<Site>,
+    /// Skipped assertions whose prior counts were retained without a new measurement.
+    pub skipped_sites: Vec<Site>,
 }
 
 /// Build a new baseline from `fresh` results for `leg`.
@@ -62,6 +64,7 @@ pub fn merge(
     let mut summary = MergeSummary::default();
     for (&key, result) in fresh {
         let prior_sub = prior.entries.get(&key);
+        let mut sites = result.sites.clone();
         for site in result.sites.keys() {
             if prior_sub.is_some_and(|sub| sub.sites.contains_key(site)) {
                 summary.carried += 1;
@@ -70,10 +73,16 @@ pub fn merge(
             }
         }
         if let Some(sub) = prior_sub {
+            for (site, &count) in &sub.sites {
+                if result.skipped_reason(site).is_some() {
+                    sites.insert(site.clone(), count);
+                    summary.skipped_sites.push(site.clone());
+                }
+            }
             summary.dropped_sites.extend(
                 sub.sites
                     .keys()
-                    .filter(|site| !result.sites.contains_key(*site))
+                    .filter(|site| !sites.contains_key(*site))
                     .cloned(),
             );
         }
@@ -81,12 +90,13 @@ pub fn merge(
             key,
             SubtestBaseline {
                 crash: result.crash,
-                sites: result.sites.clone(),
+                sites,
             },
         );
     }
     summary.new_sites.dedup();
     summary.dropped_sites.dedup();
+    summary.skipped_sites.dedup();
     (next, summary)
 }
 

--- a/unix/conformance/src/merge/tests.rs
+++ b/unix/conformance/src/merge/tests.rs
@@ -106,3 +106,42 @@ fn a_single_leg_update_keeps_the_other_legs() {
     assert!(summary.new_sites.is_empty());
     assert!(summary.dropped_sites.is_empty());
 }
+
+#[test]
+fn an_observed_skip_keeps_the_prior_pin_without_inventing_a_failure() {
+    let key = (I686, Subtest::Device);
+    let mut prior = Baseline::default();
+    prior.entries.insert(
+        key,
+        SubtestBaseline {
+            crash: false,
+            sites: BTreeMap::from([(site(6780), 1), (site(5975), 2)]),
+        },
+    );
+    let output = "device.c:6706: Tests skipped: Test loop took too long (100 ms), skipping large query tests.\n\
+        device: 58913 tests executed (75 marked as todo, 0 as flaky, 786 failures), 21 skipped.\n";
+    let result = crate::scan::parse_subtest_output(output, false);
+    assert!(result.sites.is_empty(), "a skip is not a measured failure");
+    let fresh = BTreeMap::from([(key, result)]);
+    let (next, summary) = merge(&prior, I686, &fresh, "new".to_owned());
+    assert_eq!(next.entries[&key].sites, BTreeMap::from([(site(6780), 1)]));
+    assert_eq!(summary.skipped_sites, vec![site(6780)]);
+    assert_eq!(summary.carried, 0, "no failures were measured");
+    assert_eq!(summary.dropped_sites, vec![site(5975)]);
+
+    let (new, summary) = merge(&Baseline::default(), I686, &fresh, "new".to_owned());
+    assert!(new.entries[&key].sites.is_empty(), "no pin to retain");
+    assert!(summary.skipped_sites.is_empty());
+
+    let output = format!(
+        "{output}device.c:6780: Test failed: Got unexpected query result.\n\
+        device.c:6780: Test failed: Got unexpected query result.\n"
+    );
+    let fresh = BTreeMap::from([(key, crate::scan::parse_subtest_output(&output, false))]);
+    let (next, summary) = merge(&prior, I686, &fresh, "new".to_owned());
+    assert_eq!(next.entries[&key].sites[&site(6780)], 2);
+    assert!(
+        summary.skipped_sites.is_empty(),
+        "observed failures take precedence"
+    );
+}

--- a/unix/conformance/src/model.rs
+++ b/unix/conformance/src/model.rs
@@ -140,6 +140,22 @@ pub struct SubtestResult {
     /// `flaky_marked`, kept out of `sites` and non-gating; recorded only for
     /// report visibility.
     pub todo_marked: BTreeMap<Site, u32>,
+    /// Assertions bypassed by a recognized upstream skip, with the full skip line as evidence.
+    pub skipped: BTreeMap<Site, String>,
+}
+
+impl SubtestResult {
+    /// Evidence that an absent assertion was skipped in a completed subtest.
+    ///
+    /// A crash cannot excuse a missing failure, and an observed failure takes
+    /// precedence over a skip marker in the same output.
+    #[must_use]
+    pub fn skipped_reason(&self, site: &Site) -> Option<&str> {
+        if self.crash || self.sites.contains_key(site) {
+            return None;
+        }
+        self.skipped.get(site).map(String::as_str)
+    }
 }
 
 impl Variant {

--- a/unix/conformance/src/scan.rs
+++ b/unix/conformance/src/scan.rs
@@ -74,6 +74,7 @@ pub fn parse_subtest_output(output: &str, signaled: bool) -> SubtestResult {
     let mut sites: BTreeMap<Site, u32> = BTreeMap::new();
     let mut flaky_marked: BTreeMap<Site, u32> = BTreeMap::new();
     let mut todo_marked: BTreeMap<Site, u32> = BTreeMap::new();
+    let mut skipped = BTreeMap::new();
     let mut crash = signaled || !output.contains(SUMMARY_MARKER);
     let mut panic: Option<String> = None;
     // The Rust panic message sits on the line *after* the `panicked at` header
@@ -107,6 +108,10 @@ pub fn parse_subtest_output(output: &str, signaled: bool) -> SubtestResult {
                 .or_insert(0) += 1;
             continue;
         }
+        if let Some(site) = skipped_assertion(line) {
+            skipped.insert(site, line.to_owned());
+            continue;
+        }
         if let Some(idx) = line.find(PANIC_MARKER) {
             crash = true;
             if panic.is_none() {
@@ -126,7 +131,26 @@ pub fn parse_subtest_output(output: &str, signaled: bool) -> SubtestResult {
         panic,
         flaky_marked,
         todo_marked,
+        skipped,
     }
+}
+
+/// Map the reviewed timing skip to the assertion it bypasses.
+///
+/// `test_occlusion_query` jumps from device.c:6706 to cleanup before 6780.
+/// Match both the source location and complete message shape so unrelated
+/// skips and upstream source drift cannot excuse an absent failure.
+fn skipped_assertion(line: &str) -> Option<Site> {
+    let elapsed = line
+        .strip_prefix("device.c:6706: Tests skipped: Test loop took too long (")?
+        .strip_suffix(" ms), skipping large query tests.")?;
+    if !elapsed.parse::<u32>().is_ok_and(|ms| ms > 70) {
+        return None;
+    }
+    Some(Site {
+        file: "device.c".to_owned(),
+        line: 6780,
+    })
 }
 
 /// Recover `<file>.c:<line>` from the text preceding [`FAILURE_MARKER`].


### PR DESCRIPTION
The conformance gate reports `device.c:6780 1 -> 0 STALE BASELINE (site gone)` when Wine's timing precheck skips the large occlusion-query tests. The archived Intel run took 100 ms, printed the skip at device.c:6706, and reached its summary without executing 6780.

Keep that skip line as separate evidence and report 6780 as `SKIPPED` only when the recognized source location and message are present, the subtest completed, and the assertion has no observed failure. A zero without that evidence still gates as stale; a count above the pin still regresses. Baseline recording retains the previous count for the skipped assertion and reports that retention. The baseline count and `expected` classification remain unchanged. A `ceiling` classification was considered but would also tolerate an assertion that ran and passed, which the observed skip does not establish.

Verification: the host regression failed before the change with the reported stale-baseline line and passed afterwards. All 66 conformance runner tests pass, including wrong-site/message controls, absent evidence, unrelated missing sites, count increases, crashes, and baseline update retention. Replaying the complete archived Intel device output through the runner against its original baseline counts exits 0 and reports the skip evidence. `make fmt` and full `make check` pass. `make ISOLATED=1 test` passes both host workspaces and the full suite on each PE architecture. Its exact exit status is 0.

Rules check: CONTRIBUTING.md's single-issue scope and host regression placement are followed. docs/CONVENTIONS.md's formatting, Clippy, audit and documentation gates pass. No static, config key, environment variable, wire field, dependency, derive, unsafe block, lint suppression, or duplicated parser is introduced. docs/ARCHITECTURE.md's boundary and threading contracts are unchanged. Conformance is not required by source scope because this changes only the host runner and its documentation, with no render, state, shader or shared-crate changes. The archived replay verifies gate handling, not a new GPU result.

Closes #524
