### PR TITLE
Stop e2e runs after reported GPU hangs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,13 @@ config, `docs/ARCHITECTURE.md` says how), so a kept `.stderr` that carries a
 AppKit call the layer made off the main thread and the thread that made it;
 that call is the failure, whatever the process printed after it.
 
+An explicit driver GPU-hang report ends the leg with exit code 3 and no
+verdict, even under `FAIL_FAST=0` or when the process itself exits cleanly.
+The runner watches stderr while the process runs, checks the layer log before
+it can launch another process, and keeps both accounts of the initiating
+process. Assertions after that report are not measurements of the source: the
+later results may reflect the hosted GPU's failed state.
+
 In CI every end-to-end leg uploads all three kinds of file as its
 `e2e-logs-<image>-<arch>` artifact on every run, kept fourteen days; the
 directory holds the ten newest of each, so a leg that restarted more than ten

--- a/unix/e2e/src/attribute.rs
+++ b/unix/e2e/src/attribute.rs
@@ -33,6 +33,8 @@
 //! ended unaccounted for quotes both, and the runner moves that log out of
 //! the layer's retention (the newest ten logs, which the runs that follow
 //! soon exceed) so the account is still there when someone reads the note.
+//! A driver GPU-hang report in either account ends the leg before attribution
+//! can launch another process, and both accounts are kept immediately.
 //!
 //! One kind of test ends its process on purpose: it declares its name and
 //! the code it is about to exit with on stdout (see [`declared_exit`]), and
@@ -71,6 +73,8 @@ pub struct ProcessEnd {
     pub kind: ExitKind,
     pub stdout: String,
     pub stderr: String,
+    /// The process or its layer log reported a GPU hang.
+    pub gpu_hang: bool,
 }
 
 /// Runs the processes of one test binary.
@@ -139,10 +143,19 @@ pub struct TestResult {
     pub verdict: Verdict,
 }
 
+/// Why a binary's measurement ended.
+#[derive(Debug, PartialEq, Eq)]
+pub enum BinaryOutcome {
+    Complete,
+    /// The driver reported a GPU hang, so the leg has no verdict.
+    GpuHang,
+}
+
 /// What running a binary cost and whether anything in it failed.
 pub struct BinaryRun {
     pub processes: u32,
     pub failed: bool,
+    pub outcome: BinaryOutcome,
 }
 
 /// Where the results and the notes about a binary's processes go.
@@ -187,6 +200,7 @@ pub fn run_binary(
     let mut run = BinaryRun {
         processes: 0,
         failed: false,
+        outcome: BinaryOutcome::Complete,
     };
     // The inner loop runs one binary's rounds; leaving it means the rounds
     // are done, and the outer one picks up whatever a narrowed round set
@@ -210,6 +224,17 @@ pub fn run_binary(
                 }
                 Event::Summary(summary) => round.summary = Some(summary),
             })?;
+            if end.gpu_hang {
+                let kept = kept_stderr(launcher.keep_stderr(end.pid, &end.stderr));
+                report.note(&format!(
+                    "the driver reported a GPU hang; the leg stopped at this process and has no \
+                     verdict\n{kept}; its last lines:\n{}\n{}",
+                    stderr_tail(&end.stderr),
+                    kept_layer_log(launcher.keep_layer_log(end.pid))
+                ));
+                run.outcome = BinaryOutcome::GpuHang;
+                return Ok(run);
+            }
             let ran_something = !round.finished.is_empty();
             let reported = u32::try_from(round.finished.len()).unwrap_or(u32::MAX);
             let before = done.len();

--- a/unix/e2e/src/attribute/tests.rs
+++ b/unix/e2e/src/attribute/tests.rs
@@ -104,6 +104,8 @@ impl Launcher for Scripted {
             pid: PID,
             kind: script.kind,
             stdout: script.stdout.to_owned(),
+            gpu_hang: crate::run::is_gpu_hang_report(&script.stderr)
+                || script.layer.is_some_and(crate::run::is_gpu_hang_report),
             stderr: script.stderr,
         })
     }

