### PR TITLE
Reap stopped runners before killing their remaining descendants

### DIFF
--- a/unix/e2e/src/run.rs
+++ b/unix/e2e/src/run.rs
@@ -185,10 +185,9 @@ pub fn run(
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         }
     }
-    let (status, hung) = if reported_gpu_hang {
-        let status = child
-            .wait()
-            .map_err(|e| format!("wait on {} after GPU hang failed: {e}", exe.display()))?;
+    let (status, hung) = if reported_gpu_hang || timed_out {
+        let status = wait_killed(&mut child)
+            .map_err(|e| format!("wait on {} after stop failed: {e}", exe.display()))?;
         (status, false)
     } else {
         match wait_bounded(&mut child, timeout, &gpu_hang) {
@@ -196,15 +195,13 @@ pub fn run(
             Wait::GpuHang => {
                 kill_group(&child);
                 reported_gpu_hang = true;
-                let status = child
-                    .wait()
-                    .map_err(|e| format!("wait on {} after GPU hang failed: {e}", exe.display()))?;
+                let status = wait_killed(&mut child)
+                    .map_err(|e| format!("wait on {} after stop failed: {e}", exe.display()))?;
                 (status, false)
             }
             Wait::TimedOut => {
                 kill_group(&child);
-                let status = child
-                    .wait()
+                let status = wait_killed(&mut child)
                     .map_err(|e| format!("wait on {} failed: {e}", exe.display()))?;
                 (status, true)
             }
@@ -265,6 +262,16 @@ fn drain_stderr(chunks: &mpsc::Receiver<Vec<u8>>, grace: Duration) -> Stderr {
             }
         }
     }
+}
+
+/// Reap a killed child and stop descendants its group signal missed.
+fn wait_killed(child: &mut Child) -> std::io::Result<ExitStatus> {
+    let status = child.wait()?;
+    // A group signal visits a snapshot: a child forked while it is sent
+    // can miss it and keep the pipes open. Reaping the leader ensures its
+    // in-flight fork has finished before the group is signalled again.
+    kill_group(child);
+    Ok(status)
 }
 
 /// The result of waiting for a process after its stdout closed.

--- a/unix/e2e/src/run/tests.rs
+++ b/unix/e2e/src/run/tests.rs
@@ -2,7 +2,12 @@
 
 use std::{
     fs,
+    io::{BufRead, BufReader, Read},
+    os::unix::process::CommandExt,
     path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::mpsc,
+    thread,
     time::{Duration, Instant},
 };
 
@@ -147,4 +152,45 @@ fn a_descendant_holding_stderr_does_not_park_the_run() {
         exit.stderr
     );
     assert!(elapsed < Duration::from_secs(5), "took {elapsed:?}");
+}
+
+#[test]
+fn reaping_a_killed_leader_stops_a_descendant_missed_by_the_first_signal() {
+    let path = script("missed-child", "sleep 30 &\necho ready\nwait\n");
+    let mut child = Command::new("/bin/sh")
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0)
+        .spawn()
+        .expect("spawn group leader");
+    let mut ready = String::new();
+    BufReader::new(child.stdout.take().expect("stdout piped"))
+        .read_line(&mut ready)
+        .expect("read readiness");
+    assert_eq!(ready, "ready\n");
+    // The child exists before the parent is killed. Signalling only the
+    // leader models a group signal whose snapshot missed the new child,
+    // without requiring the signal to race a particular fork instruction.
+    child.kill().expect("kill group leader");
+    let status = super::wait_killed(&mut child).expect("reap group leader");
+    let mut stderr = child.stderr.take().expect("stderr piped");
+    let (closed, eof) = mpsc::channel();
+    let reader = thread::spawn(move || {
+        let mut bytes = Vec::new();
+        closed
+            .send(stderr.read_to_end(&mut bytes))
+            .expect("report EOF");
+    });
+    let collected = eof.recv_timeout(Duration::from_secs(1));
+    // Clean up the fixture even when the assertion below fails.
+    super::kill_group(&child);
+    reader.join().expect("stderr reader");
+    assert!(!status.success());
+    assert!(
+        collected.is_ok(),
+        "descendant kept stderr open: {collected:?}"
+    );
+    assert_eq!(collected.expect("EOF delivered").expect("read stderr"), 0);
 }


### PR DESCRIPTION
The split-stderr GPU-hang test could detect the complete hang signature and stop its shell promptly, yet append `stderr not collected in full` because a sleeping descendant still held the pipe. Seven of 1,600 native repetitions reproduced the failure; each process snapshot showed the survivor in the original process group after its parent had exited.

The measured survivors and XNU's process-group snapshot implementation support a fork racing the first signal: the shell starts its final sleep immediately after completing the hang line. Reap a forcibly stopped leader and signal its group again before collecting stderr. This covers GPU-hang, stdout-silence and post-stdout exit timeouts without changing their deadlines, the stderr grace, hang detection or the original exact-output assertion.

Changing the fixture to exec its final sleep would avoid the fork race in the test while leaving the runner's pipe collection exposed to it. Instead, a deterministic native regression starts a descendant before killing only its leader, modeling a first group signal that missed the descendant. It verifies that reaping the leader also stops the surviving pipe holder, and cleans up the fixture before any failure assertion.

Verification: `make fmt`, `make check` and `make test-unit` passed, including 1,107 Windows host tests and 307 Unix host tests. The new regression failed with a wait-only helper and passed with the second group signal. The unchanged split-write test passed all 1,600 repetitions at concurrency eight after the fix. Full `make check` and `make ISOLATED=1 test` pass on the final candidate. Conformance is not needed for this host-runner-only change.

## Rules check

CONTRIBUTING.md: one host-runner fix with native red/green regression evidence and the checks above. CONVENTIONS.md: the private helper stays in `run.rs`, tests stay in `run/tests.rs`, and the three forced-exit waits share the helper. No static, config key, environment variable, wire field, dependency, derive, lint suppression or duplicate mechanism is introduced. ARCHITECTURE.md: no runtime thread, Metal object, PE/Unix boundary or shared-crate change; classifier, caps, cache-schema and conformance companions do not apply.

Closes #553
