### PR TITLE
Preserve hosted e2e system logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,49 @@ jobs:
             ${{ runner.temp }}/*.layer-log
           retention-days: 14
           if-no-files-found: ignore
+      # The job budget is twenty minutes. Include five minutes of bounded
+      # pre-job context without changing the test command or its result.
+      - name: Collect e2e system log
+        if: always()
+        continue-on-error: true
+        timeout-minutes: 2
+        run: |
+          output="$RUNNER_TEMP/e2e-system"
+          mkdir -p "$output"
+          interval_end=$(date +%s)
+          interval_start=$((interval_end - 25 * 60))
+          predicate='process == "kernel" OR process == "WindowServer" OR subsystem CONTAINS[c] "GPU" OR subsystem CONTAINS[c] "IOAccel" OR subsystem CONTAINS[c] "IOSurface" OR subsystem CONTAINS[c] "AppleParavirt" OR senderImagePath CONTAINS[c] "GPU" OR senderImagePath CONTAINS[c] "IOAccel" OR senderImagePath CONTAINS[c] "IOSurface" OR senderImagePath CONTAINS[c] "AppleParavirt"'
+          {
+            printf 'interval_start_epoch=%s\n' "$interval_start"
+            printf 'interval_end_epoch=%s\n' "$interval_end"
+            printf 'timezone=UTC\n'
+            printf 'predicate=%s\n' "$predicate"
+            printf 'state=started\n'
+          } > "$output/collection-status.txt"
+          set +e
+          sudo -n /usr/bin/log show \
+            --start "@$interval_start" \
+            --end "@$interval_end" \
+            --style compact \
+            --timezone UTC \
+            --info \
+            --debug \
+            --predicate "$predicate" \
+            > "$output/system.log" \
+            2> "$output/collection.stderr"
+          collector_status=$?
+          {
+            printf 'exit_code=%s\n' "$collector_status"
+            printf 'state=completed\n'
+          } >> "$output/collection-status.txt"
+          exit "$collector_status"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-system-${{ matrix.runner }}-${{ matrix.arch }}${{ matrix.scale && format('-scale-{0}', matrix.scale) || '' }}
+          path: ${{ runner.temp }}/e2e-system
+          retention-days: 14
+          if-no-files-found: warn
 
   # Wine's own d3d9_test.exe against our staged builtin, per-site counts diffed
   # against unix/conformance/baseline.txt. One arch per runner process, and not


### PR DESCRIPTION
Hosted e2e artifacts retain layer logs and process stderr, but they do not retain the macOS unified-log context around GPU allocation failures. Once a hosted runner is gone, kernel, WindowServer, IOAccel, IOSurface, and AppleParavirt messages from that run cannot be inspected.

Collect a fixed 25-minute unified-log slice after the existing process artifact upload on every e2e matrix leg. The collector has its own two-minute timeout, runs noninteractively through `sudo -n`, and records its requested interval, UTC timezone, predicate, started state, stdout, stderr, and actual exit code. Completion is recorded only when the command returns, so denial, failure, and interruption cannot be read as a clean log. A distinct `e2e-system-<image>-<arch>` artifact keeps this evidence separate from the existing process artifacts.

The diagnostic step uses `always()` and `continue-on-error: true`, so its outcome cannot replace the original test result. The e2e command, 20-minute job budget, matrix, process artifact names and patterns, all image gates, conformance jobs, and main concurrency settings are unchanged. Collecting only on failed legs was considered, but successful sibling logs are needed for comparison. This change provides evidence for the allocation investigation and leaves #477 unresolved.

Local verification:

- `actionlint 1.7.12 .github/workflows/ci.yml`
- Bash syntax check of the extracted collector block
- Fake collector boundary tests for output success, empty success, permission denial, and interruption
- Addition-only diff and nonrecursive artifact-glob checks
- `make fmt`
- `make check`
- `make test-unit` (307 passed)

Full `make check` and `make ISOLATED=1 test` pass on the final rebased candidate. Actual collection support, exit codes, and artifact contents on the hosted macOS images remain pending the first hosted run; local fake output does not establish hosted evidence.

Rules check: `CONTRIBUTING.md` is satisfied by keeping this to one workflow diagnostic and reporting local checks and full isolated gates separately from pending hosted evidence. `docs/CONVENTIONS.md` is satisfied because this adds no statics, config keys, environment knobs, wire fields, dependencies, derives, lint suppressions, or runtime duplication, and collector failures remain explicit. `docs/ARCHITECTURE.md` is unchanged in substance: there is no PE/Unix boundary, thread, queue, resource, AppKit, Metal, runtime logger, or allocation behavior change. Conformance is not needed for a workflow-only change.

Closes #556
