### PR TITLE
Wait briefly for exit after a process-group EPERM

### DIFF
--- a/unix/e2e/src/run.rs
+++ b/unix/e2e/src/run.rs
@@ -89,6 +89,12 @@ const GPU_HANG_MARKERS: [&str; 2] = [
 /// How often the bounded wait for the process's exit looks again.
 const EXIT_POLL: Duration = Duration::from_millis(20);
 
+/// How long EPERM may wait for an owned group leader to become waitable.
+const SIGNAL_EXIT_GRACE: Duration = Duration::from_secs(1);
+
+/// How often an EPERM exit observation retries during its grace.
+const SIGNAL_EXIT_POLL: Duration = Duration::from_millis(1);
+
 /// How long stderr may stay open after the process has ended.
 ///
 /// A pipe every holder has died on closes within milliseconds of the kill;
@@ -372,17 +378,9 @@ impl ProcessGroup {
         if result == 0 {
             return Ok(());
         }
-        let error = std::io::Error::last_os_error();
-        // macOS skips zombies when signalling a group and returns EPERM when
-        // no live member could be signalled. The retained zombie alone therefore
-        // produces EPERM too. This does not prove every descendant exited;
-        // an open stderr pipe still reports a survivor.
-        if error.raw_os_error() == Some(libc::ESRCH)
-            || (error.raw_os_error() == Some(libc::EPERM) && self.observe_exit(libc::WNOHANG)?)
-        {
-            return Ok(());
-        }
-        Err(error)
+        resolve_group_signal_error(std::io::Error::last_os_error(), SIGNAL_EXIT_GRACE, || {
+            self.observe_exit(libc::WNOHANG)
+        })
     }
 }
 
@@ -409,6 +407,35 @@ impl Drop for ProcessGroup {
         {
             eprintln!("[e2e] reap process during cleanup failed: {error}");
         }
+    }
+}
+
+/// Resolve a group signal error without consuming the leader's waitable status.
+fn resolve_group_signal_error(
+    error: std::io::Error,
+    grace: Duration,
+    mut observe_exit: impl FnMut() -> std::io::Result<bool>,
+) -> std::io::Result<()> {
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        return Ok(());
+    }
+    if error.raw_os_error() != Some(libc::EPERM) {
+        return Err(error);
+    }
+    // macOS can stop finding an exiting group member before waitid reports
+    // its exit, and skips retained zombies too. Accept EPERM only after exit
+    // is observed without reaping. This does not prove descendants exited;
+    // an open stderr pipe still reports a survivor.
+    let deadline = Instant::now() + grace;
+    loop {
+        if observe_exit()? {
+            return Ok(());
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(error);
+        }
+        thread::sleep(SIGNAL_EXIT_POLL.min(remaining));
     }
 }
 

--- a/unix/e2e/src/run/tests.rs
+++ b/unix/e2e/src/run/tests.rs
@@ -220,6 +220,18 @@ fn observing_a_clean_exit_keeps_the_leader_waitable() {
             .expect("observe exit again")
     );
     assert_waitable(pid);
+    super::resolve_group_signal_error(
+        std::io::Error::from_raw_os_error(libc::EPERM),
+        Duration::ZERO,
+        || group.observe_exit(libc::WNOHANG),
+    )
+    .expect("EPERM accepts an already waitable leader");
+    group
+        .wait_killed()
+        .expect("signal after observing clean exit");
+    assert_waitable(pid);
+    group.kill().expect("final signal before reap");
+    assert_waitable(pid);
     let status = group.reap().expect("reap group leader");
     assert_eq!(status.code(), Some(7));
     assert_reaped(pid);
@@ -264,12 +276,19 @@ fn losing_the_waitable_child_disables_group_signals() {
     // Model an external waiter consuming the child, without reusing any ID.
     child.wait().expect("external reap");
     let mut group = ProcessGroup { child: Some(child) };
-    let error = group
-        .kill()
-        .expect_err("must not signal after external reap");
+    let error = super::resolve_group_signal_error(
+        std::io::Error::from_raw_os_error(libc::EPERM),
+        Duration::from_mins(1),
+        || group.observe_exit(libc::WNOHANG),
+    )
+    .expect_err("EPERM observation must revoke ownership after external reap");
     assert_eq!(error.raw_os_error(), Some(libc::ECHILD));
     assert!(group.child.is_none());
     let error = group.kill().expect_err("ownership stays revoked");
+    assert_eq!(error.raw_os_error(), Some(libc::ECHILD));
+    let error = group
+        .signal_group()
+        .expect_err("no signal without ownership");
     assert_eq!(error.raw_os_error(), Some(libc::ECHILD));
 }
 
