### PR TITLE
Discard abandoned occlusion query segments on reissue

### DIFF
--- a/windows/core/src/visibility.rs
+++ b/windows/core/src/visibility.rs
@@ -62,6 +62,12 @@ pub enum QueryStatus {
 /// Held by `Arc` so the encoder-side pending list can keep the core alive
 /// past the COM wrapper's refcount reaching zero.
 pub struct VisibilityQueryCore {
+    /// Identity of the most recent BEGIN processed by the encoder.
+    ///
+    /// Even at one billion BEGINs per second, a `u64` lasts more than 584
+    /// years. Overflow panics instead of recycling an identity that an older
+    /// pending segment could still carry.
+    issue_generation: AtomicU64,
     /// Frame submit-seq at `Issue(BEGIN)`.
     ///
     /// Only valid once `status` leaves `NeverIssued`.
@@ -123,6 +129,7 @@ impl VisibilityQueryCore {
     #[must_use]
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
+            issue_generation: AtomicU64::new(0),
             seq_begin: AtomicU64::new(0),
             seq_end: AtomicU64::new(0),
             offset_begin: AtomicU32::new(0),
@@ -152,6 +159,11 @@ impl VisibilityQueryCore {
     /// Metal encoder will write to. Moves the query from
     /// `NeverIssued`/`Issued` back into `Pending` — a second Issue on the
     /// same wrapper reuses the core.
+    ///
+    /// # Panics
+    ///
+    /// Panics after `u64::MAX` brackets rather than recycling an issue
+    /// generation that a pending segment could still carry.
     pub fn begin(
         &self,
         seq: u64,
@@ -160,6 +172,11 @@ impl VisibilityQueryCore {
         render: (u32, u32),
         draws_seen: u64,
     ) {
+        self.issue_generation
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |generation| {
+                generation.checked_add(1)
+            })
+            .expect("visibility query issue generation exhausted");
         self.seq_begin.store(seq, Ordering::Release);
         self.offset_begin.store(offset, Ordering::Release);
         self.logical_area.store(area(logical), Ordering::Release);
@@ -274,6 +291,11 @@ impl VisibilityQueryCore {
     /// this query yet.
     pub fn seq_end_loaded(&self) -> u64 {
         self.seq_end.load(Ordering::Acquire)
+    }
+
+    /// Identity of the bracket whose BEGIN the encoder processed most recently.
+    fn issue_generation(&self) -> u64 {
+        self.issue_generation.load(Ordering::Acquire)
     }
 
     /// Fold one retired segment's sample count into the span's running total.
@@ -552,6 +574,7 @@ impl VisibilityBufferPool {
 struct PendingSegment {
     submit_seq: u64,
     core: Arc<VisibilityQueryCore>,
+    issue_generation: u64,
     span: (u32, u32),
     /// Whether this segment carries the query's `Issue(END)`.
     ///
@@ -752,9 +775,11 @@ impl VisibilityQueryState {
         span: (u32, u32),
         closes_span: bool,
     ) {
+        let issue_generation = core.issue_generation();
         self.pending.push_back(PendingSegment {
             submit_seq,
             core,
+            issue_generation,
             span,
             closes_span,
         });
@@ -772,6 +797,7 @@ impl VisibilityQueryState {
             self.pending.push_back(PendingSegment {
                 submit_seq,
                 core: core.clone(),
+                issue_generation: core.issue_generation(),
                 span: (core.offset_begin(), end),
                 closes_span: false,
             });
@@ -825,8 +851,11 @@ impl VisibilityQueryState {
     /// since a frame that reserved no slot for the query reserved no buffer
     /// either. A non-empty span whose buffer cannot be found (retired and
     /// evicted before intake ran, which the normal flow never produces)
-    /// leaves the whole span uncounted. Retired buffers whose seq has been
-    /// reached then move into the free list so the next frame can reuse them.
+    /// leaves the whole span uncounted. A segment from a bracket abandoned by
+    /// a later BEGIN is skipped instead of being folded into that replacement
+    /// bracket. Its retired buffer still moves through the normal release path
+    /// once its seq has been reached, so abandoning a bracket changes no
+    /// storage lifetime.
     ///
     /// Each retired buffer's `PageBox` points at PE-allocated Shared storage
     /// wrapped by Metal. Once `coherent_seq >= release_seq` the GPU is done
@@ -849,6 +878,9 @@ impl VisibilityQueryState {
                 continue;
             }
             let entry = self.pending.remove(i).expect("bound-checked");
+            if entry.issue_generation != entry.core.issue_generation() {
+                continue;
+            }
             let (begin, end) = entry.span;
             let sum = if begin >= end {
                 0

--- a/windows/core/src/visibility/tests.rs
+++ b/windows/core/src/visibility/tests.rs
@@ -7,7 +7,8 @@
 //! over-cap retire hands the evicted entry back. The segment cases pin what a span that
 //! outlives its submit does: it is cut at the boundary, reopened in the continuation, and
 //! the two sums add up, while a span that lost its slots reads `u32::MAX` unless it held
-//! no draw, where zero is exact.
+//! no draw, where zero is exact. Reissuing before intake discards the pending segments of
+//! the abandoned bracket while keeping the replacement bracket's result.
 
 use mtld3d_shared::MetalHandle;
 
@@ -287,6 +288,65 @@ fn state_intake_adds_a_split_span_up_across_its_two_frames() {
     state.intake_completed(2);
     assert_eq!(core.status(), QueryStatus::Issued);
     assert_eq!(core.get_u32(), 1_000);
+}
+
+#[test]
+fn state_reissue_before_intake_discards_the_abandoned_span() {
+    use super::{QueryStatus, VisibilityQueryState};
+    let mut state = VisibilityQueryState::new();
+    let core = VisibilityQueryCore::new();
+    let mut buffer = dummy_buf(1);
+    write_slot(&mut buffer, 0, 100);
+    write_slot(&mut buffer, 1, 7);
+    state.pool.retire(buffer);
+
+    core.begin(1, 0, (640, 480), (640, 480), 0);
+    core.end(1, 1);
+    state.push_pending(1, core.clone(), (0, 1), true);
+
+    // Reissuing before the first segment retires abandons that bracket. Both
+    // segments still share the frame's visibility buffer, but only the second
+    // bracket belongs to the result the application asked for most recently.
+    core.begin(1, 1, (640, 480), (640, 480), 1);
+    core.end(1, 2);
+    state.push_pending(1, core.clone(), (1, 2), true);
+
+    state.intake_completed(1);
+    assert_eq!(core.status(), QueryStatus::Issued);
+    assert_eq!(core.get_u32(), 7);
+}
+
+#[test]
+fn state_reissue_waits_for_the_replacement_segments_sequence() {
+    use super::{QueryStatus, VisibilityQueryState};
+    let mut state = VisibilityQueryState::new();
+    let core = VisibilityQueryCore::new();
+
+    let mut abandoned = dummy_buf(1);
+    write_slot(&mut abandoned, 0, 100);
+    state.pool.retire(abandoned);
+    core.begin(1, 0, (640, 480), (640, 480), 0);
+    core.end(1, 1);
+    state.push_pending(1, core.clone(), (0, 1), true);
+
+    let mut replacement = dummy_buf(2);
+    write_slot(&mut replacement, 0, 7);
+    state.pool.retire(replacement);
+    core.begin(2, 0, (640, 480), (640, 480), 1);
+    core.end(2, 2);
+    state.push_pending(2, core.clone(), (0, 1), true);
+
+    state.intake_completed(1);
+    assert_eq!(
+        core.status(),
+        QueryStatus::Pending,
+        "the abandoned result does not complete the replacement bracket"
+    );
+    assert_eq!(state.pending.len(), 1);
+
+    state.intake_completed(2);
+    assert_eq!(core.status(), QueryStatus::Issued);
+    assert_eq!(core.get_u32(), 7);
 }
 
 #[test]


### PR DESCRIPTION
Reissuing an occlusion query before the previous bracket's results were taken in could combine both brackets. A native state regression that writes 100 for the abandoned bracket and 7 for its replacement returned 107 instead of 7 because pending segments only identified their shared query core. BEGIN reset the accumulator, but an older segment could still retire later and fold into the replacement result.

Advance a checked `u64` issue generation for every encoder-side BEGIN and record it on each pending segment, including frame-split segments. Intake now skips segments from abandoned generations while retiring their buffers through the existing pool path. The checked increment prevents an identity collision instead of allowing a wrapped generation to match a still-pending segment.

Removing pending entries at BEGIN would couple bracket invalidation to the queue that owns buffer retirement. Keeping the entries until their submit sequences complete preserves the existing split, retirement, and storage-lifetime flow.

Verification:

- Native regression before the fix: 100 + 7 produced 107 instead of 7.
- Native regression after the fix: the replacement bracket produced 7.
- The split-sequence regression leaves the replacement Pending after the abandoned bracket retires, then publishes only 7 when the replacement sequence completes.
- `make fmt`
- `make check`
- `make test-unit`: 1,107 Windows tests and 297 Unix tests passed.
- `make ISOLATED=1 test`: both native workspaces and both PE architectures passed on the final candidate.
- `make ISOLATED=1 conformance`: no regressions on either architecture, no baseline change.

Rules check:

- The change stays inside the existing `mtld3d-core` query state and does not alter the PE/Unix boundary or any Metal handles.
- It adds no statics, config keys, wire fields, dependencies, derives, lint suppressions, unsafe code, or duplicated ABI constants.
- The existing pending segment owns the generation value, and the existing intake path owns filtering and retirement.
- `make check` passed the formatting, clippy, audit, and documentation gates from `CONTRIBUTING.md`, `docs/CONVENTIONS.md`, and `docs/ARCHITECTURE.md`.

Closes #496
