### PR TITLE
Avoid stale pacing applies after a window retarget

### DIFF
--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -4000,6 +4000,7 @@ extern "system" fn device_reset(this: *mut c_void, present_params: *mut c_void) 
     } else {
         pp.device_window
     };
+    let retargeted = target_window != dev.window();
     if !resolve_reset_window_mode(dev, target_window, &mut pp) {
         warn!(
             target: LOG_TARGET,
@@ -4045,7 +4046,12 @@ extern "system" fn device_reset(this: *mut c_void, present_params: *mut c_void) 
     // A `Reset` may name another `hDeviceWindow`. The presentation surface
     // and the window subclass both live on the window the device attached, so
     // they move across before anything is recreated against the new one.
-    if target_window != dev.window() {
+    if retargeted {
+        // A pending change not yet stamped onto a frame would otherwise ride
+        // the old-layer continuation built by the retarget flush, then reach
+        // the encoder after that layer's attachment record is retired. The
+        // fresh attach below receives this Reset's pacing directly.
+        dev.pending_display_sync_enabled = None;
         retarget_device_window(dev, &pp, target_window);
     }
 
@@ -4069,8 +4075,8 @@ extern "system" fn device_reset(this: *mut c_void, present_params: *mut c_void) 
         // already matched the back-buffer to the new client size (or the game
         // Reset with identical dims). Re-issuing the recreate cycle would be a
         // wasteful no-op — up to ~tens of ms per Reset depending on GPU
-        // workload depth. State-defaults + reseed + display-sync queue below
-        // still run unconditionally (`Reset` always clobbers state per spec).
+        // workload depth. State-defaults + reseed still run unconditionally
+        // (`Reset` always clobbers state per spec).
         // The implicit depth-stencil is still reconciled, since the
         // EnableAutoDepthStencil flag can flip without a resize (a no-op when
         // it is unchanged, so the fast path stays fast).
@@ -4122,10 +4128,11 @@ extern "system" fn device_reset(this: *mut c_void, present_params: *mut c_void) 
     dev.reset_to_defaults();
     dev.flags.remove(DeviceFlags::NOT_RESET);
 
-    // 9. Defer the PresentationInterval change to the next frame's first
-    //    `nextDrawable`. Mutating `displaySyncEnabled` synchronously here
-    //    races the encoder's in-flight submission.
-    if !dev.layer_handle.is_null() {
+    // 9. On the existing attachment, defer the PresentationInterval change
+    //    to a later frame's first `nextDrawable`. Mutating the attachment
+    //    synchronously here races the encoder's in-flight submission. A
+    //    retarget's fresh attach already latched these presentation params.
+    if !retargeted && !dev.layer_handle.is_null() {
         dev.queue_display_sync_change(resolve_display_sync(pp.presentation_interval));
     }
 
@@ -4256,8 +4263,8 @@ fn retarget_device_window(
 /// new dimensions, push the new pixel size to `CAMetalLayer`, and
 /// recreate both textures. Returns the D3D9 HRESULT to bubble back to
 /// the caller on failure; `Ok(())` on success. State defaults + reseed +
-/// display-sync queue (steps 7-9) remain in the parent because they run
-/// unconditionally per spec.
+/// display-sync handling (steps 7-9) remains in the parent because the final
+/// pacing step depends on whether this Reset attached a fresh layer.
 fn reset_recreate_resources(
     dev: &mut DeviceInner,
     pp: &mtld3d_types::D3DPRESENT_PARAMETERS,


### PR DESCRIPTION
A retargeting `Reset` could emit `present: SetDisplaySyncEnabled for layer 0x... with no attachment record; the present throttle is unchanged`. An unstamped `PresentationInterval` change from an earlier reset was consumed while the first retarget flush built its old-layer continuation. A later reset flush submitted that continuation after the old attachment record had been retired.

Record whether the reset changes the device window, discard that superseded unstamped pacing request before the retarget flush, and rely on the fresh `AttachMetalLayer` request to latch the new reset's `PresentationInterval` and `present.maxFps`. Resets that keep the current attachment still use the existing deferred frame apply, including its current timing tracked by #516.

Filtering missing attachment records on the unix side would also hide real invalid or stale layer uses, so the existing warning remains unchanged. Merely skipping the new deferred request after a retarget would leave an older same-window reset request able to enter the old-layer continuation, so the pending request is cleared before the first retarget flush as well.

Verification:

- `make test-unit`: 1,107 Windows workspace tests and 306 unix workspace tests passed.
- `make check`: formatting, Clippy, audit over 306 files, audit helper tests, documentation, and both workspace checks passed.
- `make install ISOLATED=1`: both PE architectures and both unix architectures built and installed into the worktree's private SDK.
- Source review confirmed that the synchronous first retarget flush submits an already-stamped old frame before detach, the fresh attach carries the reset's resolved pacing and cap, and the same-window branch still queues its deferred apply.

Full isolated `make test` passes both native workspaces and both PE architectures. Conformance reports no regressions on either architecture, with no baseline change. The final raw end-to-end layer logs contain no missing-attachment `SetDisplaySyncEnabled` warning. Earlier captured full-run logs contain that warning on both architectures; this is a historical comparison, not a controlled before/after run on the same base.

Rules check: `CONTRIBUTING.md` is enforced by the final check and test gates; `docs/CONVENTIONS.md` and `docs/ARCHITECTURE.md` introduce no exception. This stays in existing D3D9 COM wiring and uses the existing attach and encoder-thread thunk paths. It adds no config key, environment variable, dependency, static, public field, derive, warning suppression, unsafe code, ABI value, wire value, render-state consumer, caps bit, shader emission, cache schema, test file, or kept divergence. The unix-side missing-record error remains visible.

Closes #515
