### PR TITLE
Report command-buffer completion and encoder errors on demand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ on:
           whitespace-separated patterns (e.g. `stencil msaa::`).
         type: string
         default: ''
+      e2e_log:
+        description: The RUST_LOG filter for end-to-end processes (empty keeps the default).
+        type: string
+        default: ''
       conformance_repeat:
         description: >-
           Run one conformance subtest this many times on every conformance
@@ -235,6 +239,7 @@ jobs:
       - run: make test-e2e-${{ matrix.arch }} STAGE="$STAGE" JOBS=1 TIMEOUT=120 FAIL_FAST=0 INTEL=${{ matrix.runner == 'macos-15-intel' && '1' || '' }} SCALE="${{ matrix.scale }}" FILTER="$E2E_FILTER" LOG_DIR="$LOG_DIR"
         env:
           E2E_FILTER: ${{ inputs.e2e_filter }}
+          RUST_LOG: ${{ inputs.e2e_log }}
           LOG_DIR: ${{ runner.temp }}
       # `always()`, as for the conformance output below: a diverging leg is
       # the one whose logs are worth reading, and a leg cut off by its budget

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -201,11 +201,56 @@ Every crate logs via `log` + `env_logger`. All targets sit under `mtld3d::*` and
 | `mtld3d::perf`            | 5-second averaged performance summary (`PERF=1` builds only)             |
 | `mtld3d::shim`            | Wine unix-call PE shim DLL                                               |
 | `mtld3d::unix`            | Metal-side `.so`                                                         |
+| `mtld3d::unix::command`   | command-buffer completion records and encoder error details (debug)      |
 | `mtld3d::unix::cursor`    | software cursor overlay window: sprite renders, show/hide, layer mode    |
 | `mtld3d::unix::present`   | presented-cadence probe, one row per frame (trace)                       |
 | `mtld3d::unix::depth`     | comparison-sampler creation, the unix mirror of `d3d9::depth` (trace)    |
 
 Each cdylib initializes the logger independently and idempotently; `mtld3d.so` has no owning entry point, so `d3d9.dll` dispatches a one-shot `InitLogger` thunk from its init path. Every line goes to the process's log file, `<exe>-<pid>.log` under `mtld3d-logs` beside the executable (`log.dir` moves it), never to the standard streams: a game a launcher spawned has no usable ones. `<pid>` is the macOS process id, so a launch never overwrites the log of the one before it; the directory keeps the ten newest logs and the ten newest traces, and the file appears with the first line written, so a process that logs nothing leaves nothing behind.
+
+### Command-buffer completion and encoder errors
+
+`RUST_LOG=mtld3d=warn,mtld3d::unix::command=debug` enables
+`EncoderExecutionStatus` collection for frame, upload and synchronous readback
+command buffers. These buffers keep retained resource references in both modes;
+with the target disabled, creation uses the ordinary `commandBuffer()` path.
+Collection can add CPU, GPU and memory overhead, and logging every completion
+can be verbose. Use a bounded workload when gathering diagnostics.
+
+The existing frame/upload callbacks, retirement waits, CPU submission cleanup
+and readback wait log `command-buffer` records with the actual buffer, queue
+and device addresses, device registry ID and name, labels, role, sequence where
+known, observation site, numeric/named status and error options. Roles come from
+the constructor-owned labels; an unrecognized or missing label reports `unknown`.
+Readback sequences are `unavailable`. One buffer can appear at several sites,
+so correlate the addresses and site with the sequence and log order. Addresses
+can be reused after release. No new wait or callback is added. Only a recorded
+`Completed` status establishes successful completion of that observed buffer;
+absence of an error record does not.
+
+On failure, the following `command-buffer-error` record names the same buffer,
+sequence and site and includes the signed `NSError` code, domain and description.
+It checks the encoder-info array and each element's protocol conformance before
+printing labels, numeric/named states and signposts in recorded order. Variable
+strings are quoted and escaped to keep each record on one line. Missing errors,
+missing keys, malformed payloads, empty arrays and unavailable protocol metadata
+remain distinct. The typed encoder-info protocol promises nonnull labels and
+signpost arrays; an empty signpost array is reported as `empty`, never as success.
+No per-draw signposts are inserted, so existing labels can be all the driver has.
+`Unknown`, `Completed`, `Affected`, `Pending` and `Faulted` remain distinct:
+`Affected` does not establish that the encoder caused the error, and an encoder's
+`Completed` state does not make the whole buffer successful.
+
+Creation-time texture clears, cursor-overlay buffers and the empty teardown
+fence are outside this target's construction and observation scope. A clean
+local run validates construction and completion on that device; it does not
+demonstrate a real error payload or establish another GPU's fault attribution.
+
+For a bounded manual CI run, set `e2e_filter` to
+`msaa::depth_test_holds_on_a_multisampled_target` and `e2e_log` to
+`mtld3d=warn,mtld3d::unix::command=debug` in the workflow dispatch form. The
+existing e2e steps pass `e2e_log` as `RUST_LOG` and retain their process logs in
+the e2e artifacts. An empty input preserves the ordinary logging default.
 
 ### F12: three-frame dump and GPU capture
 

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -40,6 +40,8 @@ use crate::{
     metal::{handle::IntoRetained, macdrv::attachment, null_texture, texture::mtl_pixel_format},
 };
 
