### PR TITLE
Translate predicate-based shader flow control

### DIFF
--- a/windows/core/src/dxso/emit.rs
+++ b/windows/core/src/dxso/emit.rs
@@ -2391,17 +2391,14 @@ fn translate_instruction(
             let _ = writeln!(out, "    p0 = ({} {} {});", srcs[0], op_str, srcs[1]);
             return Ok(());
         }
-        // `breakp pN` — predicate-gated break. The predicate operand
-        // is stored in `inst.predicate` (since `predicated` is set on
-        // the instruction); break when `any` of the gated lanes is
-        // true. `any(p0)` is conservative and matches D3D9 PS
-        // semantics where the swizzle picks specific lanes.
+        // `breakp p0.comp` consumes a regular predicate source. The generic
+        // source load above applies its required replicate swizzle and
+        // optional Boolean negation before this scalar test.
         Opcode::BreakP => {
-            let pred = inst.predicate.as_ref().ok_or_else(|| {
+            let pred = srcs.first().ok_or_else(|| {
                 EmitError::UnsupportedInstruction("breakp without predicate operand".into())
             })?;
-            let pred_expr = predicate_gate_expr(pred);
-            let _ = writeln!(out, "    if ({pred_expr}) break;");
+            let _ = writeln!(out, "    if (({pred}).x != 0.0) break;");
             return Ok(());
         }
         // `call sN` — inline-expand the labelled subroutine. The
@@ -2503,7 +2500,7 @@ fn expand_subroutine(out: &mut String, label: u32, ctx: &EmitContext) -> Result<
     Ok(())
 }
 
-/// Build the boolean MSL expression that gates a predicated instruction (or `breakp`).
+/// Build the Boolean MSL expression that gates a predicated instruction.
 ///
 /// The predicate operand carries a swizzle picking which p0 lane is the gate,
 /// and a `Not` modifier inverts the test. `any(p0)` is the fallback for an
@@ -2727,6 +2724,10 @@ fn register_read_expr(reg: Register, ctx: &EmitContext) -> Result<String, EmitEr
                 format!("float4(float((ps_b >> {}u) & 1u))", reg.index)
             }
         }
+        // `p0` is stored as bool4, while ordinary source operands flow through
+        // the float4 swizzle and modifier pipeline. Flow-control instructions
+        // consume one replicated component after those operations.
+        RegKind::Predicate => "float4(p0)".to_string(),
         // Label register reads only land here as the operand of
         // `Call sN` / `CallNz` — the emit arm pulls `reg.index`
         // directly off the parsed `SrcOperand` rather than this

--- a/windows/core/src/dxso/emit/tests.rs
+++ b/windows/core/src/dxso/emit/tests.rs
@@ -84,7 +84,6 @@ const OP_ENDIF: u16 = 43;
 const OP_BREAK: u16 = 44;
 const OP_BREAKC: u16 = 45;
 const OP_DEFI: u16 = 48;
-const OP_BREAKP: u16 = 96;
 const OP_SETP: u16 = 94;
 
 const TYPE_PREDICATE: u32 = 19;
@@ -2077,6 +2076,62 @@ fn setp_lt_emits_componentwise_predicate_assignment() {
 }
 
 #[test]
