### PR TITLE
Hold fullscreen test geometry under the mode lock

### DIFF
--- a/windows/tests/src/harness.rs
+++ b/windows/tests/src/harness.rs
@@ -56,7 +56,7 @@ static MODESET_HELD: Mutex<bool> = Mutex::new(false);
 static MODESET_RELEASED: Condvar = Condvar::new();
 
 /// Take the session's display mode, waiting for the harness that holds it.
-fn hold_display_mode() {
+fn take_display_mode() {
     let mut held = MODESET_HELD.lock().unwrap_or_else(PoisonError::into_inner);
     while *held {
         held = MODESET_RELEASED
@@ -361,7 +361,7 @@ impl Harness {
         let d3d9 = create_factory(cfg.config_entries);
         let mut state = HarnessState::empty();
         if cfg.windowed == 0 {
-            hold_display_mode();
+            take_display_mode();
             state |= HarnessState::HOLDS_DISPLAY_MODE;
         }
 
@@ -2616,15 +2616,25 @@ impl Harness {
         hr
     }
 
+    /// Hold the session's display mode before reading geometry for a fullscreen transition.
+    ///
+    /// A following fullscreen [`Self::reset_params`] keeps the same ownership
+    /// interval rather than taking the non-reentrant mode lock again.
+    pub fn hold_display_mode(&self) {
+        if !self.has(HarnessState::HOLDS_DISPLAY_MODE) {
+            take_display_mode();
+            self.set(HarnessState::HOLDS_DISPLAY_MODE, true);
+        }
+    }
+
     /// `Reset` with caller-built parameters (for malformed-input tests).
     ///
     /// Returns the hr; does not touch [`Self::dims`]. A fullscreen request
     /// takes the session's display mode before the call; a windowed one
     /// that succeeds gives it back.
     pub fn reset_params(&self, pp: &mut D3DPRESENT_PARAMETERS) -> i32 {
-        if pp.windowed == 0 && !self.has(HarnessState::HOLDS_DISPLAY_MODE) {
-            hold_display_mode();
-            self.set(HarnessState::HOLDS_DISPLAY_MODE, true);
+        if pp.windowed == 0 {
+            self.hold_display_mode();
         }
         // SAFETY: vtable thunk; `pp` is writable for the call.
         let hr = unsafe {

--- a/windows/tests/tests/e2e/device.rs
+++ b/windows/tests/tests/e2e/device.rs
@@ -1473,6 +1473,7 @@ fn reset_fullscreen_honors_a_settable_mode() {
 #[test]
 fn reset_fullscreen_non_mode_request_follows_the_window() {
     let h = Harness::new();
+    h.hold_display_mode();
     let (screen_w, screen_h) = Harness::screen_size();
     // 137x101 is in no display-mode list, so no game can depend on it being
     // honored: native would reject the request outright. Games that ask for
@@ -1510,11 +1511,12 @@ fn reset_fullscreen_non_mode_request_follows_the_window() {
 #[test]
 fn reset_fullscreen_retarget_keeps_the_previous_window_covered() {
     let h = Harness::new();
+    let second = create_window(320, 240, false);
     // The current resolution is a settable mode on any display, so this runs
     // wherever the suite does, unlike the tests that request 640x480.
-    let (screen_w, screen_h) = Harness::screen_size();
-    let second = create_window(320, 240, false);
+    h.hold_display_mode();
     let second_rect = window_rect(second);
+    let (screen_w, screen_h) = Harness::screen_size();
 
     let mut pp = fullscreen_params(h.hwnd(), screen_w, screen_h);
     assert_eq!(
@@ -1777,9 +1779,10 @@ fn cycle_fullscreen(
     progress: &RetargetProgress,
     windowed_workers: usize,
 ) -> Result<u32, String> {
-    let (screen_w, screen_h) = Harness::screen_size();
     let mut trips = 0;
     while progress.finished.load(Ordering::Acquire) < windowed_workers {
+        h.hold_display_mode();
+        let (screen_w, screen_h) = Harness::screen_size();
         let mut pp = fullscreen_params(h.hwnd(), screen_w, screen_h);
         let hr = h.reset_params(&mut pp);
         if hr != D3D_OK {


### PR DESCRIPTION
`reset_fullscreen_non_mode_request_follows_the_window` could snapshot another test's temporary 640x480 display mode, wait for that test to restore the desktop, and then compare the valid post-Reset geometry with the stale snapshot.

Expose the harness's existing display-mode ownership as an idempotent helper and take it before every screen-size read that precedes a fullscreen Reset and before the retarget test snapshots the window rectangle it expects to restore. `reset_params` reuses that ownership instead of taking the non-reentrant lock again. The retarget setup remains windowed until it needs the snapshot, and the concurrent cycle releases ownership on each windowed Reset, so unrelated windowed work stays concurrent.

Reading the size after Reset would fix the reported assertion alone, but it would not give tests that build a fullscreen request from the current mode one ownership interval across the read and transition. Serializing every screen-size query would also make unrelated windowed tests wait.

Verification: `make fmt`, per-file audit, `make check`, `make test-unit`, and PE test-binary prebuilds for i686 and x86_64 passed. Full `make ISOLATED=1 test` passed on i686 and x86_64. Conformance is not needed because this changes only test synchronization and no runtime, render, state, shader, or shared-crate behavior.

Rules check: this reuses the harness's existing mutex, condition variable, and state bit. It introduces no statics, config keys, wire fields, dependencies, derives, lint suppressions, type aliases, visibility exceptions, or duplicated lock state. The existing `device.rs` coverage row already describes the affected fullscreen Reset, retargeting, and concurrent window behavior, so no coverage row changes. The ownership interval matches the threading rules in `docs/ARCHITECTURE.md`, and no kept divergence in `docs/STATUS.md` changes.

Closes #528
