### PR TITLE
Reuse cached no-color pipeline siblings on warm misses

### DIFF
--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -1113,7 +1113,8 @@ pub struct FrameEncoder {
     /// sibling of the emitted handle is recorded here. Consumed at submit
     /// time by `PassState::strip_color_from_no_color_draw_passes` (Rule H)
     /// to retroactively rewrite the pass's `SetRenderPipelineState`
-    /// commands. Process-lifetime (the `pipeline_cache` itself is
+    /// commands, and queried by later draws before rebuilding a known
+    /// sibling. Process-lifetime (the `pipeline_cache` itself is
     /// process-lifetime, so the handles never dangle); no per-frame clear.
     no_color_pipeline_alt: FxHashMap<u64, MetalHandle<MTLRenderPipelineStateKind>>,
     /// Single-entry "L0" memo in front of `pipeline_cache`.
@@ -5736,12 +5737,12 @@ impl FrameEncoder {
         // previous one returns the cached handle without rebuilding the
         // `PipelineKey` (its D3D→Metal translations) or probing
         // `pipeline_cache`. It also skips the no-color twin's second resolve
-        // below: a hit means the populating miss already ran it, and
-        // `no_color_pipeline_alt` is process-lifetime, so the side-map entry
-        // is still present. Only successful resolves are memoised, so a
-        // failing snapshot still flows through the unchanged path (and keeps
-        // its existing per-draw error/retry behaviour). The `match` copies
-        // the handle out so the memo borrow ends before the `&mut perf` bump.
+        // below. A successful sibling mapping is process-lifetime; after a
+        // failed sibling build, the next L0 miss retries it. Only successful
+        // primary resolves are memoised, so a failing snapshot still flows
+        // through the unchanged path (and keeps its existing per-draw
+        // error/retry behaviour). The `match` copies the handle out so the
+        // memo borrow ends before the `&mut perf` bump.
         let memo_hit = match &self.last_pipeline_memo {
             Some((prev, handle)) if *prev == *snapshot => Some(*handle),
             _ => None,
@@ -5754,13 +5755,19 @@ impl FrameEncoder {
         // Dual-build for zero-mask draws: build the matching no-color
         // variant up-front so pass-finalisation (Rule H) can swap to it
         // retroactively if every draw in the pass had `mask == 0`.
-        // Building both is cheap — cache hit on the second call after
-        // the first frame; CreateRenderPipeline thunk on cold-miss.
-        if !with_color.is_null() && snapshot.writes_no_color() && snapshot.has_color_output() {
+        // A successful sibling mapping stays valid as long as the pipeline
+        // cache, so an L0 miss can reuse it without rebuilding the alternate
+        // snapshot and key. A failed sibling build leaves no mapping and is
+        // retried on the next L0 miss.
+        if !with_color.is_null()
+            && snapshot.writes_no_color()
+            && snapshot.has_color_output()
+            && !self.no_color_pipeline_alt.contains_key(&with_color.raw())
+        {
             // No-color twin: same identity except the attach flag (and no
             // render targets 1..3, which Rule H strips together with target
             // 0). Explicit `.clone()` because PipelineSnapshot is no longer
-            // Copy; fires once per unique pipeline (cache hit thereafter).
+            // Copy; fires on L0 misses until the sibling builds successfully.
             let mut alt = snapshot.clone();
             alt.attach
                 .remove(mtld3d_core::pipeline_state::PipelineAttachFlags::HAS_COLOR_OUTPUT);


### PR DESCRIPTION
Alternating warm pipelines with color writes disabled miss the single-entry pipeline memo. The ordinary pipeline resolves from `pipeline_cache`, but `get_or_create_pipeline` then cloned its 48-byte snapshot, translated and hashed a second key, resolved the already-known no-color sibling, and reinserted the same handle pair on every alternation.

Check the existing `no_color_pipeline_alt` mapping after the ordinary resolve and build the sibling only when that mapping is absent. Successful mappings have the same lifetime as the pipeline cache. A failed sibling build still leaves no mapping, so a later L0 miss retries it, and pass finalization keeps its existing safe fallback when no sibling is available.

The alternative was another memo or a broader L0 redesign. The existing sibling map already holds the required successful result and does not evict, so another cache would duplicate state.

The issue's release benchmark used the production pipeline types, key translation, and `FxHashMap` on native aarch64. It measured about 87 ns per affected draw for alternating warm snapshots. This is a CPU model of the path, not a Wine encoder or game-frame measurement, and no engine FPS claim follows from it.

Verification: `make fmt` and `make check` passed during issue verification. The retained host-native `mtld3d-core` and `mtld3d-types` run passed 1,122 tests. An earlier full unit run passed 1,105 Windows core/types tests and 297 Unix workspace tests. Full isolated make test, including both native workspaces and both PE architectures, and conformance pass on the final landing candidate with no baseline change.

Rules check: this changes only the existing warm pipeline resolver path. It introduces no statics, config keys, wire fields, dependencies, derives, lint suppressions, classifier or capability changes, cache schema changes, or duplicated helper logic. `make check` ran the formatting, audit, documentation, and Clippy/build gates required by `CONTRIBUTING.md` and `docs/CONVENTIONS.md`. The existing process-lifetime pipeline-cache ownership and pass-finalization fallback remain within the threading and boundary contracts in `docs/ARCHITECTURE.md`.

Closes #489
