### PR TITLE
Bound failed e2e process cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,16 @@ config, `docs/ARCHITECTURE.md` says how), so a kept `.stderr` that carries a
 AppKit call the layer made off the main thread and the thread that made it;
 that call is the failure, whatever the process printed after it.
 
+Process cleanup has one two-second budget from the first termination or cleanup
+attempt, including signal-error retries and the final reap. The leader stays
+unreaped until the last group signal. If cleanup cannot establish exit and reap,
+the runner reports the unresolved PID and exits immediately with infrastructure
+code 2. A survivor may still be running: macOS adopts the remaining children and
+owns their eventual reap. No background thread survives the runner to do that
+work. This bounds the runner's wait/retry loops, subject to scheduling, syscalls
+and diagnostic output; the kernel can also delay process exit while closing
+file descriptors. No further binary runs after this failure.
+
 An explicit driver GPU-hang report ends the leg with exit code 3 and no
 verdict, even under `FAIL_FAST=0` or when the process itself exits cleanly.
 The runner watches stderr while the process runs, checks the layer log before

--- a/unix/e2e/src/run.rs
+++ b/unix/e2e/src/run.rs
@@ -89,6 +89,9 @@ const GPU_HANG_MARKERS: [&str; 2] = [
 /// How often the bounded wait for the process's exit looks again.
 const EXIT_POLL: Duration = Duration::from_millis(20);
 
+/// One budget for termination, exit observation and final reap.
+const CLEANUP_GRACE: Duration = Duration::from_secs(2);
+
 /// How long EPERM may wait for an owned group leader to become waitable.
 const SIGNAL_EXIT_GRACE: Duration = Duration::from_secs(1);
 
@@ -133,27 +136,45 @@ pub fn run(
         .spawn()
         .map_err(|e| format!("failed to spawn {} {}: {e}", wine.display(), exe.display()))?;
 
-    let mut group = ProcessGroup { child: Some(child) };
+    collect(ProcessGroup::new(child), timeout, on_line, |reader| {
+        thread::Builder::new().spawn(reader)
+    })
+}
+
+/// Collect one owned process, retaining cleanup ownership if a reader cannot start.
+fn collect(
+    mut group: ProcessGroup,
+    timeout: Duration,
+    on_line: &mut dyn FnMut(&str),
+    mut spawn_reader: impl FnMut(Box<dyn FnOnce() + Send>) -> std::io::Result<thread::JoinHandle<()>>,
+) -> Result<Exit, String> {
     let child = group.child.as_mut().expect("just spawned group leader");
     let pid = child.id();
     let stdout = child.stdout.take().ok_or("stdout not piped")?;
     let stderr = child.stderr.take().ok_or("stderr not piped")?;
     let (lines, received) = mpsc::channel::<String>();
     // Neither reader is joined: each ends when its pipe does, and a pipe a
-    // killed process tree held open ends with the kill.
-    thread::spawn(move || {
+    // killed process tree held open ends with the kill. Fatal cleanup ends
+    // the entire runner, including readers blocked on a surviving child.
+    spawn_reader(Box::new(move || {
         for line in BufReader::new(stdout).lines().map_while(Result::ok) {
             if lines.send(line).is_err() {
                 break;
             }
         }
-    });
+    }))
+    .map_err(|e| {
+        let message = format!("start stdout reader for {pid} failed: {e}");
+        // Cleanup can terminate this CLI before the error reaches main.
+        eprintln!("[e2e] {message}");
+        message
+    })?;
     // stderr comes over in chunks so that what the process wrote before it
     // died is in hand the moment it is gone; the sender dropping is the EOF.
     let gpu_hang = Arc::new(AtomicBool::new(false));
     let (stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>();
     let stderr_gpu_hang = Arc::clone(&gpu_hang);
-    thread::spawn(move || {
+    spawn_reader(Box::new(move || {
         let mut reader = BufReader::new(stderr);
         let mut line = Vec::new();
         while let Ok(1..) = reader.read_until(b'\n', &mut line) {
@@ -164,7 +185,13 @@ pub fn run(
                 break;
             }
         }
-    });
+    }))
+    .map_err(|e| {
+        let message = format!("start stderr reader for {pid} failed: {e}");
+        // Cleanup can terminate this CLI before the error reaches main.
+        eprintln!("[e2e] {message}");
+        message
+    })?;
 
     let mut timed_out = false;
     let mut reported_gpu_hang = false;
@@ -173,7 +200,7 @@ pub fn run(
         if gpu_hang.load(Ordering::Relaxed) {
             group
                 .kill()
-                .map_err(|e| format!("stop {} failed: {e}", exe.display()))?;
+                .map_err(|e| format!("stop {pid} failed: {e}"))?;
             reported_gpu_hang = true;
             break;
         }
@@ -181,7 +208,7 @@ pub fn run(
         if since_line >= timeout {
             group
                 .kill()
-                .map_err(|e| format!("stop {} failed: {e}", exe.display()))?;
+                .map_err(|e| format!("stop {pid} failed: {e}"))?;
             timed_out = true;
             break;
         }
@@ -200,49 +227,52 @@ pub fn run(
     let hung = if reported_gpu_hang || timed_out {
         group
             .wait_killed()
-            .map_err(|e| format!("wait on {} after stop failed: {e}", exe.display()))?;
+            .map_err(|e| format!("wait on {pid} after stop failed: {e}"))?;
         false
     } else {
         match wait_bounded(&mut group, timeout, &gpu_hang)
-            .map_err(|e| format!("wait on {} failed: {e}", exe.display()))?
+            .map_err(|e| format!("wait on {pid} failed: {e}"))?
         {
             Wait::Exited => false,
             Wait::GpuHang => {
                 group
                     .kill()
-                    .map_err(|e| format!("stop {} failed: {e}", exe.display()))?;
+                    .map_err(|e| format!("stop {pid} failed: {e}"))?;
                 reported_gpu_hang = true;
                 group
                     .wait_killed()
-                    .map_err(|e| format!("wait on {} after stop failed: {e}", exe.display()))?;
+                    .map_err(|e| format!("wait on {pid} after stop failed: {e}"))?;
                 false
             }
             Wait::TimedOut => {
                 group
                     .kill()
-                    .map_err(|e| format!("stop {} failed: {e}", exe.display()))?;
+                    .map_err(|e| format!("stop {pid} failed: {e}"))?;
                 group
                     .wait_killed()
-                    .map_err(|e| format!("wait on {} failed: {e}", exe.display()))?;
+                    .map_err(|e| format!("wait on {pid} failed: {e}"))?;
                 true
             }
         }
     };
-    let mut stderr = drain_stderr(&stderr_rx, STDERR_GRACE);
+    let stderr_grace = group.cleanup_deadline.map_or(STDERR_GRACE, |deadline| {
+        STDERR_GRACE.min(deadline.saturating_duration_since(Instant::now()))
+    });
+    let mut stderr = drain_stderr(&stderr_rx, stderr_grace);
     if !stderr.complete {
         // Something the kill did not reach still holds the pipe: a process
         // that put itself in another group. Say so, and try the kill once
         // more for whatever did land in the group since.
         group
             .kill()
-            .map_err(|e| format!("stop {} failed: {e}", exe.display()))?;
+            .map_err(|e| format!("stop {pid} failed: {e}"))?;
         stderr.text.push_str(
             "[e2e] stderr not collected in full: the process tree held it open past the end\n",
         );
     }
     let status = group
         .reap()
-        .map_err(|e| format!("reap {} failed: {e}", exe.display()))?;
+        .map_err(|e| format!("reap {pid} failed: {e}"))?;
     let stderr = stderr.text;
     let kind = if timed_out {
         ExitKind::TimedOut(timeout)
@@ -268,11 +298,18 @@ struct Stderr {
     complete: bool,
 }
 
-/// Collect stderr chunks until the pipe closes or `grace` passes without one.
+/// Collect stderr chunks until the pipe closes or the total `grace` expires.
 fn drain_stderr(chunks: &mpsc::Receiver<Vec<u8>>, grace: Duration) -> Stderr {
     let mut buf = Vec::new();
+    let deadline = Instant::now() + grace;
     loop {
-        match chunks.recv_timeout(grace) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let next = if remaining.is_zero() {
+            Err(mpsc::RecvTimeoutError::Timeout)
+        } else {
+            chunks.recv_timeout(remaining)
+        };
+        match next {
             Ok(chunk) => buf.extend_from_slice(&chunk),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 return Stderr {
@@ -297,65 +334,153 @@ fn drain_stderr(chunks: &mpsc::Receiver<Vec<u8>>, grace: Duration) -> Stderr {
 /// that reservation. ECHILD revokes ownership instead of trusting a numeric ID.
 struct ProcessGroup {
     child: Option<Child>,
+    cleanup_deadline: Option<Instant>,
+    #[cfg(test)]
+    faults: tests::Faults,
 }
 
 impl ProcessGroup {
+    const fn new(child: Child) -> Self {
+        Self {
+            child: Some(child),
+            cleanup_deadline: None,
+            #[cfg(test)]
+            faults: tests::Faults::new(),
+        }
+    }
+
+    /// Start the budget once, including retries made by Drop after an error.
+    fn cleanup_deadline(&mut self) -> Instant {
+        *self
+            .cleanup_deadline
+            .get_or_insert_with(|| Instant::now() + CLEANUP_GRACE)
+    }
+
     /// Observe exit without releasing the leader's PID or group membership.
     fn observe_exit(&mut self, options: libc::c_int) -> std::io::Result<bool> {
         let child = self
             .child
             .as_ref()
             .ok_or_else(|| std::io::Error::from_raw_os_error(libc::ECHILD))?;
-        loop {
-            // SAFETY: siginfo_t contains integers and raw pointers, valid when zeroed.
-            // macOS leaves it untouched for WNOHANG when the child is still running.
-            let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
-            // SAFETY: info is writable and P_PID selects this owner's direct child.
-            // WNOWAIT observes exit without consuming the child's waitable status.
-            let result = unsafe {
-                libc::waitid(
-                    libc::P_PID,
-                    child.id(),
-                    &raw mut info,
-                    libc::WEXITED | libc::WNOWAIT | options,
-                )
-            };
-            if result == 0 {
-                return Ok(info.si_pid != 0);
-            }
-            let error = std::io::Error::last_os_error();
-            if error.kind() == std::io::ErrorKind::Interrupted {
-                continue;
-            }
-            if error.raw_os_error() == Some(libc::ECHILD) {
-                self.child.take();
-            }
-            return Err(error);
+        // SAFETY: siginfo_t contains integers and raw pointers, valid when zeroed.
+        // macOS leaves it untouched for WNOHANG when the child is still running.
+        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        // SAFETY: info is writable and P_PID selects this owner's direct child.
+        // WNOWAIT observes exit without consuming the child's waitable status.
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                child.id(),
+                &raw mut info,
+                libc::WEXITED | libc::WNOWAIT | options,
+            )
+        };
+        #[cfg(test)]
+        if self.faults.wait_interruptions > 0 {
+            self.faults.wait_interruptions -= 1;
+            return Err(std::io::Error::from_raw_os_error(libc::EINTR));
         }
+        #[cfg(test)]
+        let result = if self.faults.wait.is_some() {
+            -1
+        } else {
+            result
+        };
+        if result == 0 {
+            return Ok(info.si_pid != 0);
+        }
+        let error = std::io::Error::last_os_error();
+        #[cfg(test)]
+        let error = self
+            .faults
+            .wait
+            .map_or(error, std::io::Error::from_raw_os_error);
+        if error.raw_os_error() == Some(libc::ECHILD) {
+            self.child.take();
+        }
+        Err(error)
     }
 
     /// Verify that the leader is still ours before signalling its group.
     fn kill(&mut self) -> std::io::Result<()> {
-        self.observe_exit(libc::WNOHANG)?;
+        let deadline = self.cleanup_deadline();
+        loop {
+            match self.observe_exit(libc::WNOHANG) {
+                Ok(_) => break,
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {
+                    cleanup_pause(deadline)?;
+                }
+                Err(error) => return Err(error),
+            }
+        }
         self.signal_group()
     }
 
     /// Stop descendants a group signal's fork snapshot may have missed.
     fn wait_killed(&mut self) -> std::io::Result<()> {
-        self.observe_exit(0)?;
+        let deadline = self.cleanup_deadline();
+        loop {
+            match self.observe_exit(libc::WNOHANG) {
+                Ok(true) => break,
+                Ok(false) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(error) => return Err(error),
+            }
+            cleanup_pause(deadline)?;
+        }
         // The leader has exited, so its in-flight fork has finished. WNOWAIT
         // retains its group identity through this second signal and stderr drain.
         self.signal_group()
     }
 
-    /// Release the reserved identity, consuming the ability to signal the group.
+    /// Send the final group signal before consuming the reserved identity.
     fn reap(mut self) -> std::io::Result<ExitStatus> {
-        let result = self
+        let deadline = self.cleanup_deadline();
+        self.wait_killed()?;
+        loop {
+            match self.try_reap() {
+                Ok(Some(status)) => return Ok(status),
+                Ok(None) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(error) => return Err(error),
+            }
+            cleanup_pause(deadline)?;
+        }
+    }
+
+    /// A nonblocking consuming wait; no group signal may follow success or ECHILD.
+    fn try_reap(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        let child = self
             .child
-            .as_mut()
-            .ok_or_else(|| std::io::Error::from_raw_os_error(libc::ECHILD))?
-            .wait();
-        if result.is_ok()
+            .as_ref()
+            .ok_or_else(|| std::io::Error::from_raw_os_error(libc::ECHILD))?;
+        let pid = libc::pid_t::try_from(child.id()).expect("child PID fits pid_t");
+        #[cfg(test)]
+        let injected = if self.faults.reap_interruptions > 0 {
+            self.faults.reap_interruptions -= 1;
+            Some(libc::EINTR)
+        } else {
+            self.faults.reap
+        };
+        #[cfg(not(test))]
+        let injected = None;
+        let result = injected.map_or_else(
+            || {
+                let mut status = 0;
+                // SAFETY: status is writable and pid selects only this owner's child.
+                // WNOHANG prevents blocking. EINTR returns to the bounded caller.
+                let waited = unsafe { libc::waitpid(pid, &raw mut status, libc::WNOHANG) };
+                if waited == pid {
+                    Ok(Some(ExitStatus::from_raw(status)))
+                } else if waited == 0 {
+                    Ok(None)
+                } else {
+                    Err(std::io::Error::last_os_error())
+                }
+            },
+            |errno| Err(std::io::Error::from_raw_os_error(errno)),
+        );
+        if matches!(result, Ok(Some(_)))
             || result
                 .as_ref()
                 .is_err_and(|e| e.raw_os_error() == Some(libc::ECHILD))
@@ -374,13 +499,28 @@ impl ProcessGroup {
         let pid = libc::pid_t::try_from(child.id()).expect("child PID fits pid_t");
         // SAFETY: the child spawned as its own group leader and remains unreaped,
         // so its PID reserves this group's identity until the consuming reap.
+        #[cfg(not(test))]
         let result = unsafe { libc::kill(-pid, libc::SIGKILL) };
+        #[cfg(test)]
+        let result = if self.faults.signal.is_some() {
+            -1
+        } else {
+            // SAFETY: the same owned, unreaped leader reserves this group.
+            unsafe { libc::kill(-pid, libc::SIGKILL) }
+        };
         if result == 0 {
             return Ok(());
         }
-        resolve_group_signal_error(std::io::Error::last_os_error(), SIGNAL_EXIT_GRACE, || {
-            self.observe_exit(libc::WNOHANG)
-        })
+        let error = std::io::Error::last_os_error();
+        #[cfg(test)]
+        let error = self
+            .faults
+            .signal
+            .map_or(error, std::io::Error::from_raw_os_error);
+        let grace = self.cleanup_deadline.map_or(SIGNAL_EXIT_GRACE, |deadline| {
+            SIGNAL_EXIT_GRACE.min(deadline.saturating_duration_since(Instant::now()))
+        });
+        resolve_group_signal_error(error, grace, || self.observe_exit(libc::WNOHANG))
     }
 }
 
@@ -389,25 +529,75 @@ impl Drop for ProcessGroup {
         if self.child.is_none() {
             return;
         }
+        let deadline = self.cleanup_deadline();
         if let Err(error) = self.observe_exit(libc::WNOHANG) {
             eprintln!("[e2e] observe process during cleanup failed: {error}");
         }
-        // ECHILD means another waiter consumed the identity. Never signal it.
         if self.child.is_none() {
             return;
         }
         if let Err(error) = self.signal_group() {
             eprintln!("[e2e] stop process group during cleanup failed: {error}");
         }
-        if let Err(error) = self.wait_killed() {
-            eprintln!("[e2e] wait for stopped process during cleanup failed: {error}");
-        }
-        if let Some(mut child) = self.child.take()
-            && let Err(error) = child.wait()
-        {
-            eprintln!("[e2e] reap process during cleanup failed: {error}");
+        loop {
+            if self.child.is_none() {
+                return;
+            }
+            match self.wait_killed().and_then(|()| self.try_reap()) {
+                Ok(Some(_)) => return,
+                Ok(None) => {}
+                Err(error) => {
+                    eprintln!("[e2e] wait/reap process during cleanup failed: {error}");
+                    if self.child.is_none() {
+                        return;
+                    }
+                    // Retain ownership on genuine errors. Retrying the same
+                    // failed syscall cannot extend the cleanup budget.
+                    if error.kind() != std::io::ErrorKind::Interrupted {
+                        self.fatal_cleanup(&error);
+                    }
+                }
+            }
+            if let Err(error) = cleanup_pause(deadline) {
+                self.fatal_cleanup(&error);
+            }
         }
     }
+}
+
+impl ProcessGroup {
+    /// End this CLI while the OS can still adopt its unresolved direct child.
+    fn fatal_cleanup(&self, error: &std::io::Error) -> ! {
+        let pid = self
+            .child
+            .as_ref()
+            .expect("unresolved child stays owned")
+            .id();
+        eprintln!(
+            "[e2e] fatal cleanup for process {pid}: {error}; exit/reap not established; \
+             a survivor may remain; exiting runner with code 2, macOS will adopt and eventually reap it"
+        );
+        // SAFETY: this is the CLI's terminal infrastructure failure. _exit ends
+        // every reader thread without destructors or atexit handlers. The kernel
+        // reparents any remaining children; it does not promise to kill them.
+        unsafe { libc::_exit(2) }
+    }
+}
+
+fn cleanup_timeout() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::TimedOut,
+        "process cleanup deadline expired",
+    )
+}
+
+fn cleanup_pause(deadline: Instant) -> std::io::Result<()> {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        return Err(cleanup_timeout());
+    }
+    thread::sleep(EXIT_POLL.min(remaining));
+    Ok(())
 }
 
 /// Resolve a group signal error without consuming the leader's waitable status.
@@ -428,8 +618,11 @@ fn resolve_group_signal_error(
     // an open stderr pipe still reports a survivor.
     let deadline = Instant::now() + grace;
     loop {
-        if observe_exit()? {
-            return Ok(());
+        match observe_exit() {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(wait_error) if wait_error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(wait_error) => return Err(wait_error),
         }
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
@@ -454,8 +647,11 @@ fn wait_bounded(
 ) -> std::io::Result<Wait> {
     let deadline = Instant::now() + timeout;
     loop {
-        if group.observe_exit(libc::WNOHANG)? {
-            return Ok(Wait::Exited);
+        match group.observe_exit(libc::WNOHANG) {
+            Ok(true) => return Ok(Wait::Exited),
+            Ok(false) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
         }
         if gpu_hang.load(Ordering::Relaxed) {
             return Ok(Wait::GpuHang);
@@ -463,7 +659,7 @@ fn wait_bounded(
         if Instant::now() >= deadline {
             return Ok(Wait::TimedOut);
         }
-        thread::sleep(EXIT_POLL);
+        thread::sleep(EXIT_POLL.min(deadline.saturating_duration_since(Instant::now())));
     }
 }
 

--- a/unix/e2e/src/run/tests.rs
+++ b/unix/e2e/src/run/tests.rs
@@ -176,7 +176,7 @@ fn observing_a_killed_leader_stops_a_descendant_missed_by_the_first_signal() {
     child.kill().expect("kill group leader");
     let pid = child.id();
     let mut stderr = child.stderr.take().expect("stderr piped");
-    let mut group = ProcessGroup { child: Some(child) };
+    let mut group = ProcessGroup::new(child);
     group.wait_killed().expect("observe group leader");
     assert_waitable(pid);
     let (closed, eof) = mpsc::channel();
@@ -208,7 +208,7 @@ fn observing_a_clean_exit_keeps_the_leader_waitable() {
         .spawn()
         .expect("spawn group leader");
     let pid = child.id();
-    let mut group = ProcessGroup { child: Some(child) };
+    let mut group = ProcessGroup::new(child);
     let gpu_hang = std::sync::atomic::AtomicBool::new(false);
     let observed = super::wait_bounded(&mut group, Duration::from_secs(2), &gpu_hang)
         .expect("observe group leader");
@@ -245,7 +245,7 @@ fn a_killed_leader_stays_waitable_until_the_final_signal() {
         .spawn()
         .expect("spawn group leader");
     let pid = child.id();
-    let mut group = ProcessGroup { child: Some(child) };
+    let mut group = ProcessGroup::new(child);
     assert!(
         !group
             .observe_exit(libc::WNOHANG)
@@ -275,7 +275,7 @@ fn losing_the_waitable_child_disables_group_signals() {
         .expect("spawn group leader");
     // Model an external waiter consuming the child, without reusing any ID.
     child.wait().expect("external reap");
-    let mut group = ProcessGroup { child: Some(child) };
+    let mut group = ProcessGroup::new(child);
     let error = super::resolve_group_signal_error(
         std::io::Error::from_raw_os_error(libc::EPERM),
         Duration::from_mins(1),
@@ -300,7 +300,7 @@ fn dropping_an_unfinished_group_stops_and_reaps_its_leader() {
         .spawn()
         .expect("spawn group leader");
     let pid = child.id();
-    drop(ProcessGroup { child: Some(child) });
+    drop(ProcessGroup::new(child));
     assert_reaped(pid);
 }
 
@@ -312,7 +312,7 @@ fn an_unexpected_wait_error_retains_ownership_for_cleanup() {
         .spawn()
         .expect("spawn group leader");
     let pid = child.id();
-    let mut group = ProcessGroup { child: Some(child) };
+    let mut group = ProcessGroup::new(child);
     let error = group
         .observe_exit(libc::c_int::MAX)
         .expect_err("invalid wait options");
@@ -420,4 +420,411 @@ fn observe_fixture(pid: u32) -> std::io::Result<libc::siginfo_t> {
     } else {
         Err(std::io::Error::last_os_error())
     }
+}
+
+/// Private syscall substitutions, never exposed by the runner CLI.
+pub struct Faults {
+    pub signal: Option<i32>,
+    pub wait: Option<i32>,
+    pub wait_interruptions: u8,
+    pub reap_interruptions: u8,
+    pub reap: Option<i32>,
+}
+
+impl Faults {
+    pub const fn new() -> Self {
+        Self {
+            signal: None,
+            wait: None,
+            wait_interruptions: 0,
+            reap_interruptions: 0,
+            reap: None,
+        }
+    }
+}
+
+/// Invoked only by the parent test, so fatal cleanup cannot end the test runner.
+#[test]
+fn fatal_cleanup_fixture() {
+    let Ok(directory) = std::env::var("E2E_CLEANUP_FIXTURE") else {
+        return;
+    };
+    let mode = std::env::var("E2E_CLEANUP_MODE").expect("fixture mode");
+    let adoption = Path::new(&directory).join("adoption");
+    let child = Command::new("/usr/bin/perl")
+        .args([
+            "-e",
+            "select undef,undef,undef,$ARGV[1]; open my $f, '>', $ARGV[0] or die $!; print $f qq($$ ),getppid(); close $f;",
+        ])
+        .arg(adoption)
+        .arg(if mode.starts_with("reap-") { "0.02" } else { "3" })
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .process_group(0)
+        .spawn()
+        .expect("spawn finite owned child");
+    fs::write(Path::new(&directory).join("pid"), child.id().to_string()).expect("record child");
+    let mut group = ProcessGroup::new(child);
+    group.cleanup_deadline = Some(Instant::now() + Duration::from_millis(100));
+    group.faults.signal = Some(libc::EPERM);
+    match mode.as_str() {
+        "drop" => drop(group),
+        "kill" => {
+            let error = group.kill().expect_err("injected signal denial");
+            eprintln!("initial kill: {error}");
+            drop(group);
+        }
+        "wait" => {
+            group.faults.wait = Some(libc::EIO);
+            drop(group);
+        }
+        "interrupt" => {
+            group.faults.wait = Some(libc::EINTR);
+            drop(group);
+        }
+        "reap-error" | "reap-interrupt" => {
+            group.wait_killed().expect("observe finite child");
+            group.faults.reap = Some(if mode == "reap-error" {
+                libc::EIO
+            } else {
+                libc::EINTR
+            });
+            assert_waitable(group.child.as_ref().expect("owned child").id());
+            let error = group.reap().expect_err("injected consuming wait failure");
+            panic!("reap returned after failed cleanup: {error}");
+        }
+        "reap" => {
+            group.faults.reap = Some(libc::EIO);
+            let error = group.reap().expect_err("live child cannot be reaped");
+            panic!("reap returned after failed cleanup: {error}");
+        }
+        "spawn" => {
+            let error = super::collect(group, Duration::from_millis(10), &mut |_| {}, |_| {
+                Err(std::io::Error::from_raw_os_error(libc::EAGAIN))
+            })
+            .err();
+            panic!("reader spawn returned after failed cleanup: {error:?}");
+        }
+        _ => panic!("unknown fixture mode"),
+    }
+}
+
+#[test]
+fn persistent_signal_denial_ends_the_runner_and_transfers_reaping_to_the_os() {
+    check_fatal_cleanup("drop");
+}
+
+#[test]
+fn failed_kill_does_not_restart_the_cleanup_budget() {
+    check_fatal_cleanup("kill");
+}
+
+#[test]
+fn persistent_wait_errors_do_not_block_cleanup() {
+    check_fatal_cleanup("wait");
+}
+
+#[test]
+fn interrupted_waits_do_not_restart_the_cleanup_budget() {
+    check_fatal_cleanup("interrupt");
+}
+
+#[test]
+fn consuming_reap_cannot_wait_for_a_live_unsignalable_child() {
+    check_fatal_cleanup("reap");
+}
+
+#[test]
+fn reader_spawn_failure_keeps_a_live_child_owned_until_fatal_exit() {
+    check_fatal_cleanup("spawn");
+}
+
+fn check_fatal_cleanup(mode: &str) {
+    let path = script(&format!("fatal-{mode}"), "");
+    let directory = path.parent().expect("fixture directory");
+    for name in ["pid", "adoption"] {
+        match fs::remove_file(directory.join(name)) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => panic!("reset fixture: {error}"),
+        }
+    }
+    let started = Instant::now();
+    let mut fixture = Command::new(std::env::current_exe().expect("test executable"))
+        .args([
+            "--exact",
+            "run::tests::fatal_cleanup_fixture",
+            "--nocapture",
+        ])
+        .env("E2E_CLEANUP_FIXTURE", directory)
+        .env("E2E_CLEANUP_MODE", mode)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .process_group(0)
+        .spawn()
+        .expect("spawn fixture runner");
+    let status = loop {
+        if let Some(status) = fixture.try_wait().expect("poll fixture runner") {
+            break status;
+        }
+        if started.elapsed() > Duration::from_secs(6) {
+            fixture.kill().expect("stop owned fixture runner");
+            break fixture.wait().expect("reap owned fixture runner");
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+    let elapsed = started.elapsed();
+    let mut stderr = String::new();
+    fixture
+        .stderr
+        .take()
+        .expect("stderr pipe")
+        .read_to_string(&mut stderr)
+        .expect("read diagnostic");
+    let pid: i32 = fs::read_to_string(directory.join("pid"))
+        .expect("child identity")
+        .parse()
+        .expect("pid");
+    // The finite child requires no signal after the runner exits. Observe both
+    // its adoption report and its disappearance before retiring this fixture.
+    let deadline = Instant::now() + Duration::from_secs(6);
+    loop {
+        // SAFETY: signal zero only queries existence; no process is signalled.
+        let present = unsafe { libc::kill(pid, 0) };
+        if present == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "finite fixture child {pid} did not retire"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+    let adoption = fs::read_to_string(directory.join("adoption")).expect("child adoption report");
+    eprintln!("{mode}: runner {status} after {elapsed:?}; child {pid} and group retired");
+    assert_eq!(status.code(), Some(2), "{mode}: {status}; {stderr}");
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "{mode}: took {elapsed:?}; {stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("fatal cleanup for process {pid}")),
+        "{stderr}"
+    );
+    assert!(stderr.contains("a survivor may remain"), "{stderr}");
+    if !mode.starts_with("reap-") {
+        assert_eq!(
+            adoption,
+            format!("{pid} 1"),
+            "child was not adopted by launchd"
+        );
+    }
+    if mode == "spawn" {
+        assert!(stderr.contains("start stdout reader"), "{stderr}");
+        assert!(
+            stderr.contains(&std::io::Error::from_raw_os_error(libc::EAGAIN).to_string()),
+            "{stderr}"
+        );
+    }
+    if mode == "wait" || mode == "reap-error" {
+        assert!(stderr.contains("Input/output error"), "{stderr}");
+    }
+    // SAFETY: signal zero queries group existence without signalling a member.
+    assert_eq!(unsafe { libc::kill(-pid, 0) }, -1, "fixture group remains");
+    assert_eq!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::ESRCH)
+    );
+    eprintln!("{mode}: infrastructure exit in {elapsed:?}; child {pid} and group retired");
+}
+
+#[test]
+fn failure_to_start_either_reader_stops_and_reaps_the_owned_child() {
+    for fail_at in [0, 1] {
+        let child = Command::new("/bin/sleep")
+            .arg("30")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .process_group(0)
+            .spawn()
+            .expect("spawn owned child");
+        let pid = child.id();
+        let mut starts = 0;
+        let mut readers = Vec::new();
+        let error = super::collect(
+            ProcessGroup::new(child),
+            Duration::from_secs(1),
+            &mut |_| {},
+            |reader| {
+                if starts == fail_at {
+                    Err(std::io::Error::from_raw_os_error(libc::EAGAIN))
+                } else {
+                    starts += 1;
+                    let handle = thread::Builder::new().spawn(reader)?;
+                    // collect intentionally detaches the handle. This watcher is
+                    // owned by the test and verifies the started reader completes.
+                    let (done, completed) = mpsc::channel();
+                    readers.push(completed);
+                    thread::Builder::new().spawn(move || {
+                        handle.join().expect("reader");
+                        done.send(()).expect("report reader completion");
+                    })
+                }
+            },
+        )
+        .err()
+        .expect("reader spawn fails");
+        assert!(
+            error.contains(if fail_at == 0 {
+                "stdout reader"
+            } else {
+                "stderr reader"
+            }),
+            "{error}"
+        );
+        assert_reaped(pid);
+        for reader in readers {
+            reader
+                .recv_timeout(Duration::from_secs(1))
+                .expect("started reader retired");
+        }
+    }
+}
+
+#[test]
+fn a_persistent_consuming_wait_error_ends_the_cli_without_releasing_ownership() {
+    check_fatal_cleanup("reap-error");
+}
+
+#[test]
+fn consuming_wait_echild_revokes_ownership_without_another_group_signal() {
+    let mut child = Command::new("/bin/sh")
+        .args(["-c", "exit 0"])
+        .process_group(0)
+        .spawn()
+        .expect("spawn child");
+    let pid = child.id();
+    child.wait().expect("external reap");
+    let mut group = ProcessGroup::new(child);
+    let error = group
+        .try_reap()
+        .expect_err("external waiter consumed status");
+    assert_eq!(error.raw_os_error(), Some(libc::ECHILD));
+    assert!(group.child.is_none());
+    assert_eq!(
+        group
+            .signal_group()
+            .expect_err("signals revoked")
+            .raw_os_error(),
+        Some(libc::ECHILD)
+    );
+    assert_reaped(pid);
+}
+
+#[test]
+fn a_consuming_wait_interruption_retains_the_child_and_the_deadline() {
+    let child = Command::new("/bin/sh")
+        .args(["-c", "exit 0"])
+        .process_group(0)
+        .spawn()
+        .expect("spawn child");
+    let pid = child.id();
+    let mut group = ProcessGroup::new(child);
+    group.wait_killed().expect("observe exit");
+    let deadline = group.cleanup_deadline;
+    group.faults.reap = Some(libc::EINTR);
+    let error = group
+        .try_reap()
+        .expect_err("injected interrupted consuming wait");
+    assert_eq!(error.raw_os_error(), Some(libc::EINTR));
+    assert_waitable(pid);
+    assert_eq!(group.cleanup_deadline, deadline);
+    group.faults.reap = None;
+    group.reap().expect("final signal then reap");
+    assert_reaped(pid);
+}
+
+#[test]
+fn stderr_chunks_do_not_restart_the_drain_deadline() {
+    let (sender, chunks) = mpsc::channel();
+    let producer = thread::spawn(move || {
+        for _ in 0..100 {
+            if sender.send(b"still alive\n".to_vec()).is_err() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    });
+    let started = Instant::now();
+    let stderr = super::drain_stderr(&chunks, Duration::from_millis(30));
+    let elapsed = started.elapsed();
+    drop(chunks);
+    producer.join().expect("producer retired");
+    assert!(!stderr.complete);
+    assert!(stderr.text.starts_with("still alive"));
+    assert!(elapsed < Duration::from_millis(500), "took {elapsed:?}");
+}
+
+#[test]
+fn transient_wait_interruptions_preserve_successful_wait_kill_and_reap() {
+    let child = Command::new("/bin/sh")
+        .args(["-c", "exit 7"])
+        .process_group(0)
+        .spawn()
+        .expect("spawn finite child");
+    let pid = child.id();
+    let mut group = ProcessGroup::new(child);
+    group.faults.wait_interruptions = 1;
+    let result = super::wait_bounded(
+        &mut group,
+        Duration::from_secs(1),
+        &std::sync::atomic::AtomicBool::new(false),
+    )
+    .expect("normal wait retries an interruption");
+    assert!(matches!(result, super::Wait::Exited));
+    assert_eq!(group.faults.wait_interruptions, 0);
+    assert_waitable(pid);
+    group.faults.wait_interruptions = 1;
+    group.kill().expect("kill retries an interruption");
+    assert_eq!(group.faults.wait_interruptions, 0);
+    group.faults.reap_interruptions = 1;
+    assert_eq!(
+        group.reap().expect("reap retries an interruption").code(),
+        Some(7)
+    );
+    assert_reaped(pid);
+}
+
+#[test]
+fn permission_grace_retries_interrupted_observation_without_resetting_time() {
+    let mut observations = 0;
+    super::resolve_group_signal_error(
+        std::io::Error::from_raw_os_error(libc::EPERM),
+        Duration::from_secs(1),
+        || {
+            observations += 1;
+            if observations == 1 {
+                Err(std::io::Error::from_raw_os_error(libc::EINTR))
+            } else {
+                Ok(true)
+            }
+        },
+    )
+    .expect("transient interrupted observation");
+    assert_eq!(observations, 2);
+    let started = Instant::now();
+    let error = super::resolve_group_signal_error(
+        std::io::Error::from_raw_os_error(libc::EPERM),
+        Duration::from_millis(20),
+        || Err(std::io::Error::from_raw_os_error(libc::EINTR)),
+    )
+    .expect_err("persistent interruptions expire with original denial");
+    assert_eq!(error.raw_os_error(), Some(libc::EPERM));
+    assert!(started.elapsed() < Duration::from_secs(1));
+}
+
+#[test]
+fn persistent_consuming_wait_interruptions_expire_with_the_original_deadline() {
+    check_fatal_cleanup("reap-interrupt");
 }


### PR DESCRIPTION
A failed process-group signal could leave the e2e runner blocked in destructor cleanup until its still-live child exited. Keep one two-second deadline across termination, exit observation, stderr draining, destructor retries and final reap. Waits are nonblocking and interruptions use the existing deadline. The leader remains reserved with WNOWAIT until the final descendant signal, and ECHILD revokes further signalling.

When cleanup cannot resolve the owned child, print its PID and the errors and end the runner with infrastructure exit code 2. The runner retains the Child until process exit; macOS adopts any survivors and owns their eventual reap. This does not claim the survivor was killed. An immediate exit avoids an unowned return or a background reaper that would disappear with the CLI. The budget bounds userspace cleanup waits, subject to scheduling, syscall and diagnostic-output latency; kernel descriptor closure can also delay exit. Reader creation failures remain infrastructure errors and preserve cleanup ownership.

Verification: make fmt, make check (formatting, Clippy, audit and docs), and make ISOLATED=1 test. All 77 native mtld3d-e2e runner tests passed. With the original blocking cleanup bodies, the injected permission-denial regression failed after waiting for the finite child's three-second lifetime. With bounded cleanup, its fixture exited with code 2 in 104 ms under a 100 ms test budget; the child then reported adoption by PID 1 and its process and group disappeared. Other tests cover interrupted and failed waits/reaps, reader creation failures, retained group identity and continuous stderr. Conformance is not needed because this changes only the native e2e runner and its documentation/tests, with no layer rendering, state, shader or shared-crate change.

Rules check: CONTRIBUTING.md records the fatal cleanup policy and the before/after regression. CONVENTIONS.md is enforced by the green make check gates; helpers and fault injection are private, unit tests stay in run/tests.rs, and syscall safety invariants are documented. No statics, config keys, wire fields, dependencies, derives, lint suppressions or duplicate runtime helpers are introduced. ARCHITECTURE.md's boundary and graphics threading contracts are unchanged. No Windows test coverage row changes apply.

Closes #589
