### PR TITLE
Cache unchanged LOD-bias uniforms across draws

### DIFF
--- a/windows/core/src/sampler_state.rs
+++ b/windows/core/src/sampler_state.rs
@@ -109,6 +109,53 @@ pub struct SamplerSnapshot {
     pub flags: SamplerFlags,
 }
 
+/// Cached fragment LOD-bias uniform derived from effective per-slot inputs.
+///
+/// Input identity uses raw `f32` bits so signed zero and NaN payload changes
+/// are not hidden by float equality. This cache describes only the derived
+/// bytes; the render encoder's last-bound cache independently decides whether
+/// those bytes need binding in the current pass.
+pub struct LodBiasTableCache {
+    input_bits: Option<[u32; LOD_BIAS_SLOTS]>,
+    bytes: [u8; LOD_BIAS_BYTES],
+}
+
+impl LodBiasTableCache {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            input_bits: None,
+            bytes: [0; LOD_BIAS_BYTES],
+        }
+    }
+
+    /// Rebuild the table when any effective input bit pattern changed.
+    ///
+    /// Returns whether the cached bytes were rebuilt.
+    #[must_use]
+    pub fn update(&mut self, biases: &[f32; LOD_BIAS_SLOTS]) -> bool {
+        let input_bits = biases.map(f32::to_bits);
+        if self.input_bits == Some(input_bits) {
+            return false;
+        }
+        self.bytes = build_lod_bias_bytes(biases);
+        self.input_bits = Some(input_bits);
+        true
+    }
+
+    /// The table derived by the latest [`Self::update`] call.
+    #[must_use]
+    pub const fn bytes(&self) -> &[u8; LOD_BIAS_BYTES] {
+        &self.bytes
+    }
+}
+
+impl Default for LodBiasTableCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Packed-bits sampler cache key.
 ///
 /// Layout (u64 low-to-high):

--- a/windows/core/src/sampler_state/tests.rs
+++ b/windows/core/src/sampler_state/tests.rs
@@ -9,6 +9,7 @@
 use mtld3d_types::{D3DTADDRESS_WRAP, D3DTEXF_LINEAR, D3DTEXF_NONE};
 
 use super::*;