+mod diagnostics;
+
 /// `Retained<ProtocolObject<dyn MTLCommandBuffer>>` is not `Send`/`Sync` in objc2.
 ///
 /// Apple does not categorically mark its APIs thread-safe. The operations
@@ -237,7 +239,12 @@ pub fn wait_for_gpu_retire(target_seq: u64, coherent_seq_ptr: u64, failed_submit
     // Record the abort before the retirement bump: both stores are
     // `Release`, so a PE-side `Acquire` load of `coherent_seq` that sees
     // this seq is guaranteed to see the failure too.
-    if let Some((code, desc)) = record_failed_submit(&cmdbuf, retired_seq, failed_submit_seq_ptr) {
+    if let Some((code, desc)) = record_failed_submit(
+        &cmdbuf,
+        retired_seq,
+        failed_submit_seq_ptr,
+        "retirement-wait",
+    ) {
         mtld3d_shared::crumb!("gpuretirecberr", target_seq);
         mtld3d_shared::log_once_warn_by!(
             target: LOG_TARGET,
@@ -260,8 +267,11 @@ fn record_failed_submit(
     cb: &ProtocolObject<dyn MTLCommandBuffer>,
     seq: u64,
     failed_submit_seq_ptr: u64,
+    site: &str,
 ) -> Option<(u64, String)> {
-    if cb.status() != MTLCommandBufferStatus::Error {
+    let status = cb.status();
+    diagnostics::completion(cb, status, Some(seq), site);
+    if status != MTLCommandBufferStatus::Error {
         return None;
     }
     if failed_submit_seq_ptr != 0 {
@@ -272,7 +282,9 @@ fn record_failed_submit(
         let atomic = unsafe { &*(failed_submit_seq_ptr as *const AtomicU64) };
         atomic.fetch_max(seq, Ordering::Release);
     }
-    Some(command_buffer_error(cb.error().as_deref()))
+    let error = cb.error();
+    diagnostics::failure(cb, Some(seq), site, error.as_deref());
+    Some(command_buffer_error(error.as_deref()))
 }
 
 /// Preserve the driver description shared by frame and readback failure diagnostics.
@@ -355,7 +367,7 @@ fn retire_failed_submit(params: &SubmitFrameParams) {
             // This waits for completion handlers too, protecting the PE sink
             // atomics as well as the backing pages read by the GPU.
             cb.waitUntilCompleted();
-            let _ = record_failed_submit(&cb, key.1, params.failed_submit_seq_ptr);
+            let _ = record_failed_submit(&cb, key.1, params.failed_submit_seq_ptr, "cpu-cleanup");
             let _ = PENDING_CMDBUFS.lock().unwrap().remove(&key);
         }
     }
@@ -386,7 +398,7 @@ fn encode_frame(params: &mut SubmitFrameParams) -> bool {
     };
 
     mtld3d_shared::crumb!("submit:cmdbuf");
-    let Some(cmd_buf) = queue.commandBuffer() else {
+    let Some(cmd_buf) = diagnostics::command_buffer(&queue) else {
         error!(target: LOG_TARGET, "submit_frame: commandBuffer() returned nil");
         return false;
     };
@@ -725,7 +737,9 @@ fn encode_frame(params: &mut SubmitFrameParams) -> bool {
                 // both stores are `Release`, so a PE-side `Acquire` load of
                 // `coherent_seq` that observes this seq observes the failure
                 // too, and the upload recovery never reads a stale "clean".
-                if let Some((code, desc)) = record_failed_submit(cb, seq, failed_seq_ptr) {
+                if let Some((code, desc)) =
+                    record_failed_submit(cb, seq, failed_seq_ptr, "frame-callback")
+                {
                     mtld3d_shared::crumb!("submit:cberr", seq);
                     mtld3d_shared::log_once_warn_by!(
                         target: LOG_TARGET,
@@ -788,7 +802,7 @@ fn submit_upload_cmd_buf(
     let submit_seq = params.submit_seq;
     let upload_coherent_seq_ptr = params.upload_coherent_seq_ptr;
     mtld3d_shared::crumb!("submit:upcmdbuf");
-    let Some(upload_cb) = queue.commandBuffer() else {
+    let Some(upload_cb) = diagnostics::command_buffer(queue) else {
         error!(target: LOG_TARGET, "submit_frame: upload commandBuffer() returned nil");
         return false;
     };
@@ -830,7 +844,9 @@ fn submit_upload_cmd_buf(
                 // SAFETY: Metal invokes the block with the completed command
                 // buffer; the pointer is valid for the handler's duration.
                 let cb = unsafe { cb_ptr.as_ref() };
-                if let Some((code, desc)) = record_failed_submit(cb, seq, failed_seq_ptr) {
+                if let Some((code, desc)) =
+                    record_failed_submit(cb, seq, failed_seq_ptr, "upload-callback")
+                {
                     mtld3d_shared::crumb!("submit:upcberr", seq);
                     mtld3d_shared::log_once_warn_by!(
                         target: LOG_TARGET,
@@ -3176,7 +3192,7 @@ pub fn blit_texture_to_buffer(args: &BlitArgs) -> bool {
         dst_buffer.setLabel(Some(&label));
     }
 
-    let Some(cmd_buf) = queue.commandBuffer() else {
+    let Some(cmd_buf) = diagnostics::command_buffer(&queue) else {
         error!(target: LOG_TARGET, "blit_texture_to_buffer: commandBuffer() nil");
         return false;
     };
@@ -3288,8 +3304,14 @@ pub fn blit_texture_to_buffer(args: &BlitArgs) -> bool {
     blit.endEncoding();
     cmd_buf.commit();
     cmd_buf.waitUntilCompleted();
+    let status = cmd_buf.status();
+    diagnostics::completion(&cmd_buf, status, None, "readback-wait");
     // The wrapper owns no pages; the caller keeps the destination allocation.
-    readback_completed(cmd_buf.status(), || cmd_buf.error())
+    readback_completed(status, || {
+        let error = cmd_buf.error();
+        diagnostics::failure(&cmd_buf, None, "readback-wait", error.as_deref());
+        error
+    })
 }
 
 /// Accept a readback only after Metal reports successful completion.

--- a/unix/unix/src/metal/command/diagnostics.rs
+++ b/unix/unix/src/metal/command/diagnostics.rs
@@ -1,0 +1,212 @@
+use std::fmt::Write;
+
+use log::{Level, debug, log_enabled};
+use objc2::{
+    ProtocolType,
+    rc::Retained,
+    runtime::{AnyObject, ProtocolObject},
+};
+use objc2_foundation::{NSArray, NSError, NSString};
+use objc2_metal::{
+    MTLCommandBuffer, MTLCommandBufferDescriptor, MTLCommandBufferEncoderInfo,
+    MTLCommandBufferEncoderInfoErrorKey, MTLCommandBufferErrorOption, MTLCommandBufferStatus,
+    MTLCommandEncoderErrorState, MTLCommandQueue, MTLDevice,
+};
+
+const LOG_TARGET: &str = "mtld3d::unix::command";
+
+pub fn command_buffer(
+    queue: &ProtocolObject<dyn MTLCommandQueue>,
+) -> Option<Retained<ProtocolObject<dyn MTLCommandBuffer>>> {
+    let descriptor = diagnostic_descriptor(log_enabled!(target: LOG_TARGET, Level::Debug));
+    descriptor.map_or_else(
+        || queue.commandBuffer(),
+        |descriptor| queue.commandBufferWithDescriptor(&descriptor),
+    )
+}
+
+pub fn completion(
+    cb: &ProtocolObject<dyn MTLCommandBuffer>,
+    status: MTLCommandBufferStatus,
+    seq: Option<u64>,
+    site: &str,
+) {
+    if !log_enabled!(target: LOG_TARGET, Level::Debug) {
+        return;
+    }
+    let label = cb.label().map(|s| s.to_string());
+    let queue = cb.commandQueue();
+    let device = cb.device();
+    debug!(
+        target: LOG_TARGET,
+        "command-buffer buffer={cb:p} queue={:p} device={:p} registry_id={:#x} \
+         device_name={:?} role={} seq={} site={site:?} status={}({}) \
+         error_options={:#x} retained_references={} label={} queue_label={}",
+        Retained::as_ptr(&queue),
+        Retained::as_ptr(&device),
+        device.registryID(),
+        device.name().to_string(),
+        buffer_role(label.as_deref()),
+        sequence(seq),
+        status.0,
+        status_name(status),
+        cb.errorOptions().0,
+        cb.retainedReferences(),
+        optional_string(label.as_deref()),
+        optional_string(queue.label().map(|s| s.to_string()).as_deref()),
+    );
+}
+
+/// Follows the completion envelope with details from the same error the caller handles.
+pub fn failure(
+    cb: &ProtocolObject<dyn MTLCommandBuffer>,
+    seq: Option<u64>,
+    site: &str,
+    error: Option<&NSError>,
+) {
+    if !log_enabled!(target: LOG_TARGET, Level::Debug) {
+        return;
+    }
+    debug!(
+        target: LOG_TARGET,
+        "command-buffer-error buffer={cb:p} seq={} site={site:?} {}",
+        sequence(seq),
+        error_details(error),
+    );
+}
+
+fn diagnostic_descriptor(enabled: bool) -> Option<Retained<MTLCommandBufferDescriptor>> {
+    enabled.then(|| {
+        let descriptor = MTLCommandBufferDescriptor::new();
+        descriptor.setRetainedReferences(true);
+        descriptor.setErrorOptions(MTLCommandBufferErrorOption::EncoderExecutionStatus);
+        descriptor
+    })
+}
+
+fn sequence(seq: Option<u64>) -> String {
+    seq.map_or_else(|| "unavailable".to_owned(), |seq| format!("{seq:#x}"))
+}
+
+fn optional_string(value: Option<&str>) -> String {
+    value.map_or_else(|| "missing".to_owned(), |value| format!("{value:?}"))
+}
+
+fn buffer_role(label: Option<&str>) -> &'static str {
+    match label {
+        Some(label) if label.starts_with("mtld3d-frame-") => "frame",
+        Some(label) if label.starts_with("mtld3d-upload-") => "upload",
+        Some("mtld3d-readback") => "readback",
+        // Labels belong to the constructors; do not guess an unknown buffer's role.
+        _ => "unknown",
+    }
+}
+
+const fn status_name(status: MTLCommandBufferStatus) -> &'static str {
+    match status {
+        MTLCommandBufferStatus::NotEnqueued => "NotEnqueued",
+        MTLCommandBufferStatus::Enqueued => "Enqueued",
+        MTLCommandBufferStatus::Committed => "Committed",
+        MTLCommandBufferStatus::Scheduled => "Scheduled",
+        MTLCommandBufferStatus::Completed => "Completed",
+        MTLCommandBufferStatus::Error => "Error",
+        // The numeric status is printed beside this name for future SDK values.
+        _ => "unrecognized",
+    }
+}
+
+const fn encoder_state_name(state: MTLCommandEncoderErrorState) -> &'static str {
+    match state {
+        MTLCommandEncoderErrorState::Unknown => "Unknown",
+        MTLCommandEncoderErrorState::Completed => "Completed",
+        MTLCommandEncoderErrorState::Affected => "Affected",
+        MTLCommandEncoderErrorState::Pending => "Pending",
+        MTLCommandEncoderErrorState::Faulted => "Faulted",
+        // Preserve future values without folding them into Metal's Unknown state.
+        _ => "unrecognized",
+    }
+}
+
+fn error_details(error: Option<&NSError>) -> String {
+    let Some(error) = error else {
+        return "error=missing encoder_info=unavailable".to_owned();
+    };
+    let mut output = format!(
+        "error=present domain={:?} code={} description={:?}",
+        error.domain().to_string(),
+        error.code(),
+        error.localizedDescription().to_string(),
+    );
+    // SAFETY: Metal exports this immutable Foundation string on every supported macOS.
+    let key = unsafe { MTLCommandBufferEncoderInfoErrorKey };
+    let payload = error.userInfo().objectForKey(key);
+    append_encoder_info(&mut output, payload.as_deref());
+    output
+}
+
+fn append_encoder_info(output: &mut String, payload: Option<&AnyObject>) {
+    let Some(payload) = payload else {
+        output.push_str(" encoder_info=missing-key");
+        return;
+    };
+    let Some(encoders) = payload.downcast_ref::<NSArray<AnyObject>>() else {
+        output.push_str(" encoder_info=malformed-non-array");
+        return;
+    };
+    if encoders.is_empty() {
+        output.push_str(" encoder_info=empty");
+        return;
+    }
+    write!(
+        output,
+        " encoder_info=present encoder_count={}",
+        encoders.len()
+    )
+    .expect("writing to a String cannot fail");
+    let Some(protocol) = <dyn MTLCommandBufferEncoderInfo>::protocol() else {
+        output.push_str(" encoders=unavailable-protocol");
+        return;
+    };
+    for (index, object) in encoders.iter().enumerate() {
+        write!(output, " encoder[{index}]={{").expect("writing to a String cannot fail");
+        if !object.class().conforms_to(protocol) {
+            output.push_str("malformed-nonconforming}");
+            continue;
+        }
+        // SAFETY: the erased array yielded a retained live object, and its runtime class
+        // conforms to MTLCommandBufferEncoderInfo as checked above. The protocol has no
+        // extra Rust invariants; the cast transfers this retain without changing lifetime.
+        let encoder = unsafe {
+            Retained::cast_unchecked::<ProtocolObject<dyn MTLCommandBufferEncoderInfo>>(object)
+        };
+        let state = encoder.errorState();
+        write!(
+            output,
+            "label={:?} state={}({}) signposts=",
+            encoder.label().to_string(),
+            state.0,
+            encoder_state_name(state),
+        )
+        .expect("writing to a String cannot fail");
+        append_signposts(output, &encoder.debugSignposts());
+        output.push('}');
+    }
+}
+
+fn append_signposts(output: &mut String, signposts: &NSArray<NSString>) {
+    if signposts.is_empty() {
+        output.push_str("empty");
+        return;
+    }
+    output.push('[');
+    for (index, signpost) in signposts.iter().enumerate() {
+        if index != 0 {
+            output.push_str(", ");
+        }
+        write!(output, "{:?}", signpost.to_string()).expect("writing to a String cannot fail");
+    }
+    output.push(']');
+}
+
+#[cfg(test)]
+mod tests;

--- a/unix/unix/src/metal/command/diagnostics/tests.rs
+++ b/unix/unix/src/metal/command/diagnostics/tests.rs
@@ -1,0 +1,183 @@
+use objc2::{define_class, extern_methods, rc::Retained, runtime::AnyObject};
+use objc2_foundation::{
+    NSArray, NSDictionary, NSError, NSLocalizedDescriptionKey, NSObject, NSObjectProtocol, NSString,
+};
+use objc2_metal::{
+    MTLCommandBufferEncoderInfo, MTLCommandBufferEncoderInfoErrorKey, MTLCommandBufferErrorOption,
+    MTLCommandBufferStatus, MTLCommandEncoderErrorState,
+};
+
+use super::{
+    append_signposts, buffer_role, diagnostic_descriptor, encoder_state_name, error_details,
+    optional_string, sequence, status_name,
+};
+
+define_class!(
+    // SAFETY: NSObject has no subclassing requirements. This fixture has no ivars or Drop.
+    #[unsafe(super = NSObject)]
+    struct CommandEncoderInfoFixture;
+
+    // SAFETY: NSObject supplies the NSObjectProtocol methods.
+    unsafe impl NSObjectProtocol for CommandEncoderInfoFixture {}
+
+    // SAFETY: these methods implement the typed protocol signatures with owned objects.
+    unsafe impl MTLCommandBufferEncoderInfo for CommandEncoderInfoFixture {
+        #[unsafe(method_id(label))]
+        fn label(&self) -> Retained<NSString> {
+            NSString::from_str("pass\"\n\\label")
+        }
+
+        #[unsafe(method_id(debugSignposts))]
+        fn debug_signposts(&self) -> Retained<NSArray<NSString>> {
+            NSArray::from_retained_slice(&[
+                NSString::from_str("first\nmarker"),
+                NSString::from_str("second\t\"marker\\"),
+            ])
+        }
+
+        #[unsafe(method(errorState))]
+        fn error_state(&self) -> MTLCommandEncoderErrorState {
+            MTLCommandEncoderErrorState::Affected
+        }
+    }
+);
+
+impl CommandEncoderInfoFixture {
+    extern_methods!(
+        // SAFETY: NSObject's inherited new initializes this subclass, which has no ivars.
+        #[unsafe(method(new))]
+        #[unsafe(method_family = new)]
+        fn new() -> Retained<Self>;
+    );
+}
+
+#[test]
+fn descriptor_opt_in_retains_resources_and_requests_encoder_status() {
+    assert!(diagnostic_descriptor(false).is_none());
+    let descriptor = diagnostic_descriptor(true).expect("diagnostics enabled");
+    assert!(descriptor.retainedReferences());
+    assert_eq!(
+        descriptor.errorOptions(),
+        MTLCommandBufferErrorOption::EncoderExecutionStatus,
+    );
+}
+
+#[test]
+fn missing_error_and_missing_encoder_key_are_distinct() {
+    assert_eq!(
+        error_details(None),
+        "error=missing encoder_info=unavailable"
+    );
+    let error = fixture_error(None);
+    assert_eq!(
+        error_details(Some(&error)),
+        "error=present domain=\"fixture\\n\\\"domain\" code=-9 \
+         description=\"driver\\n\\\"detail\\\\\" encoder_info=missing-key",
+    );
+    assert_eq!(super::super::command_buffer_error(Some(&error)).0, 9);
+}
+
+#[test]
+fn encoder_payload_checks_array_class_and_protocol_per_element() {
+    let wrong_type = NSString::from_str("not an array");
+    assert!(
+        error_details(Some(&fixture_error(Some(wrong_type.as_ref()))))
+            .ends_with("encoder_info=malformed-non-array")
+    );
+    let empty = NSArray::<AnyObject>::new();
+    assert!(
+        error_details(Some(&fixture_error(Some(empty.as_ref())))).ends_with("encoder_info=empty")
+    );
+
+    let encoder = CommandEncoderInfoFixture::new();
+    let nonconforming = NSObject::new();
+    let payload = NSArray::<AnyObject>::from_slice(&[
+        nonconforming.as_ref(),
+        encoder.as_ref(),
+        nonconforming.as_ref(),
+    ]);
+    let details = error_details(Some(&fixture_error(Some(payload.as_ref()))));
+    assert!(
+        details.ends_with(
+            "encoder_info=present encoder_count=3 encoder[0]={malformed-nonconforming} \
+         encoder[1]={label=\"pass\\\"\\n\\\\label\" state=2(Affected) \
+         signposts=[\"first\\nmarker\", \"second\\t\\\"marker\\\\\"]} \
+         encoder[2]={malformed-nonconforming}"
+        ),
+        "{details}"
+    );
+    assert!(!details.contains(['\n', '\r', '\t']));
+}
+
+#[test]
+fn empty_signposts_do_not_claim_success() {
+    let mut output = String::new();
+    append_signposts(&mut output, &NSArray::new());
+    assert_eq!(output, "empty");
+}
+
+#[test]
+fn all_encoder_states_and_future_values_keep_their_names() {
+    for (state, name) in [
+        (MTLCommandEncoderErrorState::Unknown, "Unknown"),
+        (MTLCommandEncoderErrorState::Completed, "Completed"),
+        (MTLCommandEncoderErrorState::Affected, "Affected"),
+        (MTLCommandEncoderErrorState::Pending, "Pending"),
+        (MTLCommandEncoderErrorState::Faulted, "Faulted"),
+        (MTLCommandEncoderErrorState(-9), "unrecognized"),
+    ] {
+        assert_eq!(encoder_state_name(state), name);
+    }
+}
+
+#[test]
+fn completion_states_include_nonterminal_and_future_values() {
+    for (status, name) in [
+        (MTLCommandBufferStatus::NotEnqueued, "NotEnqueued"),
+        (MTLCommandBufferStatus::Enqueued, "Enqueued"),
+        (MTLCommandBufferStatus::Committed, "Committed"),
+        (MTLCommandBufferStatus::Scheduled, "Scheduled"),
+        (MTLCommandBufferStatus::Completed, "Completed"),
+        (MTLCommandBufferStatus::Error, "Error"),
+        (MTLCommandBufferStatus(99), "unrecognized"),
+    ] {
+        assert_eq!(status_name(status), name);
+    }
+}
+
+#[test]
+fn optional_identity_fields_preserve_missing_and_escape_present_strings() {
+    assert_eq!(sequence(None), "unavailable");
+    assert_eq!(sequence(Some(17)), "0x11");
+    assert_eq!(optional_string(None), "missing");
+    assert_eq!(optional_string(Some("")), "\"\"");
+    assert_eq!(optional_string(Some("a\n\"b\\")), "\"a\\n\\\"b\\\\\"");
+    assert_eq!(buffer_role(Some("mtld3d-frame-0x1")), "frame");
+    assert_eq!(buffer_role(Some("mtld3d-upload-0x1")), "upload");
+    assert_eq!(buffer_role(Some("mtld3d-readback")), "readback");
+    assert_eq!(buffer_role(Some("unexpected")), "unknown");
+    assert_eq!(buffer_role(None), "unknown");
+}
+
+fn fixture_error(payload: Option<&AnyObject>) -> Retained<NSError> {
+    let description = NSString::from_str("driver\n\"detail\\");
+    // SAFETY: Foundation exports this immutable NSString key on every supported macOS.
+    let description_key = unsafe { NSLocalizedDescriptionKey };
+    let mut keys = vec![description_key];
+    let mut values = vec![AsRef::<AnyObject>::as_ref(&*description)];
+    if let Some(payload) = payload {
+        // SAFETY: Metal exports this immutable Foundation string on every supported macOS.
+        keys.push(unsafe { MTLCommandBufferEncoderInfoErrorKey });
+        values.push(payload);
+    }
+    let info = NSDictionary::from_slices(&keys, &values);
+    // SAFETY: the user-info description is NSString; encoder-info payloads are deliberately
+    // erased fixtures that the diagnostic decoder checks before using their typed APIs.
+    unsafe {
+        NSError::errorWithDomain_code_userInfo(
+            &NSString::from_str("fixture\n\"domain"),
+            -9,
+            Some(&info),
+        )
+    }
+}


### PR DESCRIPTION
Metal command-buffer failures currently report a driver code and description, which cannot identify the affected encoder or distinguish unreported errors from recorded successful completion. `RUST_LOG=mtld3d=warn,mtld3d::unix::command=debug` now enables encoder execution status collection for frame, upload and synchronous readback buffers, and logs completion observations from the existing callbacks and waits. Records identify the buffer, queue, device, role, known sequence and observation site. Failures include the signed NSError code, domain, description and checked encoder labels, states and signposts, with missing, malformed and unavailable data kept distinct.

Collection stays behind the existing diagnostic log target because requesting it for every buffer adds driver overhead. Both creation paths retain encoded resources. The existing waits, submission order, failed-submit counters and readback failure propagation remain intact; successful readbacks still do not query NSError. One optional manual workflow input, `e2e_log`, passes the filter through the existing RUST_LOG environment variable, with an empty input preserving the logging default. The documentation describes the buffer scope and attribution limits.

Verification: the seven new native descriptor/formatting/Foundation fixtures and both existing readback completion tests passed in scoped runs. Formatting, audit, Unix documentation and Unix all-targets Clippy passed. The scoped enabled-log e2e smoke passed both existing tests on i686 and x86_64. Each raw log contains 16 Completed observations covering frame, upload and readback, all with encoder reporting enabled and retained references true; callback/wait identities and the loaded binaries were checked. Full make check, isolated make test (both native workspaces and both PE architectures), and conformance pass on the final landing candidate with no baseline change. Native fixtures use synthetic NSError payloads and do not demonstrate a real GPU fault. No cause or resolution of the retained Intel failures is claimed.

Rules check: CONTRIBUTING.md's full gates remain required. CONVENTIONS.md's audit covers the new child module and separate test file; there are no new production statics, runtime config keys, environment keys, wire fields, dependencies, derives or lint suppressions. The log target uses the existing diagnostic mechanism, and the single workflow input is passed through structured env. The checked array and per-object protocol conversion use typed bindings, with one documented unsafe cast after runtime conformance checks. ARCHITECTURE.md's resource retention, object labels, PE boundary and threading contracts remain unchanged. No new callbacks, waits or tracking registry are introduced.

Closes #571