@@ -301,6 +320,75 @@ fn an_unexpected_wait_error_retains_ownership_for_cleanup() {
     assert!(group.child.is_some());
     drop(group);
     assert_reaped(pid);
+}
+
+#[test]
+fn a_group_permission_error_waits_for_delayed_exit_observation() {
+    let mut observations = [false, false, true].into_iter();
+    super::resolve_group_signal_error(
+        std::io::Error::from_raw_os_error(libc::EPERM),
+        Duration::from_mins(1),
+        || Ok(observations.next().expect("stop observing once exited")),
+    )
+    .expect("an exiting leader becomes waitable after EPERM");
+    assert_eq!(observations.next(), None);
+}
+
+#[test]
+fn a_group_permission_error_survives_the_exit_observation_deadline() {
+    let mut observations = 0;
+    let error = super::resolve_group_signal_error(
+        std::io::Error::from_raw_os_error(libc::EPERM),
+        Duration::ZERO,
+        || {
+            observations += 1;
+            Ok(false)
+        },
+    )
+    .expect_err("a still-running leader does not excuse EPERM");
+    assert_eq!(error.raw_os_error(), Some(libc::EPERM));
+    assert_eq!(observations, 1);
+}
+
+#[test]
+fn a_group_permission_error_propagates_wait_errors_without_retrying() {
+    for errno in [libc::ECHILD, libc::EIO] {
+        let mut observations = 0;
+        let error = super::resolve_group_signal_error(
+            std::io::Error::from_raw_os_error(libc::EPERM),
+            Duration::from_mins(1),
+            || {
+                observations += 1;
+                if observations == 1 {
+                    Ok(false)
+                } else {
+                    Err(std::io::Error::from_raw_os_error(errno))
+                }
+            },
+        )
+        .expect_err("wait errors must propagate");
+        assert_eq!(error.raw_os_error(), Some(errno));
+        assert_eq!(observations, 2);
+    }
+}
+
+#[test]
+fn other_group_signal_errors_do_not_observe_exit() {
+    for errno in [libc::EINVAL, libc::EACCES, libc::EINTR] {
+        let error = super::resolve_group_signal_error(
+            std::io::Error::from_raw_os_error(errno),
+            Duration::from_mins(1),
+            || panic!("only EPERM needs exit observation"),
+        )
+        .expect_err("unrelated signal errors must propagate immediately");
+        assert_eq!(error.raw_os_error(), Some(errno));
+    }
+    super::resolve_group_signal_error(
+        std::io::Error::from_raw_os_error(libc::ESRCH),
+        Duration::from_mins(1),
+        || panic!("an absent group needs no exit observation"),
+    )
+    .expect("ESRCH still accepts an absent group");
 }
 
 fn assert_waitable(pid: u32) {


### PR DESCRIPTION
A cleanly exiting e2e child can fail with `Operation not permitted (os error 1)`: macOS can stop finding the group member before a non-reaping wait reports its exit. The immediate EPERM classifier rejected that interval.

Allow up to one second for non-reaping exit observation after EPERM, with one-millisecond sleeps between observations. Keep the original permission error if the leader is still not waitable at the deadline, propagate wait errors, and leave other signal errors immediate. ECHILD revokes ownership. The leader remains unreaped through the final descendant signals and stderr drain. Accepting EPERM unconditionally would hide genuine stop failures; a blocking exit observation would remove the classifier's deadline.

Verification: `make fmt` and `make check` passed, including formatting, Clippy, audit and documentation. `cargo test --manifest-path unix/Cargo.toml --bin mtld3d-e2e -- --nocapture` passed all 62 native runner tests. The deterministic false, false, true regression failed with EPERM under the extracted original one-observation logic and passed with the grace. Tests cover expired grace, wait errors, ECHILD revocation, immediate other errors, retained child identity, missed descendants, hang reports and timeouts. The existing clean-exit race test passed 500 serial repetitions. This campaign is integration evidence, not a measurement of production failure frequency. Full isolated `make test` passes both native workspaces and both PE architectures on the final landing candidate. No rendering or shared-crate behavior changed, so conformance is not applicable.

The grace bounds error classification only. The existing Drop path still logs a persistent signal failure and waits for the leader, which can block for a genuinely unsignalable live child. Changing that needs a separate failed-termination ownership policy.

Rules check: CONTRIBUTING.md's single-change and failure-before/success-after requirements are met. CONVENTIONS.md's native test placement and existing syscall safety contracts are preserved; the only new constants set the signal-error observation budget and poll interval. No statics, config keys, wire fields, dependencies, derives, lint suppressions or duplicated runtime helpers are introduced. ARCHITECTURE.md's PE/Unix boundary and graphics threading are unchanged.

Closes #588
