### PR TITLE
Honor predicates on mova address writes

### DIFF
--- a/windows/core/src/dxso/emit.rs
+++ b/windows/core/src/dxso/emit.rs
@@ -2434,7 +2434,13 @@ fn translate_instruction(
                     "MovA without dst".to_string(),
                 ));
             };
-            write_address_register(out, dst, &srcs[0], /* use_floor */ false);
+            write_address_register(
+                out,
+                dst,
+                &srcs[0],
+                /* use_floor */ false,
+                inst.predicate.as_ref(),
+            );
             return Ok(());
         }
         op => return Err(EmitError::UnsupportedInstruction(format!("{op:?}"))),
@@ -2446,7 +2452,7 @@ fn translate_instruction(
         // `RegKind::Addr` through the int4 `a` register, bypassing the
         // float `store_dst` path the same way the `MovA` arm does.
         if dst.reg.kind == RegKind::Addr && ctx.is_vertex() {
-            write_address_register(out, dst, &expr, /* use_floor */ true);
+            write_address_register(out, dst, &expr, /* use_floor */ true, None);
             return Ok(());
         }
         // Predicated execution keeps each destination component whose
@@ -2800,21 +2806,38 @@ fn apply_src_modifier(expr: &str, m: SrcModifier) -> String {
 
 /// Write the VS int4 address register `a`.
 ///
-/// Rounds each component to the nearest integer per the D3D9 spec. Shared by
-/// `mova` (SM2+) and a plain `mov a0, …` (`vs_1_1`, which predates `mova`).
-/// Bypasses `store_dst`'s `saturate()` / float-swizzle path — neither makes
-/// sense for the int4 `a`.
-fn write_address_register(out: &mut String, dst: DstOperand, value: &str, use_floor: bool) {
+/// Rounds and conditionally writes each selected address-register component.
+///
+/// Shared by `mova` (SM2+) and a plain `mov a0, …` (`vs_1_1`, which predates
+/// `mova`). Bypasses `store_dst`'s `saturate()` / float-swizzle path because
+/// neither applies to the int4 `a`.
+fn write_address_register(
+    out: &mut String,
+    dst: DstOperand,
+    value: &str,
+    use_floor: bool,
+    predicate: Option<&SrcOperand>,
+) {
     // D3D9: `mova` (SM2+) rounds the float to the nearest integer; a plain
     // `mov` to the address register (vs_1_1, which has no `mova`) FLOORS it
     // (mova -2.4 → -2, but mov -2.4 → -3).
     let conv = if use_floor { "floor" } else { "round" };
     let rounded = format!("int4({conv}({value}))");
-    if dst.write_mask == WriteMask::ALL {
-        let _ = writeln!(out, "    a = {rounded};");
+    let mask = dst.write_mask;
+    let (target, value) = if mask == WriteMask::ALL {
+        ("a".to_string(), rounded)
     } else {
-        let chars = write_mask_chars(dst.write_mask);
-        let _ = writeln!(out, "    a.{chars} = ({rounded}).{chars};");
+        let chars = write_mask_chars(mask);
+        (format!("a.{chars}"), format!("({rounded}).{chars}"))
+    };
+    if let Some(pred) = predicate {
+        let predicate = predicate_mask_expr(pred, mask);
+        let _ = writeln!(
+            out,
+            "    {target} = select({target}, {value}, {predicate});"
+        );
+    } else {
+        let _ = writeln!(out, "    {target} = {value};");
     }
 }
 

--- a/windows/core/src/dxso/emit/tests.rs
+++ b/windows/core/src/dxso/emit/tests.rs
@@ -421,6 +421,129 @@ fn mova_respects_write_mask() {
 }
 
 #[test]
+fn predicated_mova_preserves_false_address_components() {
+    // vs_3_0 {
+    //   dcl_position v0; dcl_position o0;
+    //   def c0, 0, 1, 0, 1; def c1, 0.5, 0.5, 0.5, 0.5;
+    //   def c2, 2, 2, 2, 2; def c3, 9, 9, 9, 9;
+    //   setp_lt p0, c0, c1; mova a0, c2; (p0) mova a0, c3;
+    //   mov o0, v0;
+    // }
+    let setp_lt_token = u32::from(OP_SETP) | ((4u32) << 16) | (3u32 << 24);
+    let predicated_mova_token = u32::from(OP_MOVA) | (1u32 << 28) | (3u32 << 24);
+    let bc = vec![
+        VS3_HEADER,
+        opcode_token(OP_DCL, 2),
+        dcl_usage_token(DCL_POSITION, 0),
+        dst_token(TYPE_INPUT, 0, 0xF, false),
+        opcode_token(OP_DCL, 2),
+        dcl_usage_token(DCL_POSITION, 0),
+        dst_token(TYPE_OUTPUT, 0, 0xF, false),
+        opcode_token(OP_DEF, 5),
+        dst_token(TYPE_CONST, 0, 0xF, false),
+        f32::to_bits(0.0),
+        f32::to_bits(1.0),
+        f32::to_bits(0.0),
+        f32::to_bits(1.0),
+        opcode_token(OP_DEF, 5),
+        dst_token(TYPE_CONST, 1, 0xF, false),
+        f32::to_bits(0.5),
+        f32::to_bits(0.5),
+        f32::to_bits(0.5),
+        f32::to_bits(0.5),
+        opcode_token(OP_DEF, 5),
+        dst_token(TYPE_CONST, 2, 0xF, false),
+        f32::to_bits(2.0),
+        f32::to_bits(2.0),
+        f32::to_bits(2.0),
+        f32::to_bits(2.0),
+        opcode_token(OP_DEF, 5),
+        dst_token(TYPE_CONST, 3, 0xF, false),
+        f32::to_bits(9.0),
+        f32::to_bits(9.0),
+        f32::to_bits(9.0),
+        f32::to_bits(9.0),
+        setp_lt_token,
+        dst_token(TYPE_PREDICATE, 0, 0xF, false),
+        src_token(TYPE_CONST, 0, SWIZ_IDENTITY, 0),
+        src_token(TYPE_CONST, 1, SWIZ_IDENTITY, 0),
+        opcode_token(OP_MOVA, 2),
+        dst_token(TYPE_ADDR, 0, 0xF, false),
+        src_token(TYPE_CONST, 2, SWIZ_IDENTITY, 0),
+        predicated_mova_token,
+        dst_token(TYPE_ADDR, 0, 0xF, false),
+        src_token(TYPE_PREDICATE, 0, SWIZ_IDENTITY, 0),
+        src_token(TYPE_CONST, 3, SWIZ_IDENTITY, 0),
+        opcode_token(OP_MOV, 2),
+        dst_token(TYPE_OUTPUT, 0, 0xF, false),
+        src_token(TYPE_INPUT, 0, SWIZ_IDENTITY, 0),
+        END_TOKEN,
+    ];
+    let vs = parse(&bc).expect("VS3 parse");
+    assert_eq!(bc.len(), 46, "keep the issue proof's exact bytecode words");
+    assert!(
+        vs.instructions[2].predicate.is_some(),
+        "parser must preserve the mova predicate operand"
+    );
+    let vs_msl = emit_vs_programmable(&vs).expect("emit VS3");
+    assert!(
+        vs_msl.contains("a = select(a, int4(round(c3)), p0);"),
+        "predicated mova must retain a0.yw when p0.yw is false:\n{vs_msl}"
+    );
+    metal_compile_or_fail(&vs_msl);
+}
+
+#[test]
+fn predicated_mova_maps_replicated_negated_partial_masks() {
+    // vs_3_0 {
+    //   dcl_position v0; dcl_position o0; setp_lt p0, c0, c1;
+    //   mova a0, c2; (p0.zzzz) mova a0.yw, c3;
+    //   (!p0) mova a0.xz, c0; mov o0, v0;
+    // }
+    let setp_lt_token = u32::from(OP_SETP) | ((4u32) << 16) | (3u32 << 24);
+    let predicated_mova_token = u32::from(OP_MOVA) | (1u32 << 28) | (3u32 << 24);
+    let bc = vec![
+        VS3_HEADER,
+        opcode_token(OP_DCL, 2),
+        dcl_usage_token(DCL_POSITION, 0),
+        dst_token(TYPE_INPUT, 0, 0xF, false),
+        opcode_token(OP_DCL, 2),
+        dcl_usage_token(DCL_POSITION, 0),
+        dst_token(TYPE_OUTPUT, 0, 0xF, false),
+        setp_lt_token,
+        dst_token(TYPE_PREDICATE, 0, 0xF, false),
+        src_token(TYPE_CONST, 0, SWIZ_IDENTITY, 0),
+        src_token(TYPE_CONST, 1, SWIZ_IDENTITY, 0),
+        opcode_token(OP_MOVA, 2),
+        dst_token(TYPE_ADDR, 0, 0xF, false),
+        src_token(TYPE_CONST, 2, SWIZ_IDENTITY, 0),
+        predicated_mova_token,
+        dst_token(TYPE_ADDR, 0, 0b1010, false),
+        src_token(TYPE_PREDICATE, 0, 0xAA /* .zzzz */, 0),
+        src_token(TYPE_CONST, 3, SWIZ_IDENTITY, 0),
+        predicated_mova_token,
+        dst_token(TYPE_ADDR, 0, 0b0101, false),
+        src_token(TYPE_PREDICATE, 0, SWIZ_IDENTITY, 13 /* logical NOT */),
+        src_token(TYPE_CONST, 0, SWIZ_IDENTITY, 0),
+        opcode_token(OP_MOV, 2),
+        dst_token(TYPE_OUTPUT, 0, 0xF, false),
+        src_token(TYPE_INPUT, 0, SWIZ_IDENTITY, 0),
+        END_TOKEN,
+    ];
+    let vs = parse(&bc).expect("VS3 parse");
+    let vs_msl = emit_vs_programmable(&vs).expect("emit VS3");
+    assert!(
+        vs_msl.contains("a.yw = select(a.yw, (int4(round(vs_c[3]))).yw, p0.zz);"),
+        "replicate predicate must cover only address components in the write mask:\n{vs_msl}"
+    );
+    assert!(
+        vs_msl.contains("a.xz = select(a.xz, (int4(round(vs_c[0]))).xz, !(p0.xz));"),
+        "predicate NOT must invert each address component in the write mask:\n{vs_msl}"
+    );
+    metal_compile_or_fail(&vs_msl);
+}
+
+#[test]
 fn reading_addr_register_casts_to_float4() {
     // vs_2_0 { dcl_position v0; mova a0, v0; mov r0, a0; mov oPos, v0; }
     let bc = vec![

--- a/windows/core/src/shader_cache.rs
+++ b/windows/core/src/shader_cache.rs
@@ -292,7 +292,10 @@ use crate::shader_compile_stats::CompileBucket;
 ///
 /// `72` applies sampler operand swizzles to programmable texture sample results,
 /// changing the MSL of every shader that uses a non-identity sampler swizzle.
-pub const SHADER_CACHE_SCHEMA_VERSION: u32 = 72;
+///
+/// `73` applies componentwise predicate selection to `mova` writes of the
+/// integer address register, changing programmable vertex shader MSL.
+pub const SHADER_CACHE_SCHEMA_VERSION: u32 = 73;
 
 /// File magic.
 ///


### PR DESCRIPTION
A predicated VS3 `mova` ignored its predicate because the opcode returned through the integer address-register store before the normal predicated destination path. With `p0 = (true, false, true, false)`, initializing `a0` to 2 and executing `(p0) mova a0, 9` therefore produced `(9, 9, 9, 9)` instead of `(9, 2, 9, 2)`.

Pass the parsed predicate into the address-register store and use the shared component-mask lowering from #487. The store now preserves each false lane, maps predicate swizzles against the destination write mask, handles replicate swizzles and logical negation, and keeps the existing `round` conversion for SM2+ `mova`. The unpredicated SM1 `mov a0` path still uses `floor`.

Wrapping the whole write in one scalar condition was considered, but that loses the per-component predicate contract and gives the wrong result for mixed predicate vectors. Reusing the component-mask helper also keeps floating and integer destination semantics aligned.

The shader-cache schema advances to 73 because programmable vertex shader MSL changes.

Verification: the initialized 46-word parser/emitter regression failed before the change with an unconditional `a = int4(round(c3));` and passes after with `a = select(a, int4(round(c3)), p0);`. Additional cases cover a replicated predicate on `a0.yw` and a negated predicate on `a0.xz`. On the final integrated commit, both focused tests pass with `--nocapture`, both generated shaders compile through the real Metal API at language version 2.4, and `make fmt` and `make check` pass. Before the final integration, the broader `make test-unit` run passed 1,112 Windows/core/type tests and 306 unix tests. Full isolated `make test` passes both native workspaces and both PE architectures on the final landing candidate. Conformance reports no regressions on either architecture, with no baseline change.

Rules check: no statics, config keys, wire fields, dependencies, derives, lint suppressions, public visibility, aliases, unsafe code, Objective-C calls, maps, or duplicated predicate helpers are introduced. No PE/Unix boundary, thunk, command, pointer-backing, threading, or Metal resource-lifetime contract changes. The cache schema bump is the companion edit required by `CONTRIBUTING.md`; `make check` passed the `CONVENTIONS.md` rules and architecture audit.

Closes #544