--- a/unix/e2e/src/binary.rs
+++ b/unix/e2e/src/binary.rs
@@ -127,11 +127,13 @@ impl Launcher for WineLauncher {
                 on_event(event);
             }
         })?;
+        let layer_gpu_hang = self.layer_reported_gpu_hang(exit.pid)?;
         Ok(ProcessEnd {
             pid: exit.pid,
             kind: exit.kind,
             stdout,
             stderr: exit.stderr,
+            gpu_hang: exit.gpu_hang || layer_gpu_hang,
         })
     }
 
@@ -170,12 +172,43 @@ impl Launcher for WineLauncher {
         // The layer names the file after the executable's whole stem, cargo
         // hash and all, and after the host pid, which is the one the runner
         // spawned the process under.
-        let stem = self
-            .exe
+        let stem = self.exe_stem();
+        keep_layer_log(&self.log_dir, stem, &binary_name(&self.exe), pid)
+    }
+}
+
+impl WineLauncher {
+    /// The executable stem the layer uses in its per-process log name.
+    fn exe_stem(&self) -> &str {
+        self.exe
             .file_stem()
             .and_then(|stem| stem.to_str())
-            .unwrap_or_default();
-        keep_layer_log(&self.log_dir, stem, &binary_name(&self.exe), pid)
+            .unwrap_or_default()
+    }
+
+    /// The layer's live log path for `pid`, before the runner preserves it.
+    fn layer_log_path(&self, pid: u32) -> PathBuf {
+        self.log_dir.join(mtld3d_shared::log_paths::log_file_name(
+            self.exe_stem(),
+            pid,
+        ))
+    }
+
+    /// Whether the layer's completed log reports a GPU hang.
+    ///
+    /// A process that never loaded mtld3d has no log. Any other read error
+    /// ends the runner rather than letting another process use a GPU whose
+    /// state could not be checked.
+    fn layer_reported_gpu_hang(&self, pid: u32) -> Result<bool, String> {
+        let path = self.layer_log_path(pid);
+        match fs::read_to_string(&path) {
+            Ok(text) => Ok(run::is_gpu_hang_report(&text)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(format!(
+                "could not read {} after process exit: {e}",
+                path.display()
+            )),
+        }
     }
 }
 

--- a/unix/e2e/src/binary/tests.rs
+++ b/unix/e2e/src/binary/tests.rs
@@ -9,7 +9,26 @@ use super::{
     FATAL_LINES, KEEP, LAYER_LOG_EXT, WineLauncher, binary_name, keep_layer_log, keep_stderr,
     layer_tail, stderr_tail,
 };
-use crate::attribute::Launcher as _;
+use crate::attribute::{BinaryOutcome, Launcher as _, Report, TestResult, run_binary};
+
+const DRIVER_HANG: &str = "Caused GPU Hang Error \
+    (00000003:kIOAccelCommandBufferCallbackErrorHang)";
+
+#[derive(Default)]
+struct Log {
+    results: Vec<TestResult>,
+    notes: Vec<String>,
+}
+
+impl Report for Log {
+    fn result(&mut self, result: TestResult) {
+        self.results.push(result);
+    }
+
+    fn note(&mut self, note: &str) {
+        self.notes.push(note.to_owned());
+    }
+}
 
 /// A fresh directory under the temp dir, named after the test using it.
 fn dir(tag: &str) -> PathBuf {
@@ -186,5 +205,66 @@ fn a_layer_log_that_cannot_be_moved_is_still_quoted_where_it_is() {
     assert!(
         kept.not_kept
             .is_some_and(|why| why.contains("e2e-7.layer-log"))
+    );
+}
+
+#[test]
+fn a_clean_processes_layer_hang_stops_relaunch_and_keeps_both_accounts() {
+    let log_dir = dir("gpu-hang");
+    let script = log_dir.join("e2e-abcdef.sh");
+    let launch_count = log_dir.join("launches");
+    let body = format!(
+        "printf x >> '{}'\n\
+         echo '[e2e] running a::one' >&2\n\
+         echo 'initiating stderr' >&2\n\
+         printf '%s\\n' '{DRIVER_HANG}' > \"{}/e2e-abcdef-$$.log\"\n\
+         exit 0\n",
+        launch_count.display(),
+        log_dir.display()
+    );
+    std::fs::write(&script, body).expect("script");
+    let mut launcher = WineLauncher::new(
+        Path::new("/bin/sh"),
+        &script,
+        Some(&log_dir),
+        Duration::from_secs(5),
+        Box::new(|_| {}),
+    );
+    let selection = Some(vec!["a::one".to_owned(), "a::two".to_owned()]);
+    let mut log = Log::default();
+    let run = run_binary(&mut launcher, selection, 1, false, &mut log).expect("run fake child");
+
+    assert_eq!(run.processes, 1);
+    assert_eq!(run.outcome, BinaryOutcome::GpuHang);
+    assert!(!run.failed);
+    assert!(log.results.is_empty(), "a hung GPU gives no test verdict");
+    assert_eq!(
+        std::fs::read_to_string(&launch_count).expect("launch count"),
+        "x"
+    );
+    let note = log.notes.first().expect("GPU hang note");
+    assert!(note.contains("GPU hang"), "{note}");
+    assert!(note.contains("has no verdict"), "{note}");
+
+    let kept: Vec<PathBuf> = std::fs::read_dir(&log_dir)
+        .expect("read log dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .collect();
+    let stderr = kept
+        .iter()
+        .find(|path| path.extension().is_some_and(|ext| ext == "stderr"))
+        .expect("kept stderr");
+    let layer = kept
+        .iter()
+        .find(|path| path.extension().is_some_and(|ext| ext == LAYER_LOG_EXT))
+        .expect("kept layer log");
+    assert_eq!(
+        std::fs::read_to_string(stderr).expect("stderr evidence"),
+        "[e2e] running a::one\ninitiating stderr\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(layer).expect("layer evidence"),
+        format!("{DRIVER_HANG}\n")
     );
 }

--- a/unix/e2e/src/main.rs
+++ b/unix/e2e/src/main.rs
@@ -7,7 +7,8 @@
 //! `MTLD3D_CONFIG` and the Wine variables.
 //!
 //! Exit code 0 when every selected test passed, 1 when any failed or was
-//! left unrun by a failure, 2 when the runner itself could not do its job.
+//! left unrun by a failure, 2 when the runner itself could not do its job,
+//! and 3 when a GPU hang stopped the leg without a verdict.
 
 mod attribute;
 mod binary;
@@ -20,11 +21,14 @@ mod select;
 use std::process::ExitCode;
 
 use crate::{
-    attribute::Launcher as _,
+    attribute::{BinaryOutcome, Launcher as _},
     binary::{WineLauncher, binary_name},
     report::{BinaryReport, Tally},
     select::{selected, test_id},
 };
+
+/// A leg stopped after the driver reported a GPU hang, with no test verdict.
+const GPU_HANG_EXIT: u8 = 3;
 
 fn main() -> ExitCode {
     match real_main() {
@@ -40,8 +44,13 @@ fn real_main() -> Result<ExitCode, String> {
     let config = cli::parse_args(std::env::args().skip(1))?;
     let mut tally = Tally::default();
     let mut stopped_at: Option<String> = None;
+    let mut gpu_hang_at: Option<String> = None;
     for exe in &config.exes {
         let name = binary_name(exe);
+        if gpu_hang_at.is_some() {
+            println!("SKIP {name}:: (not run after a GPU hang)");
+            continue;
+        }
         if stopped_at.is_some() {
             println!("SKIP {name}:: (not run after a failure)");
             continue;
@@ -77,9 +86,16 @@ fn real_main() -> Result<ExitCode, String> {
             },
         )?;
         tally.processes += run.processes;
-        if run.failed && config.fail_fast {
+        if run.outcome == BinaryOutcome::GpuHang {
+            gpu_hang_at = Some(name);
+        } else if run.failed && config.fail_fast {
             stopped_at = Some(name);
         }
+    }
+    if let Some(name) = gpu_hang_at {
+        tally.print_summary();
+        println!("e2e: GPU HANG in {name}; the leg was cut short and has no verdict");
+        return Ok(ExitCode::from(GPU_HANG_EXIT));
     }
     if tally.total() == 0 {
         if config.filter.is_empty() {

--- a/unix/e2e/src/run.rs
+++ b/unix/e2e/src/run.rs
@@ -5,8 +5,9 @@
 //! while they run, and because a process that stops reporting is the only
 //! sign of a hung test: the watchdog kills it once no line has arrived for
 //! the caller's timeout. stderr is collected as it arrives too, but handed
-//! back whole once the process has ended; it carries the panic reports and
-//! Wine's own diagnostics.
+//! back whole once the process has ended; it carries the panic reports,
+//! Wine's own diagnostics, and the driver report that stops a process as
+//! soon as it says the GPU hung.
 //!
 //! The same timeout bounds a process that closes stdout and then never
 //! exits: it is killed once the timeout passes with no exit. What comes
@@ -20,11 +21,15 @@
 //! whole run, which belongs to the caller's group.
 
 use std::{
-    io::{BufRead, BufReader, Read},
+    io::{BufRead, BufReader},
     os::unix::process::{CommandExt, ExitStatusExt},
     path::Path,
     process::{Child, Command, ExitStatus, Stdio},
-    sync::mpsc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
     thread,
     time::{Duration, Instant},
 };
@@ -62,7 +67,24 @@ pub struct Exit {
     pub pid: u32,
     pub kind: ExitKind,
     pub stderr: String,
+    /// The driver reported a GPU hang before this process ended.
+    pub gpu_hang: bool,
 }
+
+/// Whether output reports one of the driver's hung-GPU codes.
+pub fn is_gpu_hang_report(text: &str) -> bool {
+    GPU_HANG_MARKERS.iter().any(|marker| text.contains(marker))
+}
+
+/// The driver's codes for a hung GPU.
+///
+/// The conformance runner keeps the same two markers. The runners are
+/// separate binaries with no runner-support crate between them, while
+/// `mtld3d-shared` is the runtime's wire-format crate.
+const GPU_HANG_MARKERS: [&str; 2] = [
+    "kIOAccelCommandBufferCallbackErrorHang",
+    "kIOAccelCommandBufferCallbackErrorSubmissionsIgnored",
+];
 
 /// How often the bounded wait for the process's exit looks again.
 const EXIT_POLL: Duration = Duration::from_millis(20);
@@ -107,7 +129,7 @@ pub fn run(
 
     let pid = child.id();
     let stdout = child.stdout.take().ok_or("stdout not piped")?;
-    let mut stderr = child.stderr.take().ok_or("stderr not piped")?;
+    let stderr = child.stderr.take().ok_or("stderr not piped")?;
     let (lines, received) = mpsc::channel::<String>();
     // Neither reader is joined: each ends when its pipe does, and a pipe a
     // killed process tree held open ends with the kill.
@@ -120,36 +142,73 @@ pub fn run(
     });
     // stderr comes over in chunks so that what the process wrote before it
     // died is in hand the moment it is gone; the sender dropping is the EOF.
+    let gpu_hang = Arc::new(AtomicBool::new(false));
     let (stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>();
+    let stderr_gpu_hang = Arc::clone(&gpu_hang);
     thread::spawn(move || {
-        let mut chunk = [0u8; 4096];
-        while let Ok(n) = stderr.read(&mut chunk) {
-            if n == 0 || stderr_tx.send(chunk[..n].to_vec()).is_err() {
+        let mut reader = BufReader::new(stderr);
+        let mut line = Vec::new();
+        while let Ok(1..) = reader.read_until(b'\n', &mut line) {
+            if is_gpu_hang_report(&String::from_utf8_lossy(&line)) {
+                stderr_gpu_hang.store(true, Ordering::Relaxed);
+            }
+            if stderr_tx.send(std::mem::take(&mut line)).is_err() {
                 break;
             }
         }
     });
 
     let mut timed_out = false;
+    let mut reported_gpu_hang = false;
+    let mut last_line = Instant::now();
     loop {
-        match received.recv_timeout(timeout) {
-            Ok(line) => on_line(&line),
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                kill_group(&child);
-                timed_out = true;
-                break;
+        if gpu_hang.load(Ordering::Relaxed) {
+            kill_group(&child);
+            reported_gpu_hang = true;
+            break;
+        }
+        let since_line = last_line.elapsed();
+        if since_line >= timeout {
+            kill_group(&child);
+            timed_out = true;
+            break;
+        }
+        let until_timeout = timeout
+            .checked_sub(since_line)
+            .expect("elapsed time checked against the timeout");
+        match received.recv_timeout(EXIT_POLL.min(until_timeout)) {
+            Ok(line) => {
+                on_line(&line);
+                last_line = Instant::now();
             }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         }
     }
-    let (status, hung) = if let Some(status) = wait_bounded(&mut child, timeout) {
-        (status, false)
-    } else {
-        kill_group(&child);
+    let (status, hung) = if reported_gpu_hang {
         let status = child
             .wait()
-            .map_err(|e| format!("wait on {} failed: {e}", exe.display()))?;
-        (status, true)
+            .map_err(|e| format!("wait on {} after GPU hang failed: {e}", exe.display()))?;
+        (status, false)
+    } else {
+        match wait_bounded(&mut child, timeout, &gpu_hang) {
+            Wait::Exited(status) => (status, false),
+            Wait::GpuHang => {
+                kill_group(&child);
+                reported_gpu_hang = true;
+                let status = child
+                    .wait()
+                    .map_err(|e| format!("wait on {} after GPU hang failed: {e}", exe.display()))?;
+                (status, false)
+            }
+            Wait::TimedOut => {
+                kill_group(&child);
+                let status = child
+                    .wait()
+                    .map_err(|e| format!("wait on {} failed: {e}", exe.display()))?;
+                (status, true)
+            }
+        }
     };
     let mut stderr = drain_stderr(&stderr_rx, STDERR_GRACE);
     if !stderr.complete {
@@ -171,7 +230,13 @@ pub fn run(
     } else {
         ExitKind::Code(status.code().unwrap_or(-1))
     };
-    Ok(Exit { pid, kind, stderr })
+    let gpu_hang = reported_gpu_hang || gpu_hang.load(Ordering::Relaxed);
+    Ok(Exit {
+        pid,
+        kind,
+        stderr,
+        gpu_hang,
+    })
 }
 
 /// Everything stderr delivered, and whether its end was seen.
@@ -202,17 +267,27 @@ fn drain_stderr(chunks: &mpsc::Receiver<Vec<u8>>, grace: Duration) -> Stderr {
     }
 }
 
-/// The process's exit status if it exits within `timeout`, `None` if it does not.
-fn wait_bounded(child: &mut Child, timeout: Duration) -> Option<ExitStatus> {
+/// The result of waiting for a process after its stdout closed.
+enum Wait {
+    Exited(ExitStatus),
+    GpuHang,
+    TimedOut,
+}
+
+/// Wait for exit, a driver hang report, or `timeout` after stdout closed.
+fn wait_bounded(child: &mut Child, timeout: Duration, gpu_hang: &AtomicBool) -> Wait {
     let deadline = Instant::now() + timeout;
     loop {
         // A wait that fails is treated as a process that will not exit: the
         // caller kills the group and waits again, and that wait reports.
         if let Ok(Some(status)) = child.try_wait() {
-            return Some(status);
+            return Wait::Exited(status);
+        }
+        if gpu_hang.load(Ordering::Relaxed) {
+            return Wait::GpuHang;
         }
         if Instant::now() >= deadline {
-            return None;
+            return Wait::TimedOut;
         }
         thread::sleep(EXIT_POLL);
     }

--- a/unix/e2e/src/run/tests.rs
+++ b/unix/e2e/src/run/tests.rs
@@ -8,6 +8,9 @@ use std::{
 
 use super::{ExitKind, run};
 
+const DRIVER_HANG: &str = "Caused GPU Hang Error \
+    (00000003:kIOAccelCommandBufferCallbackErrorHang)";
+
 /// A script in a fresh directory under the target dir, run as `sh <script>`.
 fn script(name: &str, body: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("mtld3d-e2e-run-{}-{name}", std::process::id()));
@@ -34,6 +37,49 @@ fn a_clean_exit_reports_its_code_and_stderr() {
     assert_eq!(exit.kind, ExitKind::Code(3));
     assert_eq!(lines, ["one"]);
     assert_eq!(exit.stderr, "two\n");
+    assert!(!exit.gpu_hang);
+}
+
+#[test]
+fn a_gpu_hang_split_across_stderr_writes_stops_the_process() {
+    let path = script(
+        "gpu-hang",
+        "printf 'Caused GPU Hang Error (00000003:kIOAccelCommandBuffer' >&2\n\
+         sleep 0.1\n\
+         printf 'CallbackErrorHang)\\n' >&2\n\
+         sleep 30\n",
+    );
+    let started = Instant::now();
+    let (exit, elapsed, _) = run_script(&path, Duration::from_secs(5));
+    assert!(exit.gpu_hang);
+    assert_eq!(exit.stderr, format!("{DRIVER_HANG}\n"));
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "took {elapsed:?}: the runner waited instead of stopping the process"
+    );
+    assert!(started.elapsed() < Duration::from_secs(2));
+}
+
+#[test]
+fn a_gpu_hang_racing_with_a_clean_exit_still_counts() {
+    let path = script(
+        "gpu-hang-clean",
+        &format!("printf '%s\\n' '{DRIVER_HANG}' >&2\nexit 0\n"),
+    );
+    let (exit, _, _) = run_script(&path, Duration::from_secs(5));
+    assert!(exit.gpu_hang);
+    assert_eq!(exit.stderr, format!("{DRIVER_HANG}\n"));
+}
+
+#[test]
+fn unrelated_gpu_errors_are_not_hang_reports() {
+    for stderr in [
+        "0000:err:d3d9: GPU hang is not what this line reports",
+        "command buffer failed with Internal Error",
+        "kIOAccelCommandBufferCallbackErrorNotPermitted",
+    ] {
+        assert!(!super::is_gpu_hang_report(stderr), "{stderr}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
The e2e runner treated assertions after an explicit driver GPU-hang report as source failures and kept launching processes on the failed GPU. On the Intel CI incident this produced 187 failures across 191 processes and let log retention remove the initiating process's evidence.

The process runner now recognizes the two driver hang codes while streaming stderr and stops a live process immediately. After every process exit, the binary runner also checks the layer log before attribution can launch another process, which covers reports emitted only through mtld3d's file logger. Either path preserves the initiating stderr and layer log, returns a no-verdict outcome from attribution, stops the leg even with `--no-fail-fast`, and exits the e2e runner with code 3. Ordinary assertions, watchdog timeouts, and crash attribution keep their existing recovery.

The detector keeps the same two strings as the conformance runner. I considered moving them into `mtld3d-shared`, but that crate owns runtime wire values and helpers while these are host-runner process rules. The two runners are separate binaries with no runner-support crate between them, so a local two-marker check keeps the change scoped to e2e.

Host fake-child tests cover a marker split across stderr writes, prompt process termination, a marker before a clean exit, unrelated GPU error text, a clean process whose report exists only in its layer log, unconditional stopping with fail-fast disabled, and preservation of both evidence files. `make fmt`, `make check`, and `make test-unit` pass. The full `make ISOLATED=1 test` gate passes both host workspaces and every end-to-end test on both PE architectures. A direct fake-child run of the finished runner exited 3, skipped the following binary, and retained the initiating `.stderr` and `.layer-log` files.

Conformance was not run because this changes only the host e2e runner and does not touch render, state, shader, baseline, or shared-crate behavior. No real GPU hang was induced.

Rules check: `CONTRIBUTING.md` is updated with the new no-verdict and evidence contract, and the required host gates pass. `docs/CONVENTIONS.md` permits the runner-local private `GPU_HANG_MARKERS` and `GPU_HANG_EXIT` constants; the new `BinaryOutcome` derives only `Debug`, `PartialEq`, and `Eq`, so the `Clone`/`Copy` inventory does not change. No static, config key, wire field, dependency, lint suppression, or end-to-end test is introduced. The two marker strings duplicate the conformance runner for the scoped reason above. `docs/ARCHITECTURE.md` needs no companion change because the PE/Unix boundary, runtime logging path, and threading model are unchanged.

Closes #538
