### PR TITLE
Retain x86_64 nonvolatile registers and flags in fatal reports

### DIFF
--- a/unix/unix/src/crash.rs
+++ b/unix/unix/src/crash.rs
@@ -424,6 +424,8 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
         unsafe {
             let _ = libc::write(crate::log_file::raw_fd(), b.as_ptr().cast::<c_void>(), p);
         }
+        #[cfg(target_arch = "x86_64")]
+        report_nonvolatile_registers(ctx);
         let ret = caller_pc(ctx, sp);
         if ret != 0 {
             let mut rb = [0u8; 192];
@@ -893,6 +895,63 @@ const CALLER_LABEL: &[u8] = b"caller(ret@rsp)=";
 #[cfg(target_arch = "aarch64")]
 const CALLER_LABEL: &[u8] = b"caller(lr)=";
 
+/// Retain architectural nonvolatile registers and flags from the faulting context.
+///
+/// Darwin places the 64-bit thread state after its 16-byte exception state.
+/// The libc fields mirror that SDK layout, including the 64-bit RFLAGS slot.
+/// A separate line fits all seven full-width values and its newline in the
+/// existing 192-byte buffer without crowding out the argument or stack fields.
+#[cfg(target_arch = "x86_64")]
+fn report_nonvolatile_registers(ctx: *mut c_void) {
+    const REGISTERS: [(&[u8], usize); 7] = [
+        (
+            b"rbx=",
+            mem::offset_of!(libc::__darwin_mcontext64, __ss.__rbx),
+        ),
+        (
+            b" rbp=",
+            mem::offset_of!(libc::__darwin_mcontext64, __ss.__rbp),
+        ),
+        (
+            b" r12=",
+            mem::offset_of!(libc::__darwin_mcontext64, __ss.__r12),
+        ),
+        (
+            b" r13=",
+            mem::offset_of!(libc::__darwin_mcontext64, __ss.__r13),
+        ),
+        (
+            b" r14=",
+            mem::offset_of!(libc::__darwin_mcontext64, __ss.__r14),
+        ),
+        (
+            b" r15=",
+            mem::offset_of!(libc::__darwin_mcontext64, __ss.__r15),
+        ),
+        (
+            b" rflags=",
+            mem::offset_of!(libc::__darwin_mcontext64, __ss.__rflags),
+        ),
+    ];
+
+    let mut buf = [0u8; 192];
+    let mut pos = 0;
+    push(&mut buf, &mut pos, b"[mtld3d::unix] ");
+    for (label, offset) in REGISTERS {
+        push(&mut buf, &mut pos, label);
+        push_hex(&mut buf, &mut pos, mcontext_u64(ctx, offset));
+    }
+    push(&mut buf, &mut pos, b"\n");
+    // SAFETY: write(2) is async-signal-safe; the buffer holds pos initialized bytes.
+    unsafe {
+        let _ = libc::write(
+            crate::log_file::raw_fd(),
+            buf.as_ptr().cast::<c_void>(),
+            pos,
+        );
+    }
+}
+
 /// The return address of the frame that faulted, or 0 if it can't be read.
 ///
 /// `x86_64` `CALL` pushes it, so for a jump-through-garbage fault (which faults
@@ -914,8 +973,7 @@ const fn caller_pc(ctx: *mut c_void, _sp: u64) -> u64 {
 
 /// The faulting program counter from a signal `ucontext`, or 0 if it can't be read.
 ///
-/// `uc_mcontext` is a pointer to an opaque `__darwin_mcontext64` (the `libc`
-/// crate exposes it only as padding), sitting at byte offset 0x30 in
+/// `uc_mcontext` is a pointer to `__darwin_mcontext64`, sitting at byte offset 0x30 in
 /// `ucontext_t` (same on both macOS arches). The PC offset *within* the
 /// `mcontext` is arch-specific: `x86_64` `__rip` follows the 16-byte exception
 /// state + 16 thread-state `u64`s (144); `arm64` `__pc` follows the 16-byte

--- a/unix/unix/src/crash/tests.rs
+++ b/unix/unix/src/crash/tests.rs
@@ -142,14 +142,86 @@ fn fault_report_decodes_registers() {
     let caller_label = std::str::from_utf8(super::CALLER_LABEL).expect("ascii label");
     assert!(report.contains(arg0_label), "{report}");
     assert!(report.contains(caller_label), "{report}");
+    #[cfg(target_arch = "x86_64")]
+    for label in [
+        " rbx=", " rbp=", " r12=", " r13=", " r14=", " r15=", " rflags=",
+    ] {
+        assert!(value_after(label).starts_with("0x"), "{report}");
+    }
     #[cfg(target_arch = "aarch64")]
     {
+        assert!(!report.contains(" rflags="), "{report}");
         assert_eq!(
             value_after(arg0_label),
             format!("0x{BAD_ADDR:016x}"),
             "{report}"
         );
         assert_ne!(value_after(caller_label), zero, "{report}");
+    }
+}
+
+/// Typed Darwin fields must survive the terminal report at their full width.
+///
+/// Distinct sentinels catch swapped offsets; all-one values pin the longest
+/// line including its newline. The synthetic context is read only by the
+/// handler, never restored as executable machine state.
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn nonvolatile_registers_preserve_context() {
+    if let Ok(mode) = std::env::var(SELFTEST_ENV) {
+        // SAFETY: Darwin's machine context contains only integer state.
+        let mut registers: libc::__darwin_mcontext64 = unsafe { core::mem::zeroed() };
+        let sentinel = |value| if mode == "max" { u64::MAX } else { value };
+        registers.__ss.__rbx = sentinel(0x8123_4567_89ab_cdef);
+        registers.__ss.__rbp = sentinel(0x9234_5678_9abc_def0);
+        registers.__ss.__r12 = sentinel(0xa345_6789_abcd_ef01);
+        registers.__ss.__r13 = sentinel(0xb456_789a_bcde_f012);
+        registers.__ss.__r14 = sentinel(0xc567_89ab_cdef_0123);
+        registers.__ss.__r15 = sentinel(0xd678_9abc_def0_1234);
+        registers.__ss.__rflags = sentinel(0xe789_abcd_ef01_2345);
+        // SAFETY: ucontext contains integers and nullable raw pointers.
+        let mut context: libc::ucontext_t = unsafe { core::mem::zeroed() };
+        context.uc_mcontext = &raw mut registers;
+        context.uc_mcsize = core::mem::size_of_val(&registers);
+        super::handler(libc::SIGABRT, ptr::null_mut(), (&raw mut context).cast());
+        unreachable!("the terminal handler must end the child");
+    }
+
+    for (mode, expected) in [
+        (
+            "sentinels",
+            concat!(
+                "[mtld3d::unix] rbx=0x8123456789abcdef rbp=0x923456789abcdef0",
+                " r12=0xa3456789abcdef01 r13=0xb456789abcdef012",
+                " r14=0xc56789abcdef0123 r15=0xd6789abcdef01234",
+                " rflags=0xe789abcdef012345\n",
+            ),
+        ),
+        (
+            "max",
+            concat!(
+                "[mtld3d::unix] rbx=0xffffffffffffffff rbp=0xffffffffffffffff",
+                " r12=0xffffffffffffffff r13=0xffffffffffffffff",
+                " r14=0xffffffffffffffff r15=0xffffffffffffffff",
+                " rflags=0xffffffffffffffff\n",
+            ),
+        ),
+    ] {
+        let out = std::process::Command::new(std::env::current_exe().expect("test binary path"))
+            .args([
+                "--exact",
+                "crash::tests::nonvolatile_registers_preserve_context",
+                "--nocapture",
+            ])
+            .env(SELFTEST_ENV, mode)
+            .output()
+            .expect("re-exec the test binary");
+        let report = String::from_utf8_lossy(&out.stderr);
+        assert_eq!(out.status.code(), Some(1), "{report}");
+        assert!(report.contains("FATAL: SIGABRT"), "{report}");
+        assert!(report.contains(expected), "{mode}: {report}");
+        assert_eq!(expected.len(), 179);
+        assert_eq!(report.matches(" rflags=").count(), 1, "{report}");
     }
 }
 
@@ -183,6 +255,7 @@ fn foreign_fault_is_named_then_forwarded() {
 
     assert_eq!(out.status.signal(), Some(libc::SIGSEGV), "{report}");
     assert!(!report.contains("FATAL"), "{report}");
+    assert!(!report.contains(" rflags="), "{report}");
     let line = report
         .lines()
         .find(|l| l.contains("fault outside mtld3d.so"))
@@ -274,6 +347,8 @@ fn foreign_fault_without_a_teb_is_reported_not_forwarded() {
     assert!(foreign < fatal, "{report}");
     assert!(report.contains("has no Wine TEB"), "{report}");
     assert!(report.contains("native backtrace:"), "{report}");
+    #[cfg(target_arch = "x86_64")]
+    assert!(report.contains(" rflags=0x"), "{report}");
 }
 
 /// A trap instruction in our own code is fatal and named like a fault.


### PR DESCRIPTION
Terminal x86_64 reports omit RBX, RBP, R12-R15 and RFLAGS, losing architectural state that can distinguish paths into a native trap. Add them with architectural labels on a separate line using the existing kernel-context reader, fixed-buffer hex formatter and signal-safe write. Existing PC, argument, RAX, SP and caller output, forwarding, report limits and termination stay unchanged. Arm64 behavior is unchanged.

The new offsets come from the locked libc Darwin context fields. An x86_64 C probe against the installed macOS 26.4 SDK verifies the ucontext pointer at byte 48, the thread state after the 16-byte exception state, offsets 24/64/112/120/128/136/152, and eight-byte field widths. A separate 179-byte line preserves every full-width value and its newline within the existing 192-byte buffer; appending to the old register line would exceed that buffer.

Verification: the typed-context regression failed before the change because the requested register line was absent, then passed for distinct 64-bit sentinels and all-one values. The crash-only unit filter passes 11 tests on x86_64 under Rosetta and 9 on native aarch64, including real faults, default and previous-handler forwarding, no-TEB termination, and protected-stack reads. `make fmt`, `make check` (format, Clippy, audit and docs), and an additional x86_64 `cargo clippy -p mtld3d-unix --all-targets --config 'build.warnings="deny"'` pass. Every test child was reaped within a bounded run. The final isolated `make test` passes both native workspaces and both PE architectures. Conformance does not apply to this Unix diagnostic-only change: it changes no rendering, state, shader or shared-crate code.

Rules check: CONTRIBUTING.md's isolated check and test gates pass, with before/after evidence for the missing register output. CONVENTIONS.md's formatting, lint, audit and documentation gates pass. No statics, config keys, wire fields, dependencies, derives, suppressions or duplicate production helpers are introduced. ARCHITECTURE.md's boundary and threading contracts are unchanged. No timer memory, framework-private layout, new scan or image UUID capture is added. This improves a future report and does not fix or recover the missing state from #580.

Closes #593