+use crate::passes::LastBoundCache;
 
 fn base() -> SamplerSnapshot {
     SamplerSnapshot {
@@ -191,6 +192,68 @@ fn lod_bias_bytes_carry_the_bias_and_its_exponent() {
     // An unbiased slot must leave the sample unshifted: bias 0, scale 1.
     assert_eq!(row(0, 0).to_bits(), 0.0_f32.to_bits());
     assert_eq!(row(0, 1).to_bits(), 1.0_f32.to_bits());
+}
+
+#[test]
+fn lod_bias_table_cache_rebuilds_only_for_new_input_bits() {
+    let mut cache = LodBiasTableCache::new();
+    let mut biases = [0.0_f32; LOD_BIAS_SLOTS];
+    biases[3] = -0.75;
+
+    assert!(cache.update(&biases), "first table is built");
+    assert_eq!(cache.bytes(), &build_lod_bias_bytes(&biases));
+    assert!(!cache.update(&biases), "identical inputs reuse the table");
+
+    biases[3] = 0.0;
+    biases[7] = -0.75;
+    assert!(
+        cache.update(&biases),
+        "a sampled-slot transition rebuilds the effective table"
+    );
+    assert_eq!(cache.bytes(), &build_lod_bias_bytes(&biases));
+}
+
+#[test]
+fn lod_bias_table_cache_keys_signed_zero_and_nan_by_bits() {
+    let mut cache = LodBiasTableCache::new();
+    let mut biases = [0.0_f32; LOD_BIAS_SLOTS];
+    assert!(cache.update(&biases));
+
+    biases[2] = -0.0;
+    assert!(cache.update(&biases), "signed zero changes the bias lane");
+    assert!(!cache.update(&biases));
+
+    biases[2] = f32::from_bits(0x7FC0_0001);
+    assert!(
+        cache.update(&biases),
+        "NaN input payload participates in identity"
+    );
+    assert!(!cache.update(&biases));
+    biases[2] = f32::from_bits(0x7FC0_0002);
+    assert!(cache.update(&biases), "a different NaN payload rebuilds");
+}
+
+#[test]
+fn lod_bias_table_cache_is_independent_of_pass_bindings() {
+    let mut table = LodBiasTableCache::new();
+    let mut bound = LastBoundCache::new();
+    let mut biases = [0.0_f32; LOD_BIAS_SLOTS];
+    biases[0] = -0.75;
+
+    assert!(table.update(&biases));
+    assert!(bound.ps_lod_bias_changed(table.bytes()));
+    assert!(!table.update(&biases));
+    assert!(!bound.ps_lod_bias_changed(table.bytes()));
+
+    bound.reset();
+    assert!(
+        !table.update(&biases),
+        "a new pass reuses the derived table"
+    );
+    assert!(
+        bound.ps_lod_bias_changed(table.bytes()),
+        "a new pass still binds the table"
+    );
 }
 
 #[test]

--- a/windows/d3d9/src/draw.rs
+++ b/windows/d3d9/src/draw.rs
@@ -2162,17 +2162,13 @@ pub fn emit_draw(enc: &mut FrameEncoder, draw: DrawOp) {
     // Per-slot LOD bias. Bound only for a draw whose shader declares the
     // uniform; the binding then persists on the encoder, so a later biased
     // draw carrying the same table skips the re-bind.
-    if any_lod_bias {
-        let bias_bytes = mtld3d_core::sampler_state::build_lod_bias_bytes(&lod_bias);
-        if enc.last_bound().ps_lod_bias_changed(&bias_bytes) {
-            let ptr = enc.alloc_scratch(&bias_bytes);
-            enc.emit_command(Command::set_fragment_bytes_at(
-                ptr,
-                u32::try_from(mtld3d_core::sampler_state::LOD_BIAS_BYTES)
-                    .expect("LOD bias uniform is 256 bytes"),
-                PS_LOD_BIAS_SLOT,
-            ));
-        }
+    if any_lod_bias && let Some(ptr) = enc.alloc_lod_bias_if_changed(&lod_bias) {
+        enc.emit_command(Command::set_fragment_bytes_at(
+            ptr,
+            u32::try_from(mtld3d_core::sampler_state::LOD_BIAS_BYTES)
+                .expect("LOD bias uniform is 256 bytes"),
+            PS_LOD_BIAS_SLOT,
+        ));
     }
     // The render scale behind a scaled `vPos` read. Bound only for a draw
     // whose shader took the variant, from the bytes that decided the flag;

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -886,6 +886,8 @@ pub struct FrameEncoder {
     /// the previous draw in the same Metal render encoder. Reset on every
     /// new-pass entry from `begin_render_pass_if_needed`.
     last_bound: LastBoundCache,
+    /// Derived LOD-bias uniform, keyed independently of per-pass bindings.
+    lod_bias_table: sampler_state::LodBiasTableCache,
     /// Immutable VS/PS snapshots, valid only within their owning frame and encoder.
     vs_bound_constants: SnapshotBytesCache<ScratchSlice>,
     ps_bound_constants: SnapshotBytesCache<ScratchSlice>,
@@ -1562,6 +1564,7 @@ impl FrameEncoder {
         Self {
             pass_state: PassState::new(),
             last_bound: LastBoundCache::new(),
+            lod_bias_table: sampler_state::LodBiasTableCache::new(),
             vs_bound_constants: SnapshotBytesCache::new(),
             ps_bound_constants: SnapshotBytesCache::new(),
             scratch: ScratchArena::new(),
@@ -5064,6 +5067,23 @@ impl FrameEncoder {
     /// hasn't changed since the previous draw in the current pass.
     pub const fn last_bound(&mut self) -> &mut LastBoundCache {
         &mut self.last_bound
+    }
+
+    /// Allocate the effective LOD-bias table when this pass needs its binding.
+    #[must_use]
+    pub fn alloc_lod_bias_if_changed(
+        &mut self,
+        biases: &[f32; sampler_state::LOD_BIAS_SLOTS],
+    ) -> Option<u64> {
+        let _ = self.lod_bias_table.update(biases);
+        if self
+            .last_bound
+            .ps_lod_bias_changed(self.lod_bias_table.bytes())
+        {
+            Some(self.scratch.alloc(self.lod_bias_table.bytes()))
+        } else {
+            None
+        }
     }
 
     /// Raw pointer to the `OpSub` slot of the encoder's per-frame perf accumulator.


### PR DESCRIPTION
## Problem

A draw using a nonzero `D3DSAMP_MIPMAPLODBIAS` rebuilt the 256-byte fragment uniform before checking whether identical bytes were already bound. Every unchanged draw therefore evaluated `exp2` for all 16 sampler slots even though the existing binding cache suppressed the Metal command.

## Change

Cache the derived uniform by the raw bit patterns of all effective sampled-slot biases. The derived table persists across passes, while the existing last-bound cache remains per-pass, so a fresh render encoder still receives its first binding. Shader sampled-slot transitions continue to change the effective input table, and the all-zero path still skips the table and its binding.

The cache compares input bits rather than float equality, preserving signed-zero and NaN identity. Unit tests cover unchanged reuse, sampled-slot transitions, exact bit identity, and a pass reset reusing the derived bytes while requiring a new binding.

I considered storing the effective inputs in `LastBoundCache`. Its reset is part of the fresh-render-encoder contract, so coupling synthesis to it would repeat the expensive work at each pass boundary. Keeping the computation and binding caches separate matches their different lifetimes.

## Verification

`make fmt`

`make check`, including Clippy, audit and docs

`cd windows && cargo +stable nextest run -p mtld3d-core -p mtld3d-types --target aarch64-apple-darwin`: 1,132 tests passed on the rebased candidate

A standalone native aarch64 release helper benchmark of the production builder followed by `LastBoundCache::ps_lod_bias_changed` measured 22.2 ns per unchanged input. The cached helper path measured 7.5 ns, with exactly one changed bind in one million iterations on both paths. It did not run Wine or a game and does not measure frame rate.

Full isolated make test passes both native workspaces and both PE architectures. Conformance reports no regressions on either architecture, with no baseline change.

## Rules check

Checked against `CONTRIBUTING.md`, `docs/CONVENTIONS.md`, and `docs/ARCHITECTURE.md`. The pure cache logic lives in `mtld3d-core`; the D3D9 encoder only owns and calls it. This adds no static, config key, wire field, dependency, derive, lint suppression, ABI constant, shader-emission change, or duplicated cache. `make check` enforced formatting, Clippy, audit, documentation, and the repository structure rules.

Closes #488
