### PR TITLE
Preserve texture staging through upload recovery reads

### DIFF
--- a/windows/core/src/page_box.rs
+++ b/windows/core/src/page_box.rs
@@ -15,6 +15,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     alloc::{self, Layout},
     ptr::NonNull,
+    sync::{Arc, atomic::AtomicUsize},
 };
 
 /// Bytes held by live `PageBox`es, always on: one add per alloc, one sub per free.
@@ -253,6 +254,8 @@ pub struct PageBox {
     layout: Layout,
     /// This allocation's [`PAGE_BOX_GENERATION`] stamp.
     generation: u64,
+    /// Upload jobs and emitted reads, excluding cached buffer-wrapper owners.
+    readers: AtomicUsize,
 }
 
 // SAFETY: PageBox owns a heap allocation with no interior sharing. Transferring
@@ -293,6 +296,7 @@ impl PageBox {
             logical_len,
             layout,
             generation: PAGE_BOX_GENERATION.fetch_add(1, core::sync::atomic::Ordering::Relaxed) + 1,
+            readers: AtomicUsize::new(0),
         }
     }
 
@@ -319,7 +323,14 @@ impl PageBox {
             logical_len,
             layout,
             generation: PAGE_BOX_GENERATION.fetch_add(1, core::sync::atomic::Ordering::Relaxed) + 1,
+            readers: AtomicUsize::new(0),
         }
+    }
+
+    /// Whether a queued, replayable or in-flight upload still reads these pages.
+    #[must_use]
+    pub fn has_readers(&self) -> bool {
+        self.readers.load(core::sync::atomic::Ordering::Acquire) != 0
     }
 
     #[must_use]
@@ -427,6 +438,43 @@ impl Drop for PageBox {
         // SAFETY: same layout used to alloc; pointer came from that
         // allocator; nothing else owns this allocation.
         unsafe { alloc::dealloc(self.ptr.as_ptr(), self.layout) };
+    }
+}
+
+/// A queued, replayable or in-flight read of a `PageBox`.
+///
+/// The owning `Arc` keeps the allocation alive. Its separate reader count lets
+/// a writer distinguish reads from cached wrappers that only keep pages alive.
+/// New reads must be acquired before publication to another thread, or from
+/// an already-held read, so a writer observing zero cannot race a new reader.
+pub struct PageBoxRead {
+    backing: Arc<PageBox>,
+}
+
+impl PageBoxRead {
+    #[must_use]
+    pub fn new(backing: Arc<PageBox>) -> Self {
+        // Every reader owns an Arc before incrementing, so this count never
+        // exceeds Arc's bounded strong count and cannot overflow.
+        backing
+            .readers
+            .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        Self { backing }
+    }
+
+    #[must_use]
+    pub const fn backing(&self) -> &Arc<PageBox> {
+        &self.backing
+    }
+}
+
+impl Drop for PageBoxRead {
+    fn drop(&mut self) {
+        // Construction increments once and the guard is move-only,
+        // so every drop has exactly one outstanding increment to release.
+        self.backing
+            .readers
+            .fetch_sub(1, core::sync::atomic::Ordering::Release);
     }
 }
 

--- a/windows/core/src/page_box/tests.rs
+++ b/windows/core/src/page_box/tests.rs
@@ -6,9 +6,71 @@
 //! itself: page-aligned pointers, a padded length rounded up to a page multiple
 //! (one page even at zero), and the full logical range readable and writable.
 
+use std::sync::{Arc, mpsc};
+
 use super::{
-    PAGE_SIZE, PageBox, SNMALLOC_LOCAL_CACHE_BYTES, bypasses_local_cache, snmalloc_chunk_size,
+    PAGE_SIZE, PageBox, PageBoxRead, SNMALLOC_LOCAL_CACHE_BYTES, bypasses_local_cache,
+    snmalloc_chunk_size,
 };
+
+#[test]
+fn read_guards_exclude_cached_owners_and_survive_independent_drops() {
+    let backing = Arc::new(PageBox::new_zeroed(64));
+    let cached = Arc::clone(&backing);
+    let other = Arc::new(PageBox::new_zeroed(64));
+    assert!(!backing.has_readers());
+    let job = PageBoxRead::new(Arc::clone(&backing));
+    let emitted = PageBoxRead::new(Arc::clone(job.backing()));
+    assert!(backing.has_readers());
+    assert!(!other.has_readers());
+    drop(job);
+    assert!(backing.has_readers());
+    drop(emitted);
+    assert!(!backing.has_readers());
+    assert_eq!(Arc::strong_count(&backing), 2);
+    assert!(Arc::ptr_eq(&backing, &cached));
+}
+
+#[test]
+fn moving_read_guard_across_threads_keeps_it_live_until_release() {
+    let backing = Arc::new(PageBox::new_zeroed(64));
+    let read = PageBoxRead::new(Arc::clone(&backing));
+    let (release_tx, release_rx) = mpsc::sync_channel(0);
+    let (released_tx, released_rx) = mpsc::sync_channel(0);
+    std::thread::scope(|scope| {
+        scope.spawn(move || {
+            release_rx.recv().expect("release signal");
+            drop(read);
+            released_tx.send(()).expect("released signal");
+        });
+        assert!(backing.has_readers());
+        release_tx.send(()).expect("release signal");
+        released_rx.recv().expect("released signal");
+        assert!(!backing.has_readers());
+    });
+}
+
+#[test]
+fn recycled_backing_has_no_reader_state_to_reset() {
+    let backing = Arc::new(PageBox::new_zeroed(64));
+    let read = PageBoxRead::new(Arc::clone(&backing));
+    let backing = Arc::try_unwrap(backing)
+        .err()
+        .expect("read retains backing");
+    drop(read);
+    let backing = Arc::try_unwrap(backing).ok().expect("last read released");
+    let generation = backing.generation();
+    let pool = crate::page_box_pool::PageBoxPool::new(PAGE_SIZE);
+    assert!(pool.recycle(backing).is_none());
+    let reused = pool.acquire(128).expect("same page class");
+    assert_eq!(reused.generation(), generation);
+    assert!(!reused.has_readers());
+    let reused = Arc::new(reused);
+    let read = PageBoxRead::new(Arc::clone(&reused));
+    assert!(reused.has_readers());
+    drop(read);
+    assert!(!reused.has_readers());
+}
 
 /// The derived cutoff sits just above 1 MiB, and nothing hardcodes it.
 #[test]