+fn if_reads_predicate_source_with_replicate_swizzle() {
+    // ps_3_0 { setp_lt p0, c0, c1; if p0.x; mov oC0, c0; endif; }
+    let bc = vec![
+        PS3_HEADER,
+        u32::from(OP_SETP) | (4u32 << 16) | (3u32 << 24),
+        dst_token(TYPE_PREDICATE, 0, 0xF, false),
+        src_token(TYPE_CONST, 0, SWIZ_IDENTITY, 0),
+        src_token(TYPE_CONST, 1, SWIZ_IDENTITY, 0),
+        0x0100_0028,
+        0xb000_1000,
+        opcode_token(OP_MOV, 2),
+        dst_token(TYPE_COLOROUT, 0, 0xF, false),
+        src_token(TYPE_CONST, 0, SWIZ_IDENTITY, 0),
+        opcode_token(OP_ENDIF, 0),
+        END_TOKEN,
+    ];
+    let ps = parse(&bc).expect("PS3 parse");
+    let ps_msl = emit_ps_programmable(&ps, VariantKey::default()).expect("emit PS3");
+    assert!(
+        ps_msl.contains("if (((float4(p0)).xxxx).x != 0.0) {"),
+        "if must read the replicated p0.x source:\n{ps_msl}"
+    );
+    metal_compile_or_fail(&ps_msl);
+}
+
+#[test]
+fn callnz_reads_negated_predicate_source_with_replicate_swizzle() {
+    // vs_3_0 { callnz l0, !p0.z; ret; label l0; mov r0, c0; ret; }
+    let bc = vec![
+        VS3_HEADER,
+        0x0200_001a,
+        0xa0e4_1000,
+        0xbdaa_1000,
+        opcode_token(OP_RET, 0),
+        0x0100_001e,
+        0xa0e4_1000,
+        opcode_token(OP_MOV, 2),
+        dst_token(TYPE_TEMP, 0, 0xF, false),
+        src_token(TYPE_CONST, 0, SWIZ_IDENTITY, 0),
+        opcode_token(OP_RET, 0),
+        END_TOKEN,
+    ];
+    let vs = parse(&bc).expect("VS3 parse");
+    let vs_msl = emit_vs_programmable(&vs).expect("emit VS3");
+    assert!(
+        vs_msl.contains("if ((float4(!bool4((float4(p0)).zzzz))).x != 0.0) {"),
+        "callnz must read and negate the replicated p0.z source:\n{vs_msl}"
+    );
+    assert!(
+        vs_msl.contains("r[0] = vs_c[0];"),
+        "callnz body must inline-expand:\n{vs_msl}"
+    );
+    metal_compile_or_fail(&vs_msl);
+}
+
+#[test]
 fn predicated_instruction_wraps_dst_write_in_p0_check() {
     // ps_3_0 {
     //   dcl t0;
@@ -2116,8 +2171,7 @@ fn predicated_instruction_wraps_dst_write_in_p0_check() {
 
 #[test]
 fn breakp_emits_predicate_gated_break() {
-    // vs_3_0 { defi i0, 4,0,1,0; loop aL, i0; (p0) breakp p0; endloop; ... }
-    let predicated_breakp_token = u32::from(OP_BREAKP) | (1u32 << 28) | (1u32 << 24);
+    // vs_3_0 { defi i0, 4,0,1,0; loop aL, i0; breakp p0.w; endloop; ... }
     let bc = vec![
         VS3_HEADER,
         opcode_token(OP_DEFI, 5),
@@ -2132,8 +2186,8 @@ fn breakp_emits_predicate_gated_break() {
         opcode_token(OP_LOOP, 2),
         src_token(TYPE_LOOP, 0, SWIZ_IDENTITY, 0),
         src_token(TYPE_CONSTINT, 0, SWIZ_IDENTITY, 0),
-        predicated_breakp_token,
-        src_token(TYPE_PREDICATE, 0, 0x00 /* .xxxx */, 0),
+        0x0100_0060,
+        0xb0ff_1000,
         opcode_token(OP_ENDLOOP, 0),
         opcode_token(OP_MOV, 2),
         dst_token(TYPE_TEXCOORDOUT, 0, 0xF, false),
@@ -2141,11 +2195,23 @@ fn breakp_emits_predicate_gated_break() {
         END_TOKEN,
     ];
     let vs = parse(&bc).expect("VS3 parse");
+    let breakp = vs
+        .instructions
+        .iter()
+        .find(|inst| inst.opcode == super::Opcode::BreakP)
+        .expect("breakp instruction");
+    assert!(
+        breakp.predicate.is_none(),
+        "breakp must not use the instruction predication operand"
+    );
+    assert_eq!(breakp.srcs.len(), 1, "breakp must have one regular source");
+    assert_eq!(breakp.srcs[0].reg.kind, super::RegKind::Predicate);
     let vs_msl = emit_vs_programmable(&vs).expect("emit VS3");
     assert!(
-        vs_msl.contains("if (p0.x) break;"),
+        vs_msl.contains("if (((float4(p0)).wwww).x != 0.0) break;"),
         "breakp must gate break on the predicate operand:\n{vs_msl}"
     );
+    metal_compile_or_fail(&vs_msl);
 }
 
 #[test]

--- a/windows/core/src/shader_cache.rs
+++ b/windows/core/src/shader_cache.rs
@@ -280,7 +280,10 @@ use crate::shader_compile_stats::CompileBucket;
 ///
 /// `68` preserves the `texldb` instruction control and adds the coordinate's
 /// `.w` to any sampler-state bias in the emitted programmable pixel shader.
-pub const SHADER_CACHE_SCHEMA_VERSION: u32 = 68;
+///
+/// `69` lets predicate-based flow control read `p0` through the ordinary
+/// source path and emits `breakp` from that source, changing programmable MSL.
+pub const SHADER_CACHE_SCHEMA_VERSION: u32 = 69;
 
 /// File magic.
 ///


### PR DESCRIPTION
Predicate-based SM2.x and SM3 flow control rejected valid `p0` source operands with `UnsupportedRegisterKind("Predicate")`, so `if p0.x`, `callnz l0, !p0.z`, and `breakp p0.w` could not translate.

The emitter loaded every regular source before opcode dispatch, but its register reader had no predicate-register arm. `breakp` also read `Instruction::predicate`, which is the extra operand selected by instruction bit 28, instead of the ordinary source operand encoded by `breakp`.

Make `p0` readable through the ordinary source pipeline so its replicate swizzle and optional Boolean negation are applied consistently. Lower `breakp` from its regular source and keep bit-28 instruction predication on the existing separate path. The regression tests use the D3D9 instruction words for all three flow forms, assert that `breakp` parses without an extra predicate operand, and compile the emitted vertex and pixel shaders through Metal.

I considered bypassing the generic source load for predicate registers and rebuilding each condition in the three flow-control handlers. Keeping predicates in the ordinary source pipeline avoids three copies of swizzle and source-modifier handling and matches how the bytecode encodes these operands.

The shader cache schema moves from 68 to 69 because the fix changes programmable shader MSL.

Rules check: this changes pure shader-emission code and its existing unit-test module. It adds no statics, config keys, wire fields, dependencies, derives, lint suppressions, or duplicated ABI constants. No end-to-end test file is added, so `windows/tests/COVERAGE.md` needs no row. The cache-schema bump is the companion edit required by `CONTRIBUTING.md`; `make audit` enforces the applicable `CONVENTIONS.md` rules, and the change does not cross an `ARCHITECTURE.md` boundary.

Verification: `make fmt`; `make check`; focused host test before the fix reproduced three `UnsupportedRegisterKind("Predicate")` failures; the same focused test passes after the fix, including real Metal compilation for all three generated shaders; the rebased native core/types suite passes all 1,133 tests. Full isolated `make test` passes both native workspaces and both PE architectures. Conformance reports no regressions on either architecture, with no baseline change.

Closes #494
