### PR TITLE
Reject failed texture readbacks and preserve retry state

### DIFF
--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -23,7 +23,7 @@ use mtld3d_shared::{
     perf::NanosSetTimer,
 };
 use objc2::{rc::Retained, runtime::ProtocolObject};
-use objc2_foundation::NSRange;
+use objc2_foundation::{NSError, NSRange};
 use objc2_metal::{
     MTLBlitCommandEncoder, MTLBuffer, MTLClearColor, MTLCommandBuffer, MTLCommandBufferStatus,
     MTLCommandEncoder, MTLCommandQueue, MTLCullMode, MTLDevice, MTLDrawable, MTLIndexType,
@@ -272,7 +272,12 @@ fn record_failed_submit(
         let atomic = unsafe { &*(failed_submit_seq_ptr as *const AtomicU64) };
         atomic.fetch_max(seq, Ordering::Release);
     }
-    Some(cb.error().map_or_else(
+    Some(command_buffer_error(cb.error().as_deref()))
+}
+
+/// Preserve the driver description shared by frame and readback failure diagnostics.
+fn command_buffer_error(error: Option<&NSError>) -> (u64, String) {
+    error.map_or_else(
         || (0, String::new()),
         |e| {
             (
@@ -280,7 +285,7 @@ fn record_failed_submit(
                 e.localizedDescription().to_string(),
             )
         },
-    ))
+    )
 }
 
 // SubmitFrame breadcrumb probes via `mtld3d_shared::crumb!()`. Each
@@ -3096,13 +3101,12 @@ fn encode_readback_resolve(
 /// Synchronous texture→buffer readback into PE-addressable memory.
 ///
 /// Wraps the caller's page-aligned `dst_ptr / dst_len` via
-/// `newBufferWithBytesNoCopy:length:options:deallocator:` (Shared), blits
+/// `newBufferWithBytesNoCopy:length:options:deallocator:` (Managed), blits
 /// the source texture sub-rect at `mip_level` into it at `bytes_per_row`
-/// stride, commits, and waits for completion. On return the caller's
-/// memory holds the pixels. Ordering against a prior `submit_frame` call
-/// on the same `queue_handle` is guaranteed by Metal's in-order queue
-/// execution — this command buffer will not start until the previously
-/// committed render command buffer has finished.
+/// stride, commits, and waits for completion. Only a true return guarantees
+/// the caller's memory holds the requested pixels. Metal orders this command
+/// buffer after every previously committed buffer on the same `queue_handle`.
+/// A failed readback may have written part of the destination.
 pub fn blit_texture_to_buffer(args: &BlitArgs) -> bool {
     use core::{ffi::c_void, ptr::NonNull};
 
@@ -3284,9 +3288,25 @@ pub fn blit_texture_to_buffer(args: &BlitArgs) -> bool {
     blit.endEncoding();
     cmd_buf.commit();
     cmd_buf.waitUntilCompleted();
-    // dst_buffer drops here — Metal wrapper released, caller's memory
-    // untouched (deallocator was None).
-    true
+    // The wrapper owns no pages; the caller keeps the destination allocation.
+    readback_completed(cmd_buf.status(), || cmd_buf.error())
+}
+
+/// Accept a readback only after Metal reports successful completion.
+fn readback_completed(
+    status: MTLCommandBufferStatus,
+    error: impl FnOnce() -> Option<Retained<NSError>>,
+) -> bool {
+    if status == MTLCommandBufferStatus::Completed {
+        return true;
+    }
+    let (code, desc) = command_buffer_error(error().as_deref());
+    error!(
+        target: LOG_TARGET,
+        "blit_texture_to_buffer: command buffer did not complete successfully \
+         (status {status:?}, code {code}: {desc}); readback failed"
+    );
+    false
 }
 
 #[cfg(test)]

--- a/unix/unix/src/metal/command/tests.rs
+++ b/unix/unix/src/metal/command/tests.rs
@@ -34,8 +34,11 @@ use mtld3d_shared::{
     ExtraColorDesc, MetalHandle, PassDescriptor, SubmitFrameParams,
     mtl::{BlockLayout, DepthResolveFilter, LoadAction, PixelFormat, StoreAction},
 };
-use objc2::{rc::Retained, runtime::ProtocolObject};
-use objc2_foundation::NSString;
+use objc2::{
+    rc::Retained,
+    runtime::{AnyObject, ProtocolObject},
+};
+use objc2_foundation::{NSDictionary, NSError, NSLocalizedDescriptionKey, NSString};
 use objc2_metal::{
     MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder,
     MTLCommandQueue, MTLCreateSystemDefaultDevice, MTLDevice, MTLOrigin, MTLPixelFormat,
@@ -45,9 +48,10 @@ use objc2_metal::{
 
 use super::{
     CopyBufferEndpoint, CopyEndpoint, CopyRegion, CopyRejectReason, PENDING_CMDBUFS, PendingCmdBuf,
-    PresentGeometry, PresentRoute, SETTLED_PRESENTS, copy_buffer_to_texture_reject,
-    copy_texture_reject, copy_texture_to_buffer_reject, first_pending, geometry_settled,
-    present_route, submit_frame, submit_frame_with, submit_upload_cmd_buf, wait_for_gpu_retire,
+    PresentGeometry, PresentRoute, SETTLED_PRESENTS, command_buffer_error,
+    copy_buffer_to_texture_reject, copy_texture_reject, copy_texture_to_buffer_reject,
+    first_pending, geometry_settled, present_route, readback_completed, submit_frame, submit_frame_with,
+    submit_upload_cmd_buf, wait_for_gpu_retire,
 };
 
 /// Two device identities that sort either side of each other's seqs.
@@ -1084,4 +1088,51 @@ fn upload_test_pixel(
     assert_eq!(cmd.status(), MTLCommandBufferStatus::Completed);
     // SAFETY: the shared buffer holds the completed four-byte pixel copy.
     unsafe { buffer.contents().cast::<[u8; 4]>().read() }
+}
+
+/// Completion is success only for the successful terminal state.
+#[test]
+fn readback_completion_rejects_failed_and_unfinished_states() {
+    for status in [
+        MTLCommandBufferStatus::NotEnqueued,
+        MTLCommandBufferStatus::Enqueued,
+        MTLCommandBufferStatus::Committed,
+        MTLCommandBufferStatus::Scheduled,
+        MTLCommandBufferStatus::Error,
+    ] {
+        assert!(!readback_completed(status, || None), "{status:?}");
+    }
+    assert!(readback_completed(
+        MTLCommandBufferStatus::Completed,
+        || { panic!("a successful readback must not fetch error diagnostics") }
+    ));
+}
+
+/// A real `NSError` crosses the same completion decision without any GPU submission.
+#[test]
+fn readback_completion_preserves_driver_error_details() {
+    let description = "Caused GPU Hang Error (00000003:kIOAccelCommandBufferCallbackErrorHang)";
+    let value = NSString::from_str(description);
+    // SAFETY: Foundation exports this immutable NSString key.
+    let key = unsafe { NSLocalizedDescriptionKey };
+    let info = NSDictionary::from_slices(&[key], &[AsRef::<AnyObject>::as_ref(&*value)]);
+    // SAFETY: the user-info dictionary contains an NSString under the description key.
+    let error = unsafe {
+        NSError::errorWithDomain_code_userInfo(
+            &NSString::from_str("MTLCommandBufferErrorDomain"),
+            2,
+            Some(&info),
+        )
+    };
+    assert_eq!(
+        command_buffer_error(Some(&error)),
+        (2, description.to_owned())
+    );
+    assert_eq!(command_buffer_error(None), (0, String::new()));
+    let mut inspected = false;
+    assert!(!readback_completed(MTLCommandBufferStatus::Error, || {
+        inspected = true;
+        Some(error)
+    }));
+    assert!(inspected, "a failed readback must inspect its driver error");
 }

--- a/unix/unix/src/metal/command/tests.rs
+++ b/unix/unix/src/metal/command/tests.rs
@@ -50,8 +50,8 @@ use super::{
     CopyBufferEndpoint, CopyEndpoint, CopyRegion, CopyRejectReason, PENDING_CMDBUFS, PendingCmdBuf,
     PresentGeometry, PresentRoute, SETTLED_PRESENTS, command_buffer_error,
     copy_buffer_to_texture_reject, copy_texture_reject, copy_texture_to_buffer_reject,
-    first_pending, geometry_settled, present_route, readback_completed, submit_frame, submit_frame_with,
-    submit_upload_cmd_buf, wait_for_gpu_retire,
+    first_pending, geometry_settled, present_route, readback_completed, submit_frame,
+    submit_frame_with, submit_upload_cmd_buf, wait_for_gpu_retire,
 };
 
 /// Two device identities that sort either side of each other's seqs.

--- a/windows/core/src/level_authority.rs
+++ b/windows/core/src/level_authority.rs
@@ -4,8 +4,8 @@
 //! destination's Metal texture and never its CPU staging, so from that point
 //! the subresource's pixels live on the GPU alone. Every path that writes a
 //! subresource's staging asks [`LevelAuthorityMask::plan_write`] what to do
-//! about that first, and the answer records that the staging defines the
-//! subresource once the write lands.
+//! about that first, then calls [`LevelAuthorityMask::staging_wrote`] only
+//! after the staging contains the subresource's pixels.
 //!
 //! A subresource is a (face, level) pair: a 2D or volume texture uses face 0
 //! alone, a cube map all six. Face and level are tracked separately because a
@@ -69,21 +69,27 @@ impl LevelAuthorityMask {
             && self.gpu[face as usize] & (1u32 << level) != 0
     }
 
-    /// Plan a CPU write of `(face, level)` and record that its staging defines it after.
+    /// Plan a CPU write of `(face, level)` without releasing the GPU's claim.
     ///
     /// `whole_level` says the write covers every byte of the subresource. The
-    /// claim is released whichever branch the caller takes, so a read back that
-    /// cannot run costs one diagnostic rather than one per write, and a
-    /// subresource the caller overwrites costs no read back at all.
-    pub const fn plan_write(&mut self, face: u32, level: usize, whole_level: bool) -> WritePlan {
+    /// caller commits with [`Self::staging_wrote`] after a successful readback
+    /// or overwrite. A failed attempt leaves the GPU's pixels available for retry.
+    #[must_use]
+    pub const fn plan_write(&self, face: u32, level: usize, whole_level: bool) -> WritePlan {
         if !self.gpu_holds(face, level) {
             return WritePlan::WriteStaging;
         }
-        self.gpu[face as usize] &= !(1u32 << level);
         if whole_level {
             WritePlan::Overwrite
         } else {
             WritePlan::ReadBackFirst
+        }
+    }
+
+    /// Record that staging holds the complete contents of `(face, level)`.
+    pub const fn staging_wrote(&mut self, face: u32, level: usize) {
+        if face < FACE_COUNT && level < u32::BITS as usize {
+            self.gpu[face as usize] &= !(1u32 << level);
         }
     }
 }

--- a/windows/core/src/level_authority/tests.rs
+++ b/windows/core/src/level_authority/tests.rs
@@ -12,7 +12,7 @@ fn a_fresh_mask_leaves_every_subresource_to_the_staging() {
 
 #[test]
 fn a_write_of_an_unclaimed_level_is_served_from_staging() {
-    let mut mask = LevelAuthorityMask::new();
+    let mask = LevelAuthorityMask::new();
     assert_eq!(mask.plan_write(0, 0, false), WritePlan::WriteStaging);
     assert_eq!(mask.plan_write(0, 0, true), WritePlan::WriteStaging);
 }
@@ -41,6 +41,7 @@ fn a_whole_level_write_releases_the_claim() {
     let mut mask = LevelAuthorityMask::new();
     mask.gpu_wrote(0, 0);
     assert_eq!(mask.plan_write(0, 0, true), WritePlan::Overwrite);
+    mask.staging_wrote(0, 0);
     assert!(
         !mask.gpu_holds(0, 0),
         "the whole-level write released the claim"
@@ -57,6 +58,7 @@ fn a_read_back_releases_the_claim() {
     let mut mask = LevelAuthorityMask::new();
     mask.gpu_wrote(0, 3);
     assert_eq!(mask.plan_write(0, 3, false), WritePlan::ReadBackFirst);
+    mask.staging_wrote(0, 3);
     assert!(!mask.gpu_holds(0, 3));
     assert_eq!(mask.plan_write(0, 3, false), WritePlan::WriteStaging);
 }
@@ -96,6 +98,7 @@ fn a_write_of_one_face_leaves_the_others_claimed() {
         mask.gpu_wrote(face, 2);
     }
     assert_eq!(mask.plan_write(1, 2, true), WritePlan::Overwrite);
+    mask.staging_wrote(1, 2);
     assert!(!mask.gpu_holds(1, 2));
     for face in [0, 2, 3, 4, 5] {
         assert!(mask.gpu_holds(face, 2), "face {face}");
@@ -124,4 +127,149 @@ fn a_face_past_the_mask_stays_with_the_staging() {
         mask.plan_write(FACE_COUNT, 0, false),
         WritePlan::WriteStaging
     );
+}
+
+#[test]
+fn failed_materialization_keeps_every_face_and_mip_for_retry() {
+    for face in 0..FACE_COUNT {
+        for level in 0..15 {
+            let mut mask = LevelAuthorityMask::new();
+            mask.gpu_wrote(face, level);
+            assert_eq!(
+                mask.plan_write(face, level, false),
+                WritePlan::ReadBackFirst
+            );
+            // No staging write completed, so the next attempt still needs the GPU.
+            assert!(mask.gpu_holds(face, level), "face {face} level {level}");
+            assert_eq!(
+                mask.plan_write(face, level, false),
+                WritePlan::ReadBackFirst
+            );
+            assert!(
+                mask.gpu_holds(face, level),
+                "retry face {face} level {level}"
+            );
+        }
+    }
+}
+
+#[test]
+fn an_unfinished_whole_overwrite_keeps_the_gpu_copy() {
+    for face in 0..FACE_COUNT {
+        for level in 0..15 {
+            let mut mask = LevelAuthorityMask::new();
+            mask.gpu_wrote(face, level);
+            assert_eq!(mask.plan_write(face, level, true), WritePlan::Overwrite);
+            // A later copy bounds check can reject before the write completes.
+            assert!(mask.gpu_holds(face, level), "face {face} level {level}");
+            assert_eq!(
+                mask.plan_write(face, level, false),
+                WritePlan::ReadBackFirst
+            );
+        }
+    }
+}
+
+#[test]
+fn a_recreated_level_keeps_its_failed_readback_obligation() {
+    let mut mask = LevelAuthorityMask::new();
+    // Freshly allocated staging has no copy of the released level's GPU pixels.
+    mask.gpu_wrote(0, 4);
+    for _ in 0..3 {
+        assert_eq!(mask.plan_write(0, 4, false), WritePlan::ReadBackFirst);
+        assert!(mask.gpu_holds(0, 4));
+    }
+    assert_eq!(mask.plan_write(0, 4, true), WritePlan::Overwrite);
+    assert!(mask.gpu_holds(0, 4));
+}
+
+#[test]
+fn successful_retry_commits_only_its_face_and_mip() {
+    for completed_face in 0..FACE_COUNT {
+        for completed_level in 0..15 {
+            let mut mask = LevelAuthorityMask::new();
+            for face in 0..FACE_COUNT {
+                for level in 0..15 {
+                    mask.gpu_wrote(face, level);
+                }
+            }
+            for readback_completed in [false, false, true] {
+                assert_eq!(
+                    mask.plan_write(completed_face, completed_level, false),
+                    WritePlan::ReadBackFirst
+                );
+                if readback_completed {
+                    mask.staging_wrote(completed_face, completed_level);
+                }
+                for face in 0..FACE_COUNT {
+                    for level in 0..15 {
+                        let committed = readback_completed
+                            && face == completed_face
+                            && level == completed_level;
+                        assert_eq!(mask.gpu_holds(face, level), !committed);
+                    }
+                }
+            }
+            assert_eq!(
+                mask.plan_write(completed_face, completed_level, false),
+                WritePlan::WriteStaging
+            );
+        }
+    }
+}
+
+#[test]
+fn successful_whole_overwrite_commits_only_its_face_and_mip() {
+    let mut mask = LevelAuthorityMask::new();
+    for face in 0..FACE_COUNT {
+        for level in 0..15 {
+            mask.gpu_wrote(face, level);
+        }
+    }
+    assert_eq!(mask.plan_write(3, 7, true), WritePlan::Overwrite);
+    assert!(mask.gpu_holds(3, 7));
+    mask.staging_wrote(3, 7);
+    assert_eq!(mask.plan_write(3, 7, false), WritePlan::WriteStaging);
+    for face in 0..FACE_COUNT {
+        for level in 0..15 {
+            assert_eq!(mask.gpu_holds(face, level), face != 3 || level != 7);
+        }
+    }
+}
+
+#[test]
+fn recreated_staging_is_valid_only_after_successful_retry() {
+    let mut mask = LevelAuthorityMask::new();
+    let mut coverage = crate::staging_coverage::StagingCoverage::new();
+    // Allocation reset coverage before its required readback failed.
+    mask.gpu_wrote(0, 2);
+    for readback_completed in [false, true] {
+        assert!(!coverage.is_full());
+        assert_eq!(mask.plan_write(0, 2, false), WritePlan::ReadBackFirst);
+        if readback_completed {
+            coverage.mark_full();
+            mask.staging_wrote(0, 2);
+        }
+        assert_eq!(coverage.is_full(), readback_completed);
+        assert_eq!(mask.gpu_holds(0, 2), !readback_completed);
+    }
+    assert_eq!(mask.plan_write(0, 2, false), WritePlan::WriteStaging);
+}
+
+#[test]
+fn a_staging_commit_outside_the_mask_changes_no_claim() {
+    let mut mask = LevelAuthorityMask::new();
+    for face in 0..FACE_COUNT {
+        for level in 0..15 {
+            mask.gpu_wrote(face, level);
+        }
+    }
+    mask.staging_wrote(FACE_COUNT, 0);
+    mask.staging_wrote(0, u32::BITS as usize);
+    mask.staging_wrote(u32::MAX, usize::MAX);
+    for face in 0..FACE_COUNT {
+        for level in 0..15 {
+            assert!(mask.gpu_holds(face, level));
+        }
+    }
 }

--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -6203,7 +6203,7 @@ extern "system" fn device_update_surface(
         if !copied {
             mtld3d_shared::log_once_warn!(
                 target: crate::LOG_TARGET,
-                "reject UpdateSurface: source region outside the destination mip → INVALIDCALL"
+                "reject UpdateSurface: staging copy failed → INVALIDCALL"
             );
             return D3DERR_INVALIDCALL;
         }
@@ -6248,7 +6248,7 @@ extern "system" fn device_update_surface(
         if !copied {
             mtld3d_shared::log_once_warn!(
                 target: crate::LOG_TARGET,
-                "reject UpdateSurface: source region outside the destination mip → INVALIDCALL"
+                "reject UpdateSurface: staging copy failed → INVALIDCALL"
             );
             return D3DERR_INVALIDCALL;
         }
@@ -6332,15 +6332,15 @@ extern "system" fn device_update_texture(
                     let sw = src.mip_width(src_level);
                     let sh = src.mip_height(src_level);
                     let Some(c) = dr.clamp(sw, sh) else { continue };
-                    if c.x == 0 && c.y == 0 && c.w >= sw && c.h >= sh {
-                        let _ = dst.update_cube_sub_region_from(
+                    let copied = if c.x == 0 && c.y == 0 && c.w >= sw && c.h >= sh {
+                        dst.update_cube_sub_region_from(
                             (face, level),
                             src,
                             face,
                             src_level,
                             None,
                             (0, 0),
-                        );
+                        )
                     } else {
                         let rect = (
                             c.x.cast_signed(),
@@ -6348,14 +6348,19 @@ extern "system" fn device_update_texture(
                             (c.x + c.w).cast_signed(),
                             (c.y + c.h).cast_signed(),
                         );
-                        let _ = dst.update_cube_sub_region_from(
+                        dst.update_cube_sub_region_from(
                             (face, level),
                             src,
                             face,
                             src_level,
                             Some(rect),
                             (c.x.cast_signed(), c.y.cast_signed()),
-                        );
+                        )
+                    };
+                    if !copied {
+                        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+                            "reject UpdateTexture: cube staging copy failed → INVALIDCALL");
+                        return D3DERR_INVALIDCALL;
                     }
                 }
             }
@@ -6402,9 +6407,9 @@ extern "system" fn device_update_texture(
             let sw = src.mip_width(src_level);
             let sh = src.mip_height(src_level);
             let Some(c) = dr.clamp(sw, sh) else { continue };
-            if c.x == 0 && c.y == 0 && c.w >= sw && c.h >= sh {
+            let copied = if c.x == 0 && c.y == 0 && c.w >= sw && c.h >= sh {
                 // Whole mip.
-                let _ = dst.update_sub_region_from(level, src, src_level, None, (0, 0));
+                dst.update_sub_region_from(level, src, src_level, None, (0, 0))
             } else {
                 let rect = (
                     c.x.cast_signed(),
@@ -6412,13 +6417,18 @@ extern "system" fn device_update_texture(
                     (c.x + c.w).cast_signed(),
                     (c.y + c.h).cast_signed(),
                 );
-                let _ = dst.update_sub_region_from(
+                dst.update_sub_region_from(
                     level,
                     src,
                     src_level,
                     Some(rect),
                     (c.x.cast_signed(), c.y.cast_signed()),
-                );
+                )
+            };
+            if !copied {
+                mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+                    "reject UpdateTexture: staging copy failed → INVALIDCALL");
+                return D3DERR_INVALIDCALL;
             }
         }
         D3D_OK
@@ -7086,10 +7096,9 @@ extern "system" fn device_stretch_rect(
             .flags
             .contains(StretchSurfaceFlags::IS_OFFSCREEN_PLAIN_DEFAULT)
     {
-        convert_stretch_dst_staging(
+        return convert_stretch_dst_staging(
             &obj, src_surf, dst_surf, &src_info, &dst_info, src_region, dst_region,
         );
-        return D3D_OK;
     }
     let render_quad = scaling || cross_format;
 
@@ -7196,9 +7205,15 @@ fn convert_stretch_dst_staging(
     dst_info: &StretchSurfaceInfo,
     src_region: mtld3d_core::stretch_rect::StretchRegion,
     dst_region: mtld3d_core::stretch_rect::StretchRegion,
-) {
+) -> i32 {
     if src_surf.is_null() || dst_surf.is_null() {
-        return;
+        return D3D_OK;
+    }
+    if !mtld3d_core::pixel_convert::can_convert(src_info.format, dst_info.format) {
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "StretchRect: cross-format offscreen pair (src=0x{:x}, dst=0x{:x}) not CPU-convertible → skipped (HR OK)",
+            src_info.format, dst_info.format);
+        return D3D_OK;
     }
     // SAFETY: caller-supplied live `Direct3DSurface9*` from the StretchRect
     // thunk (non-null checked above).
@@ -7210,7 +7225,7 @@ fn convert_stretch_dst_staging(
             target: crate::LOG_TARGET,
             "StretchRect: cross-format offscreen dst has no distinct texture backing → skipped (HR OK)"
         );
-        return;
+        return D3D_OK;
     }
     // SAFETY: non-null (checked) and a live `Direct3DTexture9` kept alive by
     // the source surface's reference.
@@ -7234,15 +7249,16 @@ fn convert_stretch_dst_staging(
     if !converted {
         mtld3d_shared::log_once_warn!(
             target: crate::LOG_TARGET,
-            "StretchRect: cross-format offscreen pair (src=0x{:x}, dst=0x{:x}) not CPU-convertible → skipped (HR OK)",
+            "StretchRect: cross-format offscreen pair (src=0x{:x}, dst=0x{:x}) staging conversion failed → INVALIDCALL",
             src_info.format,
             dst_info.format
         );
-        return;
+        return D3DERR_INVALIDCALL;
     }
     // Upload the converted staging to the destination's Metal texture, mirroring
     // the GPU blit the same-format offscreen path emits.
     crate::texture::flush_dirty_mips(dst_tex.inner_mut(), obj.inner());
+    D3D_OK
 }
 
 /// Lazy texture upload: flush any pending dirty mips on the surfaces' parent textures.

--- a/windows/d3d9/src/surface.rs
+++ b/windows/d3d9/src/surface.rs
@@ -2693,14 +2693,6 @@ fn lockable_rt_lock_rect(
     if inner.system_memory.is_none() {
         return D3DERR_INVALIDCALL;
     }
-    // Re-locking an already-mapped surface returns INVALIDCALL with the
-    // caller's `D3DLOCKED_RECT` untouched (committed before any out-write).
-    if let Err(hr) = inner.try_begin_lock() {
-        return hr;
-    }
-    // Record the lock flags so `UnlockRect` can skip the staging→GPU upload for
-    // a `D3DLOCK_READONLY` lock (which never wrote the staging).
-    inner.lock_flags = flags;
     let Some(fmt) = mtld3d_core::format::map_d3d_format(inner.standalone_format) else {
         return D3DERR_INVALIDCALL;
     };
@@ -2710,6 +2702,10 @@ fn lockable_rt_lock_rect(
         // never reaches here (CreateRenderTarget rejects it).
         return D3DERR_INVALIDCALL;
     }
+    // Reject an existing mapping before any readback, without publishing a new lock.
+    if let Err(hr) = inner.try_begin_lock() {
+        return hr;
+    }
     // A sub-rect origin steps in whole pixels: `top * pitch + left * bpp`.
     let pitch = mtld3d_core::format::linear_row_pitch(inner.standalone_width, bpp);
     // A read (or read/modify) lock sees the current GPU content: sync the colour
@@ -2717,8 +2713,9 @@ fn lockable_rt_lock_rect(
     // skips it — the app will overwrite the whole surface. The read-back fills
     // the full surface (origin 0,0) so any sub-rect pointer derived below
     // indexes valid bytes.
-    if flags & D3DLOCK_DISCARD == 0 {
-        lockable_rt_readback_fill(inner, bpp);
+    if flags & D3DLOCK_DISCARD == 0 && !lockable_rt_readback_fill(inner, bpp) {
+        let _ = inner.try_end_lock();
+        return D3DERR_INVALIDCALL;
     }
     // SAFETY: `rect` is the *const D3DRECT delivered by LockRect; null → None.
     let (left, top) = unsafe { ValueIn::<D3DRECT>::read_opt(rect) }
@@ -2726,8 +2723,10 @@ fn lockable_rt_lock_rect(
     let to_i = |v: u32| isize::try_from(v).unwrap_or(isize::MAX);
     let offset = top * to_i(pitch) + left * to_i(bpp);
     let Some(page) = inner.system_memory.as_mut() else {
+        let _ = inner.try_end_lock();
         return D3DERR_INVALIDCALL;
     };
+    inner.lock_flags = flags;
     // SAFETY: `locked_rect` is non-null (checked by the caller before entry)
     // and per the D3D9 ABI points to a writable `D3DLOCKED_RECT`.
     let out = unsafe { &mut *locked_rect };
@@ -2742,13 +2741,11 @@ fn lockable_rt_lock_rect(
 ///
 /// The entry point for a caller that has no byte size of its own to pass:
 /// resolves the format's bytes per pixel and defers to
-/// [`lockable_rt_readback_fill`], which leaves the staging alone for a format
-/// with no CPU byte size (unreachable, the surface's creation validated an
-/// uncompressed colour format).
-fn refresh_lockable_rt_staging(inner: &mut SurfaceInner) {
+/// [`lockable_rt_readback_fill`], rejecting a format with no CPU byte size.
+fn refresh_lockable_rt_staging(inner: &mut SurfaceInner) -> bool {
     let bpp = mtld3d_core::format::map_d3d_format(inner.standalone_format)
         .map_or(0, |f| f.bytes_per_pixel());
-    lockable_rt_readback_fill(inner, bpp);
+    lockable_rt_readback_fill(inner, bpp)
 }
 
 /// Read the lockable render target's colour `MTLTexture` back into its CPU staging buffer.
@@ -2759,32 +2756,32 @@ fn refresh_lockable_rt_staging(inner: &mut SurfaceInner) {
 /// `BlitTextureToBuffer` core the backbuffer / `GetRenderTargetData` path
 /// uses. Marks the texture
 /// read-back BEFORE the flush so the store-action optimiser (Rule D) keeps the
-/// rendered content. A blit failure leaves the staging as-is (the zero-init /
-/// prior content) — the lock still succeeds.
-fn lockable_rt_readback_fill(inner: &mut SurfaceInner, bpp: u32) {
+/// rendered content. A failed blit rejects the mapping; staging may contain
+/// only part of the requested pixels.
+fn lockable_rt_readback_fill(inner: &mut SurfaceInner, bpp: u32) -> bool {
     let (width, height) = (inner.standalone_width, inner.standalone_height);
     let tex_handle = inner.live_color_handle();
     if bpp == 0 || width == 0 || height == 0 || tex_handle.is_null() {
         mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
-            "lockable RT read-back skipped: bpp={bpp} extent={width}x{height} color_handle={:#x} (staging left as-is)",
+            "lockable RT read-back skipped: bpp={bpp} extent={width}x{height} color_handle={:#x} (readback failed)",
             tex_handle.raw()
         );
-        return;
+        return false;
     }
     let bytes_per_row = mtld3d_core::format::linear_row_pitch(width, bpp);
     let needed = (bytes_per_row as usize).saturating_mul(height as usize);
     if needed == 0 {
         mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
-            "lockable RT read-back skipped: zero byte size for {width}x{height} at {bpp} bpp (staging left as-is)"
+            "lockable RT read-back skipped: zero byte size for {width}x{height} at {bpp} bpp (readback failed)"
         );
-        return;
+        return false;
     }
     let device_ptr = inner.device_inner;
     if device_ptr.is_null() {
         mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
-            "lockable RT read-back skipped: surface has no owning device (staging left as-is)"
+            "lockable RT read-back skipped: surface has no owning device (readback failed)"
         );
-        return;
+        return false;
     }
     // Borrow the staging (the blit destination) and the device separately;
     // `device_inner` is a distinct allocation from the `system_memory` PageBox,
@@ -2793,14 +2790,14 @@ fn lockable_rt_readback_fill(inner: &mut SurfaceInner, bpp: u32) {
         mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
             "lockable RT read-back skipped: surface carries no CPU staging buffer"
         );
-        return;
+        return false;
     };
     if page.len() < needed {
         mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
-            "lockable RT read-back skipped: staging {} bytes, {needed} needed for {width}x{height} at {bpp} bpp (staging left as-is)",
+            "lockable RT read-back skipped: staging {} bytes, {needed} needed for {width}x{height} at {bpp} bpp (readback failed)",
             page.len()
         );
-        return;
+        return false;
     }
     let dst_ptr = page.as_mut_ptr() as u64;
     let dst_len = page.len() as u64;
@@ -2840,9 +2837,11 @@ fn lockable_rt_readback_fill(inner: &mut SurfaceInner, bpp: u32) {
     let status = unix_call(&mut params);
     if status != 0 {
         mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
-            "lockable RT LockRect read-back: BlitTextureToBuffer failed status={status:#x} (staging left as-is)"
+            "lockable RT LockRect read-back: BlitTextureToBuffer failed status={status:#x} (readback failed)"
         );
+        return false;
     }
+    true
 }
 
 /// `UnlockRect` upload for a lockable standalone render target.
@@ -3177,9 +3176,9 @@ impl SurfaceInner {
 /// texture it owns and takes them the same way: a `StretchRect` or a `ColorFill`
 /// claims it exactly as it claims any other texture level. Only the claim half
 /// reaches a cube face, which keeps its staging for the texture's life.
-fn refill_dc_texture_level(inner: &SurfaceInner) {
+fn refill_dc_texture_level(inner: &SurfaceInner) -> bool {
     if inner.parent_texture.is_null() {
-        return;
+        return true;
     }
     // A 2D level surface carries no face; its texture keeps one staging
     // allocation per level, which the mask indexes as face zero.
@@ -3192,7 +3191,7 @@ fn refill_dc_texture_level(inner: &SurfaceInner) {
     // `Direct3DTexture9` whose refcount keeps it alive for as long as this
     // surface is live; it is a distinct allocation from the surface inner.
     let texture = unsafe { (*inner.parent_texture).inner_mut() };
-    texture.materialize_subresource_for_dc(face, inner.mip_level as usize);
+    texture.materialize_subresource_for_dc(face, inner.mip_level as usize)
 }
 
 /// Hold a texture level's staging for as long as a device context maps it.
@@ -3277,10 +3276,12 @@ extern "system" fn surface_get_dc(this: *mut c_void, hdc: *mut *mut c_void) -> i
     // `ColorFill`, a draw or a `StretchRect` into the surface is invisible to
     // the DC, exactly as it would be to a `LockRect` that skipped the same
     // read-back.
-    if inner.is_lockable_render_target() {
-        refresh_lockable_rt_staging(inner);
+    if inner.is_lockable_render_target() && !refresh_lockable_rt_staging(inner) {
+        return D3DERR_INVALIDCALL;
     }
-    refill_dc_texture_level(inner);
+    if !refill_dc_texture_level(inner) {
+        return D3DERR_INVALIDCALL;
+    }
     let Some(px) = inner.dc_pixels() else {
         mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
             "IDirect3DSurface9::GetDC on a surface with no host pixel store → INVALIDCALL");

--- a/windows/d3d9/src/texture.rs
+++ b/windows/d3d9/src/texture.rs
@@ -484,7 +484,7 @@ impl TextureInner {
         self.level_authority.gpu_wrote(face, level);
     }
 
-    /// Make a subresource's staging the copy that defines it, before a write lands in it.
+    /// Prepare a subresource's staging before a map or CPU write.
     ///
     /// Every path that gives the staging that role goes through here first: a
     /// map, a `GetDC`, and each of the copies. A write covering the whole level
@@ -492,10 +492,17 @@ impl TextureInner {
     /// untouched would otherwise push staging the GPU's pixels never reached
     /// back over them. `face` is a cube face index and zero for every other
     /// texture kind.
-    fn move_subresource_to_staging(&mut self, face: u32, level: usize, whole_level: bool) {
+    fn move_subresource_to_staging(&mut self, face: u32, level: usize, whole_level: bool) -> bool {
         match self.level_authority.plan_write(face, level, whole_level) {
-            WritePlan::WriteStaging | WritePlan::Overwrite => {}
-            WritePlan::ReadBackFirst => materialize_subresource_from_gpu(self, face, level),
+            // An overwrite releases the claim only once the caller finishes its write.
+            WritePlan::WriteStaging | WritePlan::Overwrite => true,
+            WritePlan::ReadBackFirst => {
+                if !materialize_subresource_from_gpu(self, face, level) {
+                    return false;
+                }
+                self.level_authority.staging_wrote(face, level);
+                true
+            }
         }
     }
 
@@ -679,9 +686,9 @@ impl TextureInner {
     /// never received skip it and take the pages as allocated: the first
     /// because the caller declared the old contents dead, the second because
     /// there are none to read.
-    fn ensure_staging_for_lock(&mut self, level: usize, flags: u32) {
+    fn ensure_staging_for_lock(&mut self, level: usize, flags: u32) -> bool {
         if self.dropped_staging & (1u32 << level) == 0 {
-            return;
+            return true;
         }
         let readback = mtld3d_core::texture_staging::released_level_lock_needs_readback(flags)
             && self.was_uploaded[level];
@@ -695,7 +702,7 @@ impl TextureInner {
                  received them",
                 self.texture_id.raw()
             );
-            return;
+            return true;
         }
         if self.read_level_from_gpu(level) {
             // The staging is a byte-for-byte copy of what the GPU holds, so
@@ -711,15 +718,19 @@ impl TextureInner {
                  is read back from the GPU, one blocking flush and blit per lock",
                 self.texture_id.raw()
             );
-            return;
+            return true;
         }
+        // Reallocation cleared the dropped bit; keep the readback obligation
+        // on the GPU claim so a later map or partial write retries it.
+        self.level_authority.gpu_wrote(0, level);
         mtld3d_shared::log_once_warn_by!(
             target: crate::LOG_TARGET,
             key: self.texture_id.raw(),
             "texture {:#x}: lock of level {level} after its staging was released and the read \
-             back of it failed; the lock sees uninitialised pixels",
+             back of it failed; the mapping is rejected",
             self.texture_id.raw()
         );
+        false
     }
 
     /// Re-materialise a subresource's pixels for a `GetDC`.
@@ -732,11 +743,9 @@ impl TextureInner {
     /// upload holds them nowhere else at all. The subresource is the one its
     /// surface was handed out for; a cube never releases its staging, so only
     /// the claim applies to a face.
-    pub fn materialize_subresource_for_dc(&mut self, face: u32, level: usize) {
-        self.move_subresource_to_staging(face, level, false);
-        if self.cube.is_none() {
-            self.ensure_staging_for_lock(level, 0);
-        }
+    pub fn materialize_subresource_for_dc(&mut self, face: u32, level: usize) -> bool {
+        self.move_subresource_to_staging(face, level, false)
+            && (self.cube.is_some() || self.ensure_staging_for_lock(level, 0))
     }
 
     /// Fill `level`'s staging from the GPU copy of the texture.
@@ -744,8 +753,8 @@ impl TextureInner {
     /// Flushes the frame so every pending upload has landed, resolves the
     /// texture's Metal handle on the encoder thread, then blits the level into
     /// the staging pages and waits for it. Returns false when the texture sits
-    /// between devices, has no Metal texture yet, or the blit fails, all of
-    /// which leave the pages as they were allocated.
+    /// between devices, has no Metal texture yet, or the blit fails. A failed
+    /// GPU operation may have written only part of the destination.
     ///
     /// Takes `&self`: the pages are written through the `PageBox` raw-pointer
     /// accessors, the same way every other staging writer in this file reaches
@@ -1140,10 +1149,11 @@ impl TextureInner {
         };
         let (rx, ry, rw, rh) = (src_rect.x, src_rect.y, src_rect.w, src_rect.h);
         let (dx, dy) = (dst_rect.x, dst_rect.y);
-        // The copy is what defines the destination level from here on, so the
-        // level moves off the GPU before a byte of it is written.
+        // Preserve GPU-only pixels before a partial write reaches staging.
         let whole = self.write_covers_level(dst_level, dst_rect);
-        self.move_subresource_to_staging(0, dst_level, whole);
+        if !self.move_subresource_to_staging(0, dst_level, whole) {
+            return false;
+        }
         self.ensure_staging(dst_level);
         self.prepare_volume_staging_write(dst_level);
         let (Some(dst_box), Some(src_box)) =
@@ -1266,7 +1276,9 @@ impl TextureInner {
             return false;
         };
         let whole = self.write_covers_level(dst_level, dst_rect);
-        self.move_subresource_to_staging(dst_face, dst_level, whole);
+        if !self.move_subresource_to_staging(dst_face, dst_level, whole) {
+            return false;
+        }
         let (Some(dst_cube), Some(src_cube)) = (self.cube.as_deref(), src.cube.as_deref()) else {
             return false;
         };
@@ -1426,10 +1438,11 @@ impl TextureInner {
         ) else {
             return false;
         };
-        // The conversion is what defines the destination level from here on, so
-        // the level moves off the GPU before a byte of it is written.
+        // Preserve GPU-only pixels before a partial conversion reaches staging.
         let whole = self.write_covers_level(dst_level, dst_rect);
-        self.move_subresource_to_staging(0, dst_level, whole);
+        if !self.move_subresource_to_staging(0, dst_level, whole) {
+            return false;
+        }
         self.ensure_staging(dst_level);
         self.prepare_volume_staging_write(dst_level);
         let (Some(dst_box), Some(src_box)) =
@@ -1537,7 +1550,9 @@ impl TextureInner {
             return false;
         };
         let whole = self.write_covers_level(dst_level, dst_rect);
-        self.move_subresource_to_staging(dst_face, dst_level, whole);
+        if !self.move_subresource_to_staging(dst_face, dst_level, whole) {
+            return false;
+        }
         let (Some(dst_cube), Some(src_cube)) = (self.cube.as_deref(), src.cube.as_deref()) else {
             return false;
         };
@@ -1626,8 +1641,7 @@ impl TextureInner {
         if dx + rw > self.mip_width(dst_level) || dy + rh > self.mip_height(dst_level) {
             return false;
         }
-        // The copy is what defines the destination level from here on, so the
-        // level moves off the GPU before a byte of it is written.
+        // Preserve GPU-only pixels before a partial write reaches staging.
         let whole = self.write_covers_level(
             dst_level,
             DirtyRect {
@@ -1637,7 +1651,9 @@ impl TextureInner {
                 h: rh,
             },
         );
-        self.move_subresource_to_staging(0, dst_level, whole);
+        if !self.move_subresource_to_staging(0, dst_level, whole) {
+            return false;
+        }
         self.ensure_staging(dst_level);
         let Some(dst_box) = self.staging.get(dst_level) else {
             return false;
@@ -1736,7 +1752,9 @@ impl TextureInner {
             h: rh,
         };
         let whole = self.write_covers_level(dst_level, dst_rect);
-        self.move_subresource_to_staging(dst_face, dst_level, whole);
+        if !self.move_subresource_to_staging(dst_face, dst_level, whole) {
+            return false;
+        }
         let Some(dst_box) = self
             .cube
             .as_deref()
@@ -1836,7 +1854,9 @@ impl TextureInner {
             return false;
         };
         let whole = self.write_covers_level(dst_level, dst_rect);
-        self.move_subresource_to_staging(0, dst_level, whole);
+        if !self.move_subresource_to_staging(0, dst_level, whole) {
+            return false;
+        }
         self.ensure_staging(dst_level);
         let Some(dst_box) = self.staging.get(dst_level) else {
             return false;
@@ -1892,7 +1912,9 @@ impl TextureInner {
             return false;
         };
         let whole = self.write_covers_level(dst_level, dst_rect);
-        self.move_subresource_to_staging(dst_face, dst_level, whole);
+        if !self.move_subresource_to_staging(dst_face, dst_level, whole) {
+            return false;
+        }
         let Some(dst_box) = self
             .cube
             .as_deref()
@@ -2376,6 +2398,7 @@ impl TextureInner {
 
     /// The cube form of `mark_written_region`.
     fn mark_cube_written_region(&mut self, face: u32, level: usize, rect: DirtyRect) {
+        self.level_authority.staging_wrote(face, level);
         if self.write_covers_level(level, rect) {
             self.mark_cube_dirty(face, level);
         } else {
@@ -2420,11 +2443,13 @@ impl TextureInner {
         level: usize,
         rect: Option<DirtyRect>,
         flags: u32,
-    ) -> (*mut u8, u32, usize) {
+    ) -> Option<(*mut u8, u32, usize)> {
         if self.d3d_pool == D3DPOOL_DEFAULT && self.d3d_usage & D3DUSAGE_DYNAMIC == 0 {
             DEFAULT_STATIC_LOCKS.fetch_add(1, Ordering::Relaxed);
         }
-        self.ensure_staging_for_lock(level, flags);
+        if !self.ensure_staging_for_lock(level, flags) {
+            return None;
+        }
         let pitch = self.mip_bytes_per_row[level];
         let offset = mtld3d_core::texture_staging::texture_lock_offset(
             rect,
@@ -2467,7 +2492,7 @@ impl TextureInner {
             // `decide_lock_action`; the staging `PageBox` holds at least
             // `offset + locked_bytes` bytes.
             let ptr = unsafe { base.add(offset) };
-            return (ptr, pitch, offset);
+            return Some((ptr, pitch, offset));
         }
 
         // `device_inner == 0` after `detach_from_device` — texture is
@@ -2520,7 +2545,7 @@ impl TextureInner {
         // (either in-place or freshly renamed) and holds at least
         // `offset + locked_bytes` bytes.
         let ptr = unsafe { base.add(offset) };
-        (ptr, pitch, offset)
+        Some((ptr, pitch, offset))
     }
 
     /// Rename one mip's staging while earlier uploads retain the old allocation.
@@ -2719,6 +2744,7 @@ impl TextureInner {
     /// one narrows the upload to the written union. Volume levels always mark
     /// whole: the upload path has no sub-rect form for them.
     fn mark_written_region(&mut self, level: usize, rect: DirtyRect) {
+        self.level_authority.staging_wrote(0, level);
         if self.write_covers_level(level, rect) || self.depth > 1 {
             self.mark_mip_dirty(level);
         } else {
@@ -3648,11 +3674,9 @@ unsafe fn hand_back_cached_surface(cached: u64, out: *mut *mut c_void) {
 /// `D3DPOOL_DEFAULT` texture). Flush the frame so the write has landed, then
 /// blit the subresource into its staging through the same
 /// `BlitTextureToBuffer` core `GetRenderTargetData` uses; a D3D9 Lock of a
-/// GPU-written surface stalls on a real driver too. The caller has already
-/// released the claim, so a subresource whose Metal handle or staging cannot
-/// serve the read costs one warning rather than one per map, and keeps the
-/// bytes it has.
-fn materialize_subresource_from_gpu(ti: &mut TextureInner, face: u32, level: usize) {
+/// GPU-written surface stalls on a real driver too. A failed read keeps the
+/// GPU authoritative so a later map or partial write retries the readback.
+fn materialize_subresource_from_gpu(ti: &mut TextureInner, face: u32, level: usize) -> bool {
     let (width, height) = (ti.mip_width(level), ti.mip_height(level));
     let bytes_per_row = ti.mip_bytes_per_row(level);
     let block_rows = height.div_ceil(ti.block_h.max(1));
@@ -3660,7 +3684,9 @@ fn materialize_subresource_from_gpu(ti: &mut TextureInner, face: u32, level: usi
     let device_inner_ptr = ti.device_inner;
     let texture_id = ti.texture_id;
     if device_inner_ptr == 0 || width == 0 || height == 0 || needed == 0 {
-        return;
+        mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
+            "texture {texture_id:#x}: face {face} level {level} read-back has no device or extent");
+        return false;
     }
     // A cube keeps its faces in the sidecar and never releases one; every other
     // texture kind may have to allocate the level's staging again first.
@@ -3670,14 +3696,14 @@ fn materialize_subresource_from_gpu(ti: &mut TextureInner, face: u32, level: usi
     let Some((dst_ptr, dst_len)) = ti.subresource_staging_backing(face, level) else {
         mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
             "texture {texture_id:#x}: face {face} level {level} has no staging to read back \
-             into → staging left as-is");
-        return;
+             into → materialization failed");
+        return false;
     };
     if dst_len < needed {
         mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
             "texture {texture_id:#x}: face {face} level {level} staging is too small for a \
-             read-back ({dst_len} < {needed}) → staging left as-is");
-        return;
+             read-back ({dst_len} < {needed}) → materialization failed");
+        return false;
     }
     // The staging `PageBox` and the `DeviceInner` are distinct allocations, so
     // the raw-pointer borrow below never overlaps the slice read above.
@@ -3704,8 +3730,8 @@ fn materialize_subresource_from_gpu(ti: &mut TextureInner, face: u32, level: usi
     if handle == 0 {
         mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
             "texture {texture_id:#x}: no Metal handle for a face {face} level {level} \
-             read-back → staging left as-is");
-        return;
+             read-back → materialization failed");
+        return false;
     }
     let mut params = BlitTextureToBufferParams {
         queue_handle: dev.queue_handle(),
@@ -3736,8 +3762,15 @@ fn materialize_subresource_from_gpu(ti: &mut TextureInner, face: u32, level: usi
     if status != 0 {
         mtld3d_shared::log_once_warn!(target: crate::LOG_TARGET,
             "texture {texture_id:#x}: face {face} level {level} read-back \
-             BlitTextureToBuffer failed status={status:#x} → staging left as-is");
+             BlitTextureToBuffer failed status={status:#x} → materialization failed");
+        return false;
     }
+    if ti.cube.is_none()
+        && let Some(coverage) = ti.staging_coverage.get_mut(level)
+    {
+        coverage.mark_full();
+    }
+    true
 }
 
 extern "system" fn texture_lock_rect(
@@ -3823,11 +3856,16 @@ extern "system" fn texture_lock_rect(
     // `D3DLOCK_DISCARD` is a whole-level one and promises a whole-level
     // overwrite, so it skips the stall and the claim goes with it: the staging
     // this Lock hands out is what the level holds next.
-    ti.move_subresource_to_staging(0, level_u, flags & D3DLOCK_DISCARD != 0);
+    if !ti.move_subresource_to_staging(0, level_u, flags & D3DLOCK_DISCARD != 0) {
+        return D3DERR_INVALIDCALL;
+    }
     let read_only = flags & D3DLOCK_READONLY != 0;
     let no_dirty = flags & D3DLOCK_NO_DIRTY_UPDATE != 0;
 
-    let (ptr, pitch, _offset) = ti.lock_region_ptr(level_u, dirty_rect, flags);
+    let Some((ptr, pitch, _offset)) = ti.lock_region_ptr(level_u, dirty_rect, flags) else {
+        return D3DERR_INVALIDCALL;
+    };
+    ti.level_authority.staging_wrote(0, level_u);
     ti.stash_lock(level_u, read_only, no_dirty, dirty_rect);
 
     // SAFETY: `out_locked_rect` is non-null (checked above) and per the
@@ -5388,10 +5426,13 @@ pub extern "system" fn cube_lock_rect(
     // may rename the box. A surviving `D3DLOCK_DISCARD` is a whole-level one and
     // promises a whole-level overwrite, so it skips the stall and the claim goes
     // with it.
-    ti.move_subresource_to_staging(face, level_u, flags & D3DLOCK_DISCARD != 0);
+    if !ti.move_subresource_to_staging(face, level_u, flags & D3DLOCK_DISCARD != 0) {
+        return D3DERR_INVALIDCALL;
+    }
     let Some((ptr, pitch)) = ti.cube_lock_region_ptr(face, level_u, dirty_rect, flags) else {
         return D3DERR_INVALIDCALL;
     };
+    ti.level_authority.staging_wrote(face, level_u);
     ti.cube_stash_lock(
         face,
         level_u,


### PR DESCRIPTION
A failed Metal readback could report success after waitUntilCompleted, allowing LockRect, GetDC or a staging copy to consume pixels the GPU had not finished copying. Check the command buffer's actual completion status and report every other state through the existing bool/NTSTATUS path. Frame and readback diagnostics share NSError code and description extraction, preserving the driver's hang signature.

Propagate required-readback failures through lockable render targets, texture and cube maps, DC creation and staging copies. Keep GPU authority until readback or a CPU overwrite succeeds, and retain the retry obligation when re-created staging cannot be filled. Reject failed UpdateTexture copies before clearing source dirty rectangles or scheduling the success tail. Converting StretchRect keeps the existing unsupported-format fallback through the existing capability predicate, while failed attempted conversions return INVALIDCALL.

The authority query is nonmutating instead of clearing a claim and trying to restore it after failure. Full-overwrite plans commit only after the copy succeeds or the discard mapping is accepted. A failed GPU operation can partly write staging, and an UpdateTexture can complete earlier subresources before a later one fails; neither operation promises byte rollback.

Verification: the three native authority regressions failed before the policy change and passed afterward, with all 18 authority tests green. Both controlled native completion/NSError tests pass after rebasing. make fmt and make check pass, including clippy, audit and documentation. Full isolated make test and conformance pass on the final landing candidate. COM failure injection and actual GPU failure injection were not executed; caller rejection, output publication, lock/DC cleanup and dirty-state propagation were audited in source. This does not establish the cause of the earlier Intel readback result in #510.

Rules check: CONTRIBUTING.md requires the full isolated test and conformance gates before landing because render readback and core authority state change. CONVENTIONS.md is enforced by the passing formatting, clippy, audit and documentation checks; authority logic and tests stay in core, and COM HRESULT/output wiring stays in d3d9. ARCHITECTURE.md's existing typed boundary and synchronous destination lifetime are preserved. No config key, environment key, wire field, dependency, derive, suppression, explicit process static or duplicate conversion classifier is introduced. Added diagnostics use the existing log_once mechanism. No shader, cache-schema, caps, classifier or e2e coverage entry changes are needed. The separate converting StretchRect source-authority finding is outside this change.

Closes #555