--- a/windows/core/src/texture_staging.rs
+++ b/windows/core/src/texture_staging.rs
@@ -10,7 +10,7 @@
 //!
 //! Decision tree:
 //! - `D3DLOCK_NOOVERWRITE` / `D3DLOCK_READONLY`, or uncontended
-//!   (`last_submit_seq <= coherent_seq`): `WriteInPlace`.
+//!   (no in-flight or replayable upload): `WriteInPlace`.
 //! - `D3DLOCK_DISCARD` on a whole-mip Lock of a `D3DPOOL_DEFAULT`
 //!   texture: Rename, no preserve (game promised the old bytes are
 //!   gone). Every other DISCARD is dropped first, see
@@ -172,10 +172,9 @@ const fn rect_block_aligned(r: DirtyRect, shape: MipShape) -> bool {
 
 /// Decide the Lock action for a single mip.
 ///
-/// - `coherent_seq` is the encoder thread's last retired submit seq.
-/// - `slot_last_submit_seq` is the submit seq at which this mip's
-///   staging was last referenced by a GPU-visible command. Zero if
-///   never uploaded.
+/// - `contended` includes both in-flight submits and retained upload readers.
+///   A retired upload can still be replayed, so retirement alone does not end
+///   its read lifetime.
 /// - `flags` is the raw `D3DLOCK_*` bitfield from the game. A DISCARD the
 ///   Lock cannot honour is dropped here as well as in the caller (see
 ///   [`honoured_lock_flags`]), so a verdict never rests on one.
@@ -187,8 +186,7 @@ const fn rect_block_aligned(r: DirtyRect, shape: MipShape) -> bool {
 /// `log_once_warn!`.
 #[must_use]
 pub const fn decide_lock_action(
-    coherent_seq: u64,
-    slot_last_submit_seq: u64,
+    contended: bool,
     flags: u32,
     pool: u32,
     rect: Option<DirtyRect>,
@@ -198,7 +196,7 @@ pub const fn decide_lock_action(
     if flags & (D3DLOCK_READONLY | D3DLOCK_NOOVERWRITE) != 0 {
         return LockAction::WriteInPlace;
     }
-    if !is_in_flight(slot_last_submit_seq, coherent_seq) {
+    if !contended {
         return LockAction::WriteInPlace;
     }
     if flags & D3DLOCK_DISCARD != 0 {

--- a/windows/core/src/texture_staging/tests.rs
+++ b/windows/core/src/texture_staging/tests.rs
@@ -11,9 +11,15 @@
 //! and shape combinations, since every class outside the one that releases is a level whose only
 //! copy of some byte is the staging.
 
+use std::sync::Arc;
+
 use mtld3d_types::{D3DPOOL_MANAGED, D3DPOOL_SYSTEMMEM};
 
 use super::*;
+use crate::{
+    page_box::{PageBox, PageBoxRead},
+    upload_recovery::{MAX_REISSUE_ATTEMPTS, UploadFate, UploadRecoveryQueue},
+};
 
 const DEFAULT_FLAGS: u32 = 0;
 const NO_USAGE: u32 = 0;
@@ -24,6 +30,240 @@ const COHERENT: u64 = 15;
 // 256×256 mip in pixel coords; uncompressed unless overridden.
 const MIP_W: u32 = 256;
 const MIP_H: u32 = 256;
+const RECOVERY_BYTES: usize = 4 * 4 * 4;
+const RECOVERY_SHAPE: MipShape = MipShape {
+    mip_w: 4,
+    mip_h: 4,
+    block_w: 1,
+    block_h: 1,
+};
+
+fn recovery_staging(value: u8) -> Arc<PageBox> {
+    let mut backing = PageBox::new_zeroed(RECOVERY_BYTES);
+    // SAFETY: the unique allocation holds RECOVERY_BYTES initialized bytes.
+    unsafe { backing.as_mut_ptr().write_bytes(value, RECOVERY_BYTES) };
+    Arc::new(backing)
+}
+
+fn recovery_bytes(backing: &PageBox) -> Vec<u8> {
+    // SAFETY: the test initializes every logical byte and accesses them serially.
+    unsafe { std::slice::from_raw_parts(backing.as_ptr(), RECOVERY_BYTES) }.to_vec()
+}
+
+fn write_retired_staging(backing: &mut Arc<PageBox>, original_seq: u64, retired: u64) {
+    let contended = is_in_flight(original_seq, retired) || backing.has_readers();
+    let action = decide_lock_action(contended, 0, D3DPOOL_MANAGED, None, RECOVERY_SHAPE);
+    if let LockAction::FreshBox { preserve } = action {
+        assert_eq!(preserve, PreserveKind::Cpu);
+        let mut fresh = PageBox::new_zeroed(RECOVERY_BYTES);
+        // SAFETY: distinct initialized allocations with equal logical lengths.
+        unsafe {
+            std::ptr::copy_nonoverlapping(backing.as_ptr(), fresh.as_mut_ptr(), RECOVERY_BYTES);
+        }
+        assert_eq!(recovery_bytes(&fresh), recovery_bytes(backing));
+        *backing = Arc::new(fresh);
+    }
+    // SAFETY: accesses are serial and this allocation holds RECOVERY_BYTES initialized bytes.
+    unsafe {
+        backing
+            .as_ptr()
+            .cast_mut()
+            .write_bytes(0x22, RECOVERY_BYTES);
+    };
+}
+
+#[test]
+fn failed_upload_preserves_bytes_before_recovery_runs() {
+    let mut backing = recovery_staging(0x11);
+    let mut queue = UploadRecoveryQueue::new();
+    queue.push(1, 5, PageBoxRead::new(Arc::clone(&backing)));
+    write_retired_staging(&mut backing, 5, 5);
+    let entries = queue.settle(5, 5);
+    assert_eq!(entries[0].0, UploadFate::Reissue);
+    assert_eq!(
+        recovery_bytes(entries[0].1.payload().backing()),
+        vec![0x11; RECOVERY_BYTES]
+    );
+}
+
+#[test]
+fn requeued_upload_preserves_bytes_after_original_retirement() {
+    let mut backing = recovery_staging(0x11);
+    let mut queue = UploadRecoveryQueue::new();
+    queue.push(1, 5, PageBoxRead::new(Arc::clone(&backing)));
+    let (fate, entry) = queue.settle(5, 5).pop().expect("one upload");
+    assert_eq!(fate, UploadFate::Reissue);
+    queue.requeue(entry, 6);
+    write_retired_staging(&mut backing, 5, 5);
+    let entries = queue.settle(6, 5);
+    assert_eq!(entries[0].0, UploadFate::Released);
+    assert_eq!(
+        recovery_bytes(entries[0].1.payload().backing()),
+        vec![0x11; RECOVERY_BYTES]
+    );
+}
+
+#[test]
+fn poisoned_newer_upload_preserves_bytes_after_its_successful_retirement() {
+    let mut backing = recovery_staging(0x11);
+    let mut queue = UploadRecoveryQueue::new();
+    queue.push(1, 5, PageBoxRead::new(recovery_staging(0x33)));
+    queue.push(1, 6, PageBoxRead::new(Arc::clone(&backing)));
+    for (fate, entry) in queue.settle(6, 5) {
+        assert_eq!(fate, UploadFate::Reissue);
+        queue.requeue(entry, 7);
+    }
+    write_retired_staging(&mut backing, 6, 6);
+    let entries = queue.settle(7, 5);
+    assert_eq!(
+        recovery_bytes(entries[1].1.payload().backing()),
+        vec![0x11; RECOVERY_BYTES]
+    );
+}
+
+#[test]
+fn successful_but_replayable_upload_preserves_bytes_before_a_later_failure() {
+    let mut backing = recovery_staging(0x11);
+    let mut queue = UploadRecoveryQueue::new();
+    queue.push(1, 5, PageBoxRead::new(Arc::clone(&backing)));
+    write_retired_staging(&mut backing, 5, 5);
+    let entries = queue.settle(6, 6);
+    assert_eq!(entries[0].0, UploadFate::Reissue);
+    assert_eq!(
+        recovery_bytes(entries[0].1.payload().backing()),
+        vec![0x11; RECOVERY_BYTES]
+    );
+}
+
+#[test]
+fn abandoned_unretired_replay_keeps_its_emitted_reader() {
+    let mut backing = recovery_staging(0x11);
+    let mut queue = UploadRecoveryQueue::new();
+    queue.push(1, 1, PageBoxRead::new(Arc::clone(&backing)));
+    let mut seq = 1;
+    for _ in 0..MAX_REISSUE_ATTEMPTS {
+        let (fate, entry) = queue.settle(seq, seq).pop().expect("retry");
+        assert_eq!(fate, UploadFate::Reissue);
+        seq += 1;
+        queue.requeue(entry, seq);
+    }
+    let emitted = PageBoxRead::new(Arc::clone(&backing));
+    let entries = queue.settle(seq - 1, seq);
+    assert_eq!(entries[0].0, UploadFate::Abandoned);
+    drop(entries);
+    write_retired_staging(&mut backing, 1, seq - 1);
+    assert_eq!(
+        recovery_bytes(emitted.backing()),
+        vec![0x11; RECOVERY_BYTES]
+    );
+}
+
+#[test]
+fn declined_replay_keeps_an_earlier_emitted_reader() {
+    let mut backing = recovery_staging(0x11);
+    let mut queue = UploadRecoveryQueue::new();
+    queue.push(1, 5, PageBoxRead::new(Arc::clone(&backing)));
+    let emitted = PageBoxRead::new(Arc::clone(&backing));
+    let entries = queue.settle(4, 5);
+    assert_eq!(entries[0].0, UploadFate::Reissue);
+    drop(entries);
+    write_retired_staging(&mut backing, 5, 5);
+    assert_eq!(
+        recovery_bytes(emitted.backing()),
+        vec![0x11; RECOVERY_BYTES]
+    );
+}
+
+#[test]
+fn acknowledged_upload_reuses_staging_with_a_cached_wrapper() {
+    let mut backing = recovery_staging(0x11);
+    let cached = Arc::clone(&backing);
+    let pointer = backing.as_ptr();
+    let mut queue = UploadRecoveryQueue::new();
+    queue.push(1, 5, PageBoxRead::new(Arc::clone(&backing)));
+    let emitted = PageBoxRead::new(Arc::clone(&backing));
+    drop(queue.settle(5, 0));
+    assert!(backing.has_readers());
+    drop(emitted);
+    assert!(!backing.has_readers());
+    write_retired_staging(&mut backing, 5, 5);
+    assert_eq!(backing.as_ptr(), pointer);
+    assert_eq!(recovery_bytes(&cached), vec![0x22; RECOVERY_BYTES]);
+}
+
+#[test]
+fn replayable_readers_keep_flag_and_partial_lock_contracts() {
+    let backing = recovery_staging(0x11);
+    let _read = PageBoxRead::new(Arc::clone(&backing));
+    for flags in [D3DLOCK_READONLY, D3DLOCK_NOOVERWRITE] {
+        assert_eq!(
+            decide_lock_action(
+                backing.has_readers(),
+                flags,
+                D3DPOOL_DEFAULT,
+                None,
+                RECOVERY_SHAPE
+            ),
+            LockAction::WriteInPlace
+        );
+    }
+    assert_eq!(
+        decide_lock_action(
+            backing.has_readers(),
+            D3DLOCK_DISCARD,
+            D3DPOOL_DEFAULT,
+            None,
+            RECOVERY_SHAPE
+        ),
+        LockAction::FreshBox {
+            preserve: PreserveKind::None
+        }
+    );
+    assert_eq!(
+        decide_lock_action(
+            backing.has_readers(),
+            D3DLOCK_DISCARD,
+            D3DPOOL_MANAGED,
+            None,
+            RECOVERY_SHAPE
+        ),
+        LockAction::FreshBox {
+            preserve: PreserveKind::Cpu
+        }
+    );
+    let partial = Some(DirtyRect {
+        x: 1,
+        y: 1,
+        w: 2,
+        h: 2,
+    });
+    assert_eq!(
+        decide_lock_action(
+            backing.has_readers(),
+            0,
+            D3DPOOL_MANAGED,
+            partial,
+            RECOVERY_SHAPE
+        ),
+        LockAction::WriteInPlace
+    );
+    assert_eq!(
+        decide_lock_action(
+            backing.has_readers(),
+            0,
+            D3DPOOL_MANAGED,
+            partial,
+            MipShape {
+                block_w: 4,
+                block_h: 4,
+                ..RECOVERY_SHAPE
+            }
+        ),
+        LockAction::FreshBox {
+            preserve: PreserveKind::Cpu
+        }
+    );
+}
 
 fn rect(x: u32, y: u32, w: u32, h: u32) -> DirtyRect {
     DirtyRect { x, y, w, h }
@@ -50,7 +290,7 @@ fn decide(
     coh: u64,
     block: (u32, u32),
 ) -> LockAction {
-    decide_lock_action(coh, slot, flags, pool, rect, shape(block))
+    decide_lock_action(is_in_flight(slot, coh), flags, pool, rect, shape(block))
 }
 
 // ── flag-priority arms (uncompressed) ──
@@ -466,8 +706,7 @@ fn compressed_partial_extends_to_mip_edge_in_place() {
     // it lands in the alignment-guard arm. Expect WriteInPlace.
     assert_eq!(
         decide_lock_action(
-            COHERENT,
-            IN_FLIGHT_SEQ,
+            is_in_flight(IN_FLIGHT_SEQ, COHERENT),
             DEFAULT_FLAGS,
             D3DPOOL_DEFAULT,
             Some(DirtyRect {
@@ -490,8 +729,7 @@ fn compressed_partial_extends_to_mip_edge_in_place() {
     // half. r.h=6 reaches mip_h=6 with non-multiple-of-4 height.
     assert_eq!(
         decide_lock_action(
-            COHERENT,
-            IN_FLIGHT_SEQ,
+            is_in_flight(IN_FLIGHT_SEQ, COHERENT),
             DEFAULT_FLAGS,
             D3DPOOL_DEFAULT,
             Some(DirtyRect {

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -27,7 +27,7 @@ use mtld3d_core::{
     format::map_d3d_format,
     gpu_caps::GpuCaps,
     ids::{BufferId, DepthStencilKey, ProgramId, SamplerKey, TextureId},
-    page_box::PageBox,
+    page_box::{PageBox, PageBoxRead},
     passes::{
         ColorClearOutcome, ColorLoad, DepthClearOutcome, DepthLoad, DepthResolve, ExtraColorSlot,
         LastBoundCache, Pass, PassState, SnapshotBytesCache, StencilClearOutcome, StencilLoad,
@@ -325,7 +325,7 @@ pub struct ColorFillTarget {
 /// signature to a single argument.
 pub struct TextureUploadJob {
     pub info: TextureInfo,
-    pub arc: Arc<PageBox>,
+    pub staging: PageBoxRead,
     pub level: u32,
     /// Destination array slice.
     ///
@@ -555,27 +555,25 @@ pub struct TextureGpuState {
 
 /// Frame-lifetime retention for blit-source PE-heap staging.
 ///
-/// Each entry keeps one `Arc<PageBox>` alive from blit-encode time
+/// Each entry keeps one staging read alive from blit-encode time
 /// through GPU retirement of the owning command buffer, keyed by the
 /// frame's `submit_seq`. Drained FIFO in `begin_frame` once the seq is ≤
 /// `coherent_seq`.
-struct PendingBlitArc {
+struct PendingBlitRead {
     submit_seq: u64,
-    arc: Arc<PageBox>,
+    read: PageBoxRead,
 }
 
-impl PendingBlitArc {
-    const fn new(submit_seq: u64, arc: Arc<PageBox>) -> Self {
-        Self { submit_seq, arc }
+impl PendingBlitRead {
+    const fn new(submit_seq: u64, read: PageBoxRead) -> Self {
+        Self { submit_seq, read }
     }
 
     /// Strong-count probe used by the reclaim loop's debug checks.
     ///
-    /// Also ensures the `arc` field stays `#[warn(dead_code)]`-clean
-    /// — the field's real job is to keep the Box alive until drop,
-    /// which rustc doesn't count as a "read".
+    /// Includes the guard's owning reference to the backing allocation.
     fn strong_count(&self) -> usize {
-        Arc::strong_count(&self.arc)
+        Arc::strong_count(self.read.backing())
     }
 
     /// Byte length of the retained staging Box.
@@ -583,7 +581,7 @@ impl PendingBlitArc {
     /// Used by the reclaim loop to decrement `tex_staging_retained_bytes`
     /// by the exact amount the matching submit-time push added.
     fn byte_len(&self) -> usize {
-        self.arc.len()
+        self.read.backing().len()
     }
 }
 
@@ -952,16 +950,16 @@ pub struct FrameEncoder {
     /// group so the trace node and the `[dump] draw N` line name each other.
     /// `None` outside a dump; cleared in `begin_frame`.
     dump_draw: Option<u32>,
-    /// Arc clones of staging `PageBoxes` referenced by blits emitted this frame.
+    /// Read guards for staging referenced by blits emitted this frame.
     ///
     /// Moved into `pending_blit_retention` at submit time with the frame's
     /// `submit_seq`; drained from `pending_blit_retention` in `begin_frame`
     /// once `coherent_seq` catches up.
-    current_blit_retention: Vec<Arc<PageBox>>,
-    /// Prior frames' retained staging Arcs, keyed by `submit_seq`.
+    current_blit_retention: Vec<PageBoxRead>,
+    /// Prior frames' staging read guards, keyed by `submit_seq`.
     ///
     /// Entries drop when their seq is ≤ the latest `coherent_seq`.
-    pending_blit_retention: VecDeque<PendingBlitArc>,
+    pending_blit_retention: VecDeque<PendingBlitRead>,
     /// Pointer to the shared `coherent_seq` atomic, copied from `FrameData` in `begin_frame`.
     ///
     /// Read on the encoder thread to drain `pending_blit_retention`. 0
@@ -1499,6 +1497,7 @@ struct StagedUploadRetry {
 struct HeldBackings {
     pageboxes: Vec<PageBox>,
     staging_arcs: Vec<Arc<PageBox>>,
+    staging_reads: Vec<PageBoxRead>,
 }
 
 /// Intersect a D3D9 `RECT` `(x1, y1, x2, y2)` with the viewport `(x, y, w, h)`.
@@ -6391,8 +6390,7 @@ impl FrameEncoder {
             .map(mtld3d_core::upload_recovery::PendingUpload::into_payload)
             .collect();
         self.free_stage_upload_transients(freed);
-        // Texture jobs own only a staging Arc clone, so dropping them here
-        // is the whole release.
+        // Dropping each acknowledged job releases its read guard.
         drop(
             self.pending_texture_uploads
                 .release_acknowledged(settled, failed),
@@ -6401,9 +6399,9 @@ impl FrameEncoder {
 
     /// Settle the texture half of the upload recovery.
     ///
-    /// Cheaper than the VB/IB half: the job holds a clone of the texture's
-    /// own staging `Arc` rather than a private snapshot, so a released entry
-    /// frees only the clone and a replay re-reads the same pages the
+    /// Cheaper than the VB/IB half: the job holds a read of the texture's
+    /// own staging rather than a private snapshot, so a released entry
+    /// drops the guard and a replay re-reads the same pages the
     /// original upload did (the cached per-mip `MTLBuffer` still wraps
     /// them, so it is a cache hit). When the PE side has since swapped that
     /// `Arc` for a fresh box, the newer upload's own entry orders after this
@@ -6446,8 +6444,7 @@ impl FrameEncoder {
                         "the aborted-submit replay emitted nothing",
                     );
                 }
-                // Acknowledged: dropping the job releases the staging Arc
-                // clone, which is all the entry owns.
+                // Acknowledged: dropping the job releases its staging read.
                 UploadFate::Released => {}
             }
         }
@@ -6580,8 +6577,8 @@ impl FrameEncoder {
 
     /// Drain `pending_blit_retention` entries whose `submit_seq` has been retired by the GPU.
     ///
-    /// Arcs drop here, bringing staging Box refcounts back to 1 (sole
-    /// owner: the texture's `TextureInner`).
+    /// A recovery job may still read these pages again after the emitted read
+    /// retires, so its guard is independent of this queue.
     fn reclaim_retired_blit_retention(&mut self) {
         if self.coherent_seq_ptr == 0 {
             return;
@@ -6594,8 +6591,7 @@ impl FrameEncoder {
             if front.submit_seq > coh {
                 break;
             }
-            // Arc drops here — staging Box refcount falls back to 1
-            // (the texture's TextureInner remains the sole owner).
+            // Release this emitted read; a replayable job retains its own guard.
             let entry = self
                 .pending_blit_retention
                 .pop_front()
@@ -6718,8 +6714,8 @@ impl FrameEncoder {
     ///
     /// Every path wraps the staging Box in a Shared `MTLBuffer` (lazy on
     /// first upload, cached per mip); the blit paths emit a
-    /// `BlitCopyBufferToTexture` into `frame_blit_commands`. The
-    /// `job.arc` clone is retained in `current_blit_retention` so the
+    /// `BlitCopyBufferToTexture` into `frame_blit_commands`.
+    /// A staging read is retained in `current_blit_retention` so the
     /// Box stays alive until the GPU retires the frame — blit reads
     /// happen at command-buffer execution time, long after this
     /// function returns.
@@ -6776,8 +6772,8 @@ impl FrameEncoder {
             // this answer may let it go.
             job.redirty.note_emitted(job.emitted_answer());
             // Keep the job so an aborted upload command buffer can replay
-            // it. It only holds a clone of the texture's own persistent
-            // staging Arc, so the memory cost is the clone.
+            // it. Its guard keeps writable whole-level locks renaming while
+            // the job remains replayable, even after its first submit retires.
             self.pending_texture_uploads.push(
                 job.info.texture_id.raw(),
                 self.current_submit_seq,
@@ -6965,7 +6961,7 @@ impl FrameEncoder {
             return outcome;
         }
         let _t = mtld3d_core::perf::CycleAddTimer::start(self.op_sub_cycles_ptr(OpSub::TexRaw));
-        let backing_length = job.arc.len() as u64;
+        let backing_length = job.staging.backing().len() as u64;
         if backing_length == 0 {
             return false;
         }
@@ -6976,8 +6972,11 @@ impl FrameEncoder {
         // not pixel rows: it turns `region_h` into the row count the GPU
         // actually reads, both for the alignment-pad repack below and for
         // the slice size the copy is given.
-        let staging_buffer_handle =
-            self.get_or_create_staging_buffer(job.info.texture_id, job.staging_index, &job.arc);
+        let staging_buffer_handle = self.get_or_create_staging_buffer(
+            job.info.texture_id,
+            job.staging_index,
+            job.staging.backing(),
+        );
         if staging_buffer_handle == 0 {
             return false;
         }
@@ -7075,7 +7074,7 @@ impl FrameEncoder {
         // behaviour is officially undefined. Repack the affected rows
         // into a transient padded MTLBuffer and aim the blit there.
         let info = if info.bytes_per_row < self.gpu_caps.min_linear_texture_align {
-            match self.repack_blit_source_padded(&job.arc, &info, num_blit_rows) {
+            match self.repack_blit_source_padded(job.staging.backing(), &info, num_blit_rows) {
                 Some(padded_info) => padded_info,
                 None => return false,
             }
@@ -7106,12 +7105,13 @@ impl FrameEncoder {
         self.perf.bump_texture_blit_upload();
         // Retain the staging Box for the GPU's view of this frame —
         // even on the padded path the source bytes were just copied
-        // out, but keeping the Arc alive is harmless and uniform.
-        // `pending_blit_retention` releases this clone once
-        // `coherent_seq >= submit_seq`; the caller's own clone in
+        // out, but keeping the read guard is conservative and uniform.
+        // `pending_blit_retention` releases this read once
+        // `coherent_seq >= submit_seq`; the caller's own guard in
         // `pending_texture_uploads` outlives it by however long the
         // upload takes to be acknowledged.
-        self.current_blit_retention.push(Arc::clone(&job.arc));
+        self.current_blit_retention
+            .push(PageBoxRead::new(Arc::clone(job.staging.backing())));
         true
     }
 
@@ -7139,7 +7139,7 @@ impl FrameEncoder {
             return outcome;
         }
         let _t = mtld3d_core::perf::CycleAddTimer::start(self.op_sub_cycles_ptr(OpSub::TexRaw));
-        let backing_length = job.arc.len() as u64;
+        let backing_length = job.staging.backing().len() as u64;
         if backing_length == 0 {
             return false;
         }
@@ -7155,8 +7155,11 @@ impl FrameEncoder {
         let mip_w = (job.info.width.max(1) >> job.level).max(1);
         let mip_h = (job.info.height.max(1) >> job.level).max(1);
 
-        let staging_buffer_handle =
-            self.get_or_create_staging_buffer(job.info.texture_id, job.staging_index, &job.arc);
+        let staging_buffer_handle = self.get_or_create_staging_buffer(
+            job.info.texture_id,
+            job.staging_index,
+            job.staging.backing(),
+        );
         if staging_buffer_handle == 0 {
             return false;
         }
@@ -7182,7 +7185,7 @@ impl FrameEncoder {
         // widen the slice stride to the padded row stride.
         let info = if info.bytes_per_row < self.gpu_caps.min_linear_texture_align {
             let total_rows = region_rows.saturating_mul(depth);
-            match self.repack_blit_source_padded(&job.arc, &info, total_rows) {
+            match self.repack_blit_source_padded(job.staging.backing(), &info, total_rows) {
                 Some(mut padded_info) => {
                     padded_info.bytes_per_image =
                         padded_info.bytes_per_row.saturating_mul(region_rows);
@@ -7199,7 +7202,8 @@ impl FrameEncoder {
             .push(BlitCommand::copy_buffer_to_texture(&info));
         self.flags.insert(FrameEncoderFlags::BLIT_CMDS_NEED_ENCODER);
         self.perf.bump_texture_blit_upload();
-        self.current_blit_retention.push(Arc::clone(&job.arc));
+        self.current_blit_retention
+            .push(PageBoxRead::new(Arc::clone(job.staging.backing())));
         true
     }
 
@@ -7271,7 +7275,7 @@ impl FrameEncoder {
         decode: UploadDecode,
     ) -> bool {
         let _t = mtld3d_core::perf::CycleAddTimer::start(self.op_sub_cycles_ptr(OpSub::TexRaw));
-        let backing_length = job.arc.len() as u64;
+        let backing_length = job.staging.backing().len() as u64;
         if backing_length == 0 || job.bytes_per_pixel != decode.bytes_per_texel() {
             return false;
         }
@@ -7279,8 +7283,11 @@ impl FrameEncoder {
         if pipeline == 0 {
             return false;
         }
-        let staging_buffer_handle =
-            self.get_or_create_staging_buffer(job.info.texture_id, job.staging_index, &job.arc);
+        let staging_buffer_handle = self.get_or_create_staging_buffer(
+            job.info.texture_id,
+            job.staging_index,
+            job.staging.backing(),
+        );
         if staging_buffer_handle == 0 {
             return false;
         }
@@ -7336,7 +7343,8 @@ impl FrameEncoder {
         self.perf.bump_texture_expand_upload();
         // The pass reads the staging at command-buffer execution time, long
         // after this returns; hold the Box for the GPU's view of the frame.
-        self.current_blit_retention.push(Arc::clone(&job.arc));
+        self.current_blit_retention
+            .push(PageBoxRead::new(Arc::clone(job.staging.backing())));
         true
     }
 
@@ -7999,11 +8007,10 @@ impl FrameEncoder {
             self.sub_retained_bytes(retry.page_box.len());
             held.pageboxes.push(retry.page_box);
         }
-        // Texture jobs own only a clone of the texture's staging Arc; park
-        // it with the other staging keepalives so it outlives the bulk
-        // destroy of the `MTLBuffer`s that wrap those pages.
+        // Park the jobs' guards with the other staging keepalives until
+        // the bulk destroy releases every wrapper around their pages.
         for entry in self.pending_texture_uploads.drain_all() {
-            held.staging_arcs.push(entry.into_payload().arc);
+            held.staging_reads.push(entry.into_payload().staging);
         }
 
         // 3. Bulk destroys for live caches. Pipelines reference functions,
@@ -8104,7 +8111,7 @@ impl FrameEncoder {
     /// boundary, and the next `begin_frame` reopens it against the fresh
     /// buffer, so the drain takes the buffers and leaves the open set. Does
     /// NOT touch the
-    /// `pending_blit_retention` / `current_blit_retention` Arcs (those must
+    /// `pending_blit_retention` / `current_blit_retention` guards (those must
     /// outlive the bulk destroy of the staging `MTLBuffers` that wrap them
     /// via `bytesNoCopy`). Caller drops the returned `HeldBackings` after
     /// `destroy_resources_bulk`.
@@ -9538,7 +9545,7 @@ fn finalize_submit(enc: &mut FrameEncoder, frame: &FrameData) -> (SubmitFramePar
     // keeps them alive regardless of which thread later runs the blits, so
     // this is safe to do here before handing the payload off.
     retire_visibility_buffer(enc, frame.submit_seq);
-    retire_blit_arcs(enc, frame.submit_seq);
+    retire_blit_reads(enc, frame.submit_seq);
 
     (params, payload)
 }
@@ -9854,18 +9861,18 @@ fn retire_visibility_buffer(enc: &mut FrameEncoder, submit_seq: u64) {
         });
 }
 
-/// Move this frame's blit-source Arc retentions into the pending queue.
+/// Move this frame's blit-source read guards into the pending queue.
 ///
 /// Keyed by the frame's `submit_seq`. They're released when `coherent_seq`
 /// reaches `submit_seq` — checked next `begin_frame`. Called from
 /// `finalize_submit`, before the thunk is issued: the move into
-/// `pending_blit_retention` is what keeps the Arcs alive across the blit
+/// `pending_blit_retention` keeps the reads alive across the blit
 /// encode + commit path, whichever thread runs it.
-fn retire_blit_arcs(enc: &mut FrameEncoder, submit_seq: u64) {
-    for arc in enc.current_blit_retention.drain(..) {
-        enc.perf.bump_tex_staging_retained_add(arc.len());
+fn retire_blit_reads(enc: &mut FrameEncoder, submit_seq: u64) {
+    for read in enc.current_blit_retention.drain(..) {
+        enc.perf.bump_tex_staging_retained_add(read.backing().len());
         enc.pending_blit_retention
-            .push_back(PendingBlitArc::new(submit_seq, arc));
+            .push_back(PendingBlitRead::new(submit_seq, read));
     }
 }
 

--- a/windows/d3d9/src/texture.rs
+++ b/windows/d3d9/src/texture.rs
@@ -6,7 +6,7 @@ use mtld3d_core::{
     format::block_row_pitch,
     ids::TextureId,
     level_authority::{LevelAuthorityMask, WritePlan},
-    page_box::PageBox,
+    page_box::{PageBox, PageBoxRead},
     pixel_convert,
     render_scale::RenderScale,
     staging_coverage::StagingCoverage,
@@ -2239,14 +2239,10 @@ impl TextureInner {
 
         let coherent_seq = self.staging_coherent_seq(level);
         let last_submit_seq = self.cube.as_deref()?.last_submit_seq[index];
-        let action = decide_lock_action(
-            coherent_seq,
-            last_submit_seq,
-            flags,
-            self.d3d_pool,
-            rect,
-            self.mip_shape(level),
-        );
+        let contended = is_in_flight(last_submit_seq, coherent_seq)
+            || self.cube.as_deref()?.staging[index].has_readers();
+        let action =
+            decide_lock_action(contended, flags, self.d3d_pool, rect, self.mip_shape(level));
         let device_inner = self.device_inner;
         let texture_id = self.texture_id;
         let cube = self.cube.as_deref_mut()?;
@@ -2255,10 +2251,7 @@ impl TextureInner {
                 // The kept divergence, counted like its VB/IB twin: a
                 // contended partial Lock handed back over bytes an upload
                 // may still be reading (README, "Faster than conformant").
-                if flags & D3DLOCK_NOOVERWRITE == 0
-                    && is_in_flight(last_submit_seq, coherent_seq)
-                    && device_inner != 0
-                {
+                if flags & D3DLOCK_NOOVERWRITE == 0 && contended && device_inner != 0 {
                     DeviceInner::from_ptr(device_inner)
                         .perf_mut()
                         .bump_texture_write_in_place_contended();
@@ -2486,14 +2479,10 @@ impl TextureInner {
         // command buffer that upload rides decides which retirement counter
         // frees it. See `staging_coherent_seq`.
         let coherent_seq = self.staging_coherent_seq(level);
-        let action = decide_lock_action(
-            coherent_seq,
-            self.last_submit_seq[level],
-            flags,
-            self.d3d_pool,
-            rect,
-            self.mip_shape(level),
-        );
+        let contended = is_in_flight(self.last_submit_seq[level], coherent_seq)
+            || self.staging[level].has_readers();
+        let action =
+            decide_lock_action(contended, flags, self.d3d_pool, rect, self.mip_shape(level));
 
         let base: *mut u8 = match action {
             LockAction::WriteInPlace => {
@@ -2515,10 +2504,7 @@ impl TextureInner {
                 // bytes an upload may still be reading (README, "Faster
                 // than conformant"). READONLY returned above and an
                 // uncontended Lock is the specified behaviour.
-                if flags & D3DLOCK_NOOVERWRITE == 0
-                    && is_in_flight(self.last_submit_seq[level], coherent_seq)
-                    && self.device_inner != 0
-                {
+                if flags & D3DLOCK_NOOVERWRITE == 0 && contended && self.device_inner != 0 {
                     DeviceInner::from_ptr(self.device_inner)
                         .perf_mut()
                         .bump_texture_write_in_place_contended();
@@ -4140,7 +4126,7 @@ pub fn schedule_upload(ti: &mut TextureInner, dev: &mut DeviceInner, level: u32,
     let upload_generation = ti.next_upload_generation(level_u);
     let job = TextureUploadJob {
         info: ti.texture_info(),
-        arc: ti.staging_arc(level_u),
+        staging: PageBoxRead::new(ti.staging_arc(level_u)),
         level,
         destination_slice: 0,
         staging_index: level_u,
@@ -4206,12 +4192,12 @@ fn schedule_cube_upload(
         rect.h
     );
     let cube = ti.cube.as_deref_mut().expect("cube storage");
-    let arc = Arc::clone(&cube.staging[index]);
+    let staging = PageBoxRead::new(Arc::clone(&cube.staging[index]));
     cube.last_submit_seq[index] = dev.current_seq();
     cube.was_uploaded[index] = true;
     let job = TextureUploadJob {
         info: ti.texture_info(),
-        arc,
+        staging,
         level,
         destination_slice: face,
         staging_index: index,


### PR DESCRIPTION
A whole-level writable LockRect could overwrite an upload's staging after its original submit retired, while the recovery queue still retained that allocation for replay. This also affected newer uploads replayed to preserve texture write order, and successfully retired uploads retained when a later submit failed.

Track queued and emitted reads separately from cached buffer ownership. Texture jobs hold read guards until recovery releases them, and each emitted upload retains its own guard through GPU retirement. 2D and cube locks rename while readers remain. Cached wrappers alone permit reuse; existing lock flags, partial-lock policy and volume write policy stay unchanged.

Conservative Arc contention also preserves the payload, but cached wrappers keep it contended after readers finish. A controlled 1,000-lock comparison of 64 KiB staging copied 65,536,000 bytes with that policy and zero with explicit readers once uploads were acknowledged. Both policies copied while jobs remained replayable. These are native copy counts, not game performance measurements.

Four controlled native payload tests fail before the change and pass with the production guard, recovery queue and lock policy. No hardware GPU abort was induced. make fmt, make check and make test-unit pass, including 1,118 Windows host tests and 306 Unix/shared/runner tests. The final integrated candidate passes make check, make ISOLATED=1 test and make ISOLATED=1 conformance, with no conformance regressions or baseline changes.

Rules check: CONTRIBUTING.md's before/after evidence, native checks and final runtime gates pass. CONVENTIONS.md's formatting, Clippy, audit and documentation checks pass. The guard adds one atomic field to PageBox without a new process static, config key, wire field, dependency, derive, suppression, duplicate rename helper or per-job allocation. ARCHITECTURE.md's API-thread and backing-lifetime contracts remain intact, including emitted readers surviving job abandonment and wrappers being destroyed before backing release.

Closes #554
