### PR TITLE
Keep the e2e group leader waitable until its final signal

### DIFF
--- a/unix/e2e/src/run.rs
+++ b/unix/e2e/src/run.rs
@@ -116,7 +116,7 @@ pub fn run(
     on_line: &mut dyn FnMut(&str),
 ) -> Result<Exit, String> {
     let cwd = exe.parent().unwrap_or_else(|| Path::new("."));
-    let mut child = Command::new(wine)
+    let child = Command::new(wine)
         .arg(exe)
         .args(args)
         .current_dir(cwd)
@@ -127,6 +127,8 @@ pub fn run(
         .spawn()
         .map_err(|e| format!("failed to spawn {} {}: {e}", wine.display(), exe.display()))?;
 
+    let mut group = ProcessGroup { child: Some(child) };
+    let child = group.child.as_mut().expect("just spawned group leader");
     let pid = child.id();
     let stdout = child.stdout.take().ok_or("stdout not piped")?;
     let stderr = child.stderr.take().ok_or("stderr not piped")?;
@@ -163,13 +165,17 @@ pub fn run(
     let mut last_line = Instant::now();
     loop {
         if gpu_hang.load(Ordering::Relaxed) {
-            kill_group(&child);
+            group
+                .kill()
+                .map_err(|e| format!("stop {} failed: {e}", exe.display()))?;
             reported_gpu_hang = true;
             break;
         }
         let since_line = last_line.elapsed();
         if since_line >= timeout {
-            kill_group(&child);
+            group
+                .kill()
+                .map_err(|e| format!("stop {} failed: {e}", exe.display()))?;
             timed_out = true;
             break;
         }
@@ -185,25 +191,34 @@ pub fn run(
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         }
     }
-    let (status, hung) = if reported_gpu_hang || timed_out {
-        let status = wait_killed(&mut child)
+    let hung = if reported_gpu_hang || timed_out {
+        group
+            .wait_killed()
             .map_err(|e| format!("wait on {} after stop failed: {e}", exe.display()))?;
-        (status, false)
+        false
     } else {
-        match wait_bounded(&mut child, timeout, &gpu_hang) {
-            Wait::Exited(status) => (status, false),
+        match wait_bounded(&mut group, timeout, &gpu_hang)
+            .map_err(|e| format!("wait on {} failed: {e}", exe.display()))?
+        {
+            Wait::Exited => false,
             Wait::GpuHang => {
-                kill_group(&child);
+                group
+                    .kill()
+                    .map_err(|e| format!("stop {} failed: {e}", exe.display()))?;
                 reported_gpu_hang = true;
-                let status = wait_killed(&mut child)
+                group
+                    .wait_killed()
                     .map_err(|e| format!("wait on {} after stop failed: {e}", exe.display()))?;
-                (status, false)
+                false
             }
             Wait::TimedOut => {
-                kill_group(&child);
-                let status = wait_killed(&mut child)
+                group
+                    .kill()
+                    .map_err(|e| format!("stop {} failed: {e}", exe.display()))?;
+                group
+                    .wait_killed()
                     .map_err(|e| format!("wait on {} failed: {e}", exe.display()))?;
-                (status, true)
+                true
             }
         }
     };
@@ -212,11 +227,16 @@ pub fn run(
         // Something the kill did not reach still holds the pipe: a process
         // that put itself in another group. Say so, and try the kill once
         // more for whatever did land in the group since.
-        kill_group(&child);
+        group
+            .kill()
+            .map_err(|e| format!("stop {} failed: {e}", exe.display()))?;
         stderr.text.push_str(
             "[e2e] stderr not collected in full: the process tree held it open past the end\n",
         );
     }
+    let status = group
+        .reap()
+        .map_err(|e| format!("reap {} failed: {e}", exe.display()))?;
     let stderr = stderr.text;
     let kind = if timed_out {
         ExitKind::TimedOut(timeout)
@@ -264,54 +284,159 @@ fn drain_stderr(chunks: &mpsc::Receiver<Vec<u8>>, grace: Duration) -> Stderr {
     }
 }
 
-/// Reap a killed child and stop descendants its group signal missed.
-fn wait_killed(child: &mut Child) -> std::io::Result<ExitStatus> {
-    let status = child.wait()?;
-    // A group signal visits a snapshot: a child forked while it is sent
-    // can miss it and keep the pipes open. Reaping the leader ensures its
-    // in-flight fork has finished before the group is signalled again.
-    kill_group(child);
-    Ok(status)
+/// A group whose leader stays unreaped until all group signals have been sent.
+///
+/// On macOS an unreaped child reserves its PID and process-group membership.
+/// Only this owner waits for the child; observing exit with WNOWAIT retains
+/// that reservation. ECHILD revokes ownership instead of trusting a numeric ID.
+struct ProcessGroup {
+    child: Option<Child>,
+}
+
+impl ProcessGroup {
+    /// Observe exit without releasing the leader's PID or group membership.
+    fn observe_exit(&mut self, options: libc::c_int) -> std::io::Result<bool> {
+        let child = self
+            .child
+            .as_ref()
+            .ok_or_else(|| std::io::Error::from_raw_os_error(libc::ECHILD))?;
+        loop {
+            // SAFETY: siginfo_t contains integers and raw pointers, valid when zeroed.
+            // macOS leaves it untouched for WNOHANG when the child is still running.
+            let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+            // SAFETY: info is writable and P_PID selects this owner's direct child.
+            // WNOWAIT observes exit without consuming the child's waitable status.
+            let result = unsafe {
+                libc::waitid(
+                    libc::P_PID,
+                    child.id(),
+                    &raw mut info,
+                    libc::WEXITED | libc::WNOWAIT | options,
+                )
+            };
+            if result == 0 {
+                return Ok(info.si_pid != 0);
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            if error.raw_os_error() == Some(libc::ECHILD) {
+                self.child.take();
+            }
+            return Err(error);
+        }
+    }
+
+    /// Verify that the leader is still ours before signalling its group.
+    fn kill(&mut self) -> std::io::Result<()> {
+        self.observe_exit(libc::WNOHANG)?;
+        self.signal_group()
+    }
+
+    /// Stop descendants a group signal's fork snapshot may have missed.
+    fn wait_killed(&mut self) -> std::io::Result<()> {
+        self.observe_exit(0)?;
+        // The leader has exited, so its in-flight fork has finished. WNOWAIT
+        // retains its group identity through this second signal and stderr drain.
+        self.signal_group()
+    }
+
+    /// Release the reserved identity, consuming the ability to signal the group.
+    fn reap(mut self) -> std::io::Result<ExitStatus> {
+        let result = self
+            .child
+            .as_mut()
+            .ok_or_else(|| std::io::Error::from_raw_os_error(libc::ECHILD))?
+            .wait();
+        if result.is_ok()
+            || result
+                .as_ref()
+                .is_err_and(|e| e.raw_os_error() == Some(libc::ECHILD))
+        {
+            self.child.take();
+        }
+        result
+    }
+
+    /// Signal the group while its leader remains owned and unreaped.
+    fn signal_group(&mut self) -> std::io::Result<()> {
+        let child = self
+            .child
+            .as_ref()
+            .ok_or_else(|| std::io::Error::from_raw_os_error(libc::ECHILD))?;
+        let pid = libc::pid_t::try_from(child.id()).expect("child PID fits pid_t");
+        // SAFETY: the child spawned as its own group leader and remains unreaped,
+        // so its PID reserves this group's identity until the consuming reap.
+        let result = unsafe { libc::kill(-pid, libc::SIGKILL) };
+        if result == 0 {
+            return Ok(());
+        }
+        let error = std::io::Error::last_os_error();
+        // macOS skips zombies when signalling a group and returns EPERM when
+        // no live member could be signalled. The retained zombie alone therefore
+        // produces EPERM too. This does not prove every descendant exited;
+        // an open stderr pipe still reports a survivor.
+        if error.raw_os_error() == Some(libc::ESRCH)
+            || (error.raw_os_error() == Some(libc::EPERM) && self.observe_exit(libc::WNOHANG)?)
+        {
+            return Ok(());
+        }
+        Err(error)
+    }
+}
+
+impl Drop for ProcessGroup {
+    fn drop(&mut self) {
+        if self.child.is_none() {
+            return;
+        }
+        if let Err(error) = self.observe_exit(libc::WNOHANG) {
+            eprintln!("[e2e] observe process during cleanup failed: {error}");
+        }
+        // ECHILD means another waiter consumed the identity. Never signal it.
+        if self.child.is_none() {
+            return;
+        }
+        if let Err(error) = self.signal_group() {
+            eprintln!("[e2e] stop process group during cleanup failed: {error}");
+        }
+        if let Err(error) = self.wait_killed() {
+            eprintln!("[e2e] wait for stopped process during cleanup failed: {error}");
+        }
+        if let Some(mut child) = self.child.take()
+            && let Err(error) = child.wait()
+        {
+            eprintln!("[e2e] reap process during cleanup failed: {error}");
+        }
+    }
 }
 
 /// The result of waiting for a process after its stdout closed.
 enum Wait {
-    Exited(ExitStatus),
+    Exited,
     GpuHang,
     TimedOut,
 }
 
 /// Wait for exit, a driver hang report, or `timeout` after stdout closed.
-fn wait_bounded(child: &mut Child, timeout: Duration, gpu_hang: &AtomicBool) -> Wait {
+fn wait_bounded(
+    group: &mut ProcessGroup,
+    timeout: Duration,
+    gpu_hang: &AtomicBool,
+) -> std::io::Result<Wait> {
     let deadline = Instant::now() + timeout;
     loop {
-        // A wait that fails is treated as a process that will not exit: the
-        // caller kills the group and waits again, and that wait reports.
-        if let Ok(Some(status)) = child.try_wait() {
-            return Wait::Exited(status);
+        if group.observe_exit(libc::WNOHANG)? {
+            return Ok(Wait::Exited);
         }
         if gpu_hang.load(Ordering::Relaxed) {
-            return Wait::GpuHang;
+            return Ok(Wait::GpuHang);
         }
         if Instant::now() >= deadline {
-            return Wait::TimedOut;
+            return Ok(Wait::TimedOut);
         }
         thread::sleep(EXIT_POLL);
-    }
-}
-
-/// SIGKILL the child's process group: the child and everything it forked.
-///
-/// The child is its own group leader (`process_group(0)` at spawn), so the
-/// group id is its pid. A group that is already gone is not an error.
-fn kill_group(child: &Child) {
-    let Ok(pid) = i32::try_from(child.id()) else {
-        return;
-    };
-    // SAFETY: kill(2) with a negative pid signals the group; it touches no
-    // memory of ours and a stale id is reported as ESRCH, not acted on.
-    unsafe {
-        let _ = libc::kill(-pid, libc::SIGKILL);
     }
 }
 

--- a/unix/e2e/src/run/tests.rs
+++ b/unix/e2e/src/run/tests.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use super::{ExitKind, run};
+use super::{ExitKind, ProcessGroup, run};
 
 const DRIVER_HANG: &str = "Caused GPU Hang Error \
     (00000003:kIOAccelCommandBufferCallbackErrorHang)";
@@ -155,7 +155,7 @@ fn a_descendant_holding_stderr_does_not_park_the_run() {
 }
 
 #[test]
-fn reaping_a_killed_leader_stops_a_descendant_missed_by_the_first_signal() {
+fn observing_a_killed_leader_stops_a_descendant_missed_by_the_first_signal() {
     let path = script("missed-child", "sleep 30 &\necho ready\nwait\n");
     let mut child = Command::new("/bin/sh")
         .arg(path)
@@ -174,8 +174,11 @@ fn reaping_a_killed_leader_stops_a_descendant_missed_by_the_first_signal() {
     // leader models a group signal whose snapshot missed the new child,
     // without requiring the signal to race a particular fork instruction.
     child.kill().expect("kill group leader");
-    let status = super::wait_killed(&mut child).expect("reap group leader");
+    let pid = child.id();
     let mut stderr = child.stderr.take().expect("stderr piped");
+    let mut group = ProcessGroup { child: Some(child) };
+    group.wait_killed().expect("observe group leader");
+    assert_waitable(pid);
     let (closed, eof) = mpsc::channel();
     let reader = thread::spawn(move || {
         let mut bytes = Vec::new();
@@ -185,12 +188,148 @@ fn reaping_a_killed_leader_stops_a_descendant_missed_by_the_first_signal() {
     });
     let collected = eof.recv_timeout(Duration::from_secs(1));
     // Clean up the fixture even when the assertion below fails.
-    super::kill_group(&child);
+    group.kill().expect("clean up group");
     reader.join().expect("stderr reader");
+    assert_waitable(pid);
+    let status = group.reap().expect("reap group leader");
     assert!(!status.success());
     assert!(
         collected.is_ok(),
         "descendant kept stderr open: {collected:?}"
     );
     assert_eq!(collected.expect("EOF delivered").expect("read stderr"), 0);
+}
+
+#[test]
+fn observing_a_clean_exit_keeps_the_leader_waitable() {
+    let child = Command::new("/bin/sh")
+        .args(["-c", "exit 7"])
+        .process_group(0)
+        .spawn()
+        .expect("spawn group leader");
+    let pid = child.id();
+    let mut group = ProcessGroup { child: Some(child) };
+    let gpu_hang = std::sync::atomic::AtomicBool::new(false);
+    let observed = super::wait_bounded(&mut group, Duration::from_secs(2), &gpu_hang)
+        .expect("observe group leader");
+    assert!(matches!(observed, super::Wait::Exited));
+    assert_waitable(pid);
+    assert!(
+        group
+            .observe_exit(libc::WNOHANG)
+            .expect("observe exit again")
+    );
+    assert_waitable(pid);
+    let status = group.reap().expect("reap group leader");
+    assert_eq!(status.code(), Some(7));
+    assert_reaped(pid);
+}
+
+#[test]
+fn a_killed_leader_stays_waitable_until_the_final_signal() {
+    let child = Command::new("/bin/sleep")
+        .arg("30")
+        .process_group(0)
+        .spawn()
+        .expect("spawn group leader");
+    let pid = child.id();
+    let mut group = ProcessGroup { child: Some(child) };
+    assert!(
+        !group
+            .observe_exit(libc::WNOHANG)
+            .expect("observe running child")
+    );
+    group.kill().expect("first group signal");
+    group.wait_killed().expect("observe exit and signal again");
+    assert_waitable(pid);
+    assert!(
+        group
+            .observe_exit(libc::WNOHANG)
+            .expect("observe exit again")
+    );
+    group.kill().expect("final group signal");
+    assert_waitable(pid);
+    let status = group.reap().expect("reap group leader");
+    assert!(!status.success());
+    assert_reaped(pid);
+}
+
+#[test]
+fn losing_the_waitable_child_disables_group_signals() {
+    let mut child = Command::new("/bin/sh")
+        .args(["-c", "exit 0"])
+        .process_group(0)
+        .spawn()
+        .expect("spawn group leader");
+    // Model an external waiter consuming the child, without reusing any ID.
+    child.wait().expect("external reap");
+    let mut group = ProcessGroup { child: Some(child) };
+    let error = group
+        .kill()
+        .expect_err("must not signal after external reap");
+    assert_eq!(error.raw_os_error(), Some(libc::ECHILD));
+    assert!(group.child.is_none());
+    let error = group.kill().expect_err("ownership stays revoked");
+    assert_eq!(error.raw_os_error(), Some(libc::ECHILD));
+}
+
+#[test]
+fn dropping_an_unfinished_group_stops_and_reaps_its_leader() {
+    let child = Command::new("/bin/sleep")
+        .arg("30")
+        .process_group(0)
+        .spawn()
+        .expect("spawn group leader");
+    let pid = child.id();
+    drop(ProcessGroup { child: Some(child) });
+    assert_reaped(pid);
+}
+
+#[test]
+fn an_unexpected_wait_error_retains_ownership_for_cleanup() {
+    let child = Command::new("/bin/sleep")
+        .arg("30")
+        .process_group(0)
+        .spawn()
+        .expect("spawn group leader");
+    let pid = child.id();
+    let mut group = ProcessGroup { child: Some(child) };
+    let error = group
+        .observe_exit(libc::c_int::MAX)
+        .expect_err("invalid wait options");
+    assert_eq!(error.raw_os_error(), Some(libc::EINVAL));
+    assert!(group.child.is_some());
+    drop(group);
+    assert_reaped(pid);
+}
+
+fn assert_waitable(pid: u32) {
+    let info = observe_fixture(pid).expect("exit observation must not reap the leader");
+    assert_eq!(info.si_pid.unsigned_abs(), pid);
+}
+
+fn assert_reaped(pid: u32) {
+    match observe_fixture(pid) {
+        Ok(_) => panic!("final reap left a waitable child"),
+        Err(error) => assert_eq!(error.raw_os_error(), Some(libc::ECHILD)),
+    }
+}
+
+fn observe_fixture(pid: u32) -> std::io::Result<libc::siginfo_t> {
+    // SAFETY: siginfo_t contains integers and raw pointers, all valid when zeroed.
+    let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+    // SAFETY: info is writable and P_PID selects only this fixture's direct child.
+    let result = unsafe {
+        libc::waitid(
+            libc::P_PID,
+            pid,
+            &raw mut info,
+            libc::WEXITED | libc::WNOWAIT | libc::WNOHANG,
+        )
+    };
+    if result == 0 {
+        Ok(info)
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
 }


### PR DESCRIPTION
The native e2e runner could signal a numeric process-group ID after Child::wait or Child::try_wait had reaped its leader. Reaping released the identity reservation, so the old comment that a stale ID could only return ESRCH was incorrect. No signal to an unrelated group was reproduced.

Observe child exit with waitid(WNOWAIT), retaining the leader through the second group signal and stderr grace, then consume the owner in the final reap. The second signal still follows the leader's exit so it catches a descendant missed by the first signal's fork snapshot. ECHILD revokes ownership; other errors retain an owner that attempts termination and reaping and reports cleanup failures. macOS returns EPERM for a zombie-only group, so that result is accepted after observing leader exit. It does not establish that every descendant exited.

Dropping the second signal would regress the missed-descendant case. Checking a numeric ID before signalling leaves a check/use race; retaining the waitable child reserves the ID instead. The existing per-chunk stderr grace remains unchanged.

Verification: the clean-exit retention test failed before the change because waitid returned -1 after the old polling wait reaped the child. Native runner unit tests now pass, including repeated exit observation, final reap, ECHILD ownership loss, unexpected wait errors, missed-descendant EOF, timeout distinctions and GPU-hang reports. Native clippy with denied warnings, make fmt, make audit and x86_64 runner compilation pass. The final candidate passed make check and make ISOLATED=1 test, including both host workspaces and both PE architectures.

Rules check: CONTRIBUTING.md limits this change to the runner lifecycle and its native regression tests. CONVENTIONS.md is enforced by formatting, denied-warning clippy and audit; unit tests remain in run/tests.rs and libc operations have focused safety comments. ARCHITECTURE.md's runtime threading and PE/Unix boundary are unaffected. No statics, config keys, wire fields, dependencies, derives, suppressions or duplicate runtime helpers are introduced. Conformance is not applicable because no rendering, state, shader or shared crate behavior changes.

Closes #559
