### PR TITLE
Log loaded CoreFoundation identity during startup

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -208,6 +208,14 @@ Every crate logs via `log` + `env_logger`. All targets sit under `mtld3d::*` and
 
 Each cdylib initializes the logger independently and idempotently; `mtld3d.so` has no owning entry point, so `d3d9.dll` dispatches a one-shot `InitLogger` thunk from its init path. Every line goes to the process's log file, `<exe>-<pid>.log` under `mtld3d-logs` beside the executable (`log.dir` moves it), never to the standard streams: a game a launcher spawned has no usable ones. `<pid>` is the macOS process id, so a launch never overwrites the log of the one before it; the directory keeps the ten newest logs and the ten newest traces, and the file appears with the first line written, so a process that logs nothing leaves nothing behind.
 
+The Unix initialization also records CoreFoundation's loaded path, Mach-O
+header address and UUID at `info` level under `mtld3d::unix`. It resolves the
+address of the linked `kCFRunLoopCommonModes` export without reading a CF
+object. This identifies the framework actually mapped in that process,
+including an image in the dyld shared cache. Missing path or UUID information
+is explicit. The record uses the same startup backlog and process log as the
+build stamp; the allocating loader query never runs from a signal handler.
+
 ### Command-buffer completion and encoder errors
 
 `RUST_LOG=mtld3d=warn,mtld3d::unix::command=debug` enables

--- a/unix/shared/src/identity.rs
+++ b/unix/shared/src/identity.rs
@@ -26,6 +26,8 @@
 /// manifest version (`v0.2.0`) when built outside a git checkout.
 pub const BUILD: &str = env!("MTLD3D_BUILD");
 
+#[cfg(unix)]
+pub use platform::LoadedImage;
 pub use platform::image_id;
 #[cfg(target_family = "windows")]
 pub use platform::version_blob;
@@ -414,13 +416,98 @@ mod platform {
 #[cfg(unix)]
 mod platform {
     use core::{ffi::c_void, fmt::Write as _};
+    use std::{
+        ffi::CStr,
+        os::unix::ffi::OsStrExt,
+        path::{Path, PathBuf},
+    };
 
     /// `LC_UUID`, the load command carrying the linker's image UUID.
     const LC_UUID: u32 = 0x1b;
+    /// Native-endian 64-bit Mach-O magic, for both supported Unix architectures.
+    const MACH_MAGIC_64: u32 = 0xfeed_facf;
     /// Size of a `mach_header_64`, after which the load commands start.
     const MACH_HEADER_64_SIZE: usize = 32;
     /// Offset of `ncmds` within a `mach_header_64`.
     const NCMDS: usize = 16;
+    /// Offset of `sizeofcmds` within a `mach_header_64`.
+    const SIZEOFCMDS: usize = 20;
+    /// The `cmd` and `cmdsize` words every load command starts with.
+    const LOAD_COMMAND_SIZE: usize = 8;
+    /// Load commands in 64-bit Mach-O images are aligned to eight bytes.
+    const LOAD_COMMAND_ALIGNMENT: usize = 8;
+    /// An `LC_UUID` command's header and sixteen UUID bytes.
+    const UUID_COMMAND_SIZE: usize = 24;
+
+    /// An owned identity snapshot of the image containing a linked symbol.
+    ///
+    /// No loader-owned pointer escapes construction. The numeric base is for
+    /// diagnostics, not a handle that keeps the image mapped.
+    pub struct LoadedImage {
+        path: Option<PathBuf>,
+        base: usize,
+        uuid: Option<String>,
+    }
+
+    impl LoadedImage {
+        /// Identify a loaded image through one of its linked symbols.
+        ///
+        /// Returns `None` when dyld cannot resolve the symbol's image. A missing
+        /// path or UUID stays absent independently. This allocates and queries
+        /// the loader, so it must not run in a signal handler.
+        ///
+        /// # Safety
+        ///
+        /// `symbol` must point into a dyld-loaded 64-bit Mach-O image that stays
+        /// loaded throughout this call. Its header and declared load-command
+        /// region must remain readable and unmodified throughout the call.
+        #[must_use]
+        pub unsafe fn for_symbol(symbol: *const c_void) -> Option<Self> {
+            let mut info = libc::Dl_info {
+                dli_fname: core::ptr::null(),
+                dli_fbase: core::ptr::null_mut(),
+                dli_sname: core::ptr::null(),
+                dli_saddr: core::ptr::null_mut(),
+            };
+            // SAFETY: `symbol` belongs to a live image per the contract; `info`
+            // is a live output buffer. dladdr does not retain either pointer.
+            let found = unsafe { libc::dladdr(symbol, &raw mut info) };
+            if found == 0 || info.dli_fbase.is_null() {
+                return None;
+            }
+            let path = if info.dli_fname.is_null() {
+                None
+            } else {
+                // SAFETY: dyld supplies a NUL-terminated image name, and the
+                // image remains loaded while this owned copy is made.
+                let name = unsafe { CStr::from_ptr(info.dli_fname) };
+                Some(PathBuf::from(std::ffi::OsStr::from_bytes(name.to_bytes())))
+            };
+            let base = info.dli_fbase as usize;
+            // SAFETY: dladdr returned this loaded image's header; the caller
+            // keeps its header and load commands readable throughout the call.
+            let uuid = unsafe { loaded_uuid(base) };
+            Some(Self { path, base, uuid })
+        }
+
+        /// The loader's image path, when available.
+        #[must_use]
+        pub fn path(&self) -> Option<&Path> {
+            self.path.as_deref()
+        }
+
+        /// The loaded Mach-O header's address, for relative crash offsets.
+        #[must_use]
+        pub const fn base(&self) -> usize {
+            self.base
+        }
+
+        /// The linker's UUID, absent for missing or malformed load commands.
+        #[must_use]
+        pub fn uuid(&self) -> Option<&str> {
+            self.uuid.as_deref()
+        }
+    }
 
     /// This image's Mach-O `LC_UUID`, read from its own load commands.
     ///
@@ -429,51 +516,67 @@ mod platform {
     /// `None` if the image carries no `LC_UUID`.
     #[must_use]
     pub fn image_id() -> Option<String> {
-        let base = image_base()?;
-        // SAFETY: `base` is this image's mach_header, so `ncmds` is the dword
-        // at `+16`.
-        let ncmds = unsafe { read_u32(base + NCMDS) };
-        let mut cmd = base + MACH_HEADER_64_SIZE;
-        for _ in 0..ncmds {
-            // SAFETY: `cmd` walks the load-command chain of a mapped image,
-            // bounded by the header's own `ncmds`; `cmd` is the first dword.
-            let kind = unsafe { read_u32(cmd) };
-            // SAFETY: `cmdsize` is the second dword of the same command.
-            let size = unsafe { read_u32(cmd + 4) } as usize;
-            if size == 0 {
-                return None;
-            }
-            if kind == LC_UUID {
-                // SAFETY: an `LC_UUID` command carries its 16 raw bytes right
-                // after the `cmd`/`cmdsize` pair.
-                let uuid = unsafe { read_bytes(cmd + 8) };
-                return Some(format_uuid(&uuid));
-            }
-            cmd += size;
-        }
-        None
+        let symbol = (image_id as *const ()).cast();
+        // SAFETY: our own code's image stays loaded while executing this call.
+        unsafe { LoadedImage::for_symbol(symbol) }?.uuid
     }
 
-    /// Load base of the image this code was linked into.
+    /// Read the UUID from a dyld-loaded image's mapped headers.
     ///
-    /// Asking `dladdr` about one of our own functions is what makes this the
-    /// *containing* image rather than the main executable, which matters
-    /// because we are loaded as a library beside the Wine host.
-    fn image_base() -> Option<usize> {
-        let mut info = libc::Dl_info {
-            dli_fname: core::ptr::null(),
-            dli_fbase: core::ptr::null_mut(),
-            dli_sname: core::ptr::null(),
-            dli_saddr: core::ptr::null_mut(),
-        };
-        let probe: *const c_void = (image_base as *const ()).cast();
-        // SAFETY: `probe` is a function pointer into this image and `info` is a
-        // live `Dl_info`; `dladdr` only writes through the latter.
-        let found = unsafe { libc::dladdr(probe, &raw mut info) };
-        if found == 0 || info.dli_fbase.is_null() {
+    /// # Safety
+    ///
+    /// `base` must address a readable, immutable 64-bit Mach-O header followed
+    /// by its declared load-command region, kept mapped throughout the call.
+    unsafe fn loaded_uuid(base: usize) -> Option<String> {
+        // SAFETY: the caller guarantees the complete fixed header is readable.
+        let header = unsafe { core::slice::from_raw_parts(base as *const u8, MACH_HEADER_64_SIZE) };
+        let size = command_extent(header)?;
+        base.checked_add(size)?;
+        isize::try_from(size).ok()?;
+        // SAFETY: the caller guarantees the declared command region is mapped;
+        // its length and address do not overflow, and the mapping is immutable.
+        let image = unsafe { core::slice::from_raw_parts(base as *const u8, size) };
+        mach_uuid(image).map(|uuid| format_uuid(&uuid))
+    }
+
+    /// Bound the command region by a native 64-bit Mach-O header.
+    fn command_extent(header: &[u8]) -> Option<usize> {
+        if header.len() < MACH_HEADER_64_SIZE || read_u32(header, 0)? != MACH_MAGIC_64 {
             return None;
         }
-        Some(info.dli_fbase as usize)
+        MACH_HEADER_64_SIZE.checked_add(usize::try_from(read_u32(header, SIZEOFCMDS)?).ok()?)
+    }
+
+    /// Parse only complete commands inside the header's declared byte extent.
+    fn mach_uuid(image: &[u8]) -> Option<[u8; 16]> {
+        let end = command_extent(image)?;
+        let mut commands = image.get(MACH_HEADER_64_SIZE..end)?;
+        let count = usize::try_from(read_u32(image, NCMDS)?).ok()?;
+        if count > commands.len() / LOAD_COMMAND_SIZE {
+            return None;
+        }
+        let mut uuid = None;
+        for _ in 0..count {
+            let kind = read_u32(commands, 0)?;
+            let size = usize::try_from(read_u32(commands, 4)?).ok()?;
+            if size < LOAD_COMMAND_SIZE || !size.is_multiple_of(LOAD_COMMAND_ALIGNMENT) {
+                return None;
+            }
+            let command = commands.get(..size)?;
+            if kind == LC_UUID {
+                uuid = Some(
+                    command
+                        .get(LOAD_COMMAND_SIZE..UUID_COMMAND_SIZE)?
+                        .try_into()
+                        .ok()?,
+                );
+            }
+            commands = commands.get(size..)?;
+        }
+        if !commands.is_empty() {
+            return None;
+        }
+        uuid
     }
 
     /// Format a 16-byte Mach-O UUID in the canonical 8-4-4-4-12 form.
@@ -491,23 +594,13 @@ mod platform {
         out
     }
 
-    /// Read a `u32` at `addr` without assuming alignment.
-    ///
-    /// # Safety
-    ///
-    /// `addr` must point at four readable bytes.
-    const unsafe fn read_u32(addr: usize) -> u32 {
-        // SAFETY: per the contract, four readable bytes live at `addr`.
-        unsafe { (addr as *const u32).read_unaligned() }
+    /// Read a native-endian header word without assuming alignment.
+    fn read_u32(bytes: &[u8], offset: usize) -> Option<u32> {
+        Some(u32::from_ne_bytes(
+            bytes.get(offset..offset.checked_add(4)?)?.try_into().ok()?,
+        ))
     }
 
-    /// Read 16 bytes at `addr` without assuming alignment.
-    ///
-    /// # Safety
-    ///
-    /// `addr` must point at sixteen readable bytes.
-    const unsafe fn read_bytes(addr: usize) -> [u8; 16] {
-        // SAFETY: per the contract, sixteen readable bytes live at `addr`.
-        unsafe { (addr as *const [u8; 16]).read_unaligned() }
-    }
+    #[cfg(test)]
+    mod tests;
 }

--- a/unix/shared/src/identity/platform/tests.rs
+++ b/unix/shared/src/identity/platform/tests.rs
@@ -1,0 +1,102 @@
+use super::{
+    LC_UUID, MACH_HEADER_64_SIZE, MACH_MAGIC_64, NCMDS, SIZEOFCMDS, format_uuid, mach_uuid,
+};
+
+const UUID: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+
+#[test]
+fn reads_uuid_after_an_unrelated_command() {
+    let mut commands = command(1, 8);
+    commands.extend(uuid_command());
+    assert_eq!(mach_uuid(&image(2, &commands)), Some(UUID));
+    assert_eq!(format_uuid(&UUID), "00010203-0405-0607-0809-0A0B0C0D0E0F");
+}
+
+#[test]
+fn missing_uuid_is_absent() {
+    assert_eq!(mach_uuid(&image(0, &[])), None);
+    assert_eq!(mach_uuid(&image(1, &command(1, 8))), None);
+}
+
+#[test]
+fn rejects_every_truncation_of_a_uuid_image() {
+    let bytes = image(1, &uuid_command());
+    for end in 0..bytes.len() {
+        assert_eq!(mach_uuid(&bytes[..end]), None, "length {end}");
+    }
+}
+
+#[test]
+fn rejects_wrong_magic_and_command_extent() {
+    let mut bytes = image(1, &uuid_command());
+    set_word(&mut bytes, 0, 0xfeed_face);
+    assert_eq!(mach_uuid(&bytes), None);
+    set_word(&mut bytes, 0, MACH_MAGIC_64);
+    set_word(&mut bytes, SIZEOFCMDS, u32::MAX);
+    assert_eq!(mach_uuid(&bytes), None);
+    set_word(&mut bytes, SIZEOFCMDS, 8);
+    assert_eq!(mach_uuid(&bytes), None);
+}
+
+#[test]
+fn rejects_inconsistent_command_counts() {
+    let mut bytes = image(0, &uuid_command());
+    assert_eq!(mach_uuid(&bytes), None);
+    set_word(&mut bytes, NCMDS, 2);
+    assert_eq!(mach_uuid(&bytes), None);
+    set_word(&mut bytes, NCMDS, u32::MAX);
+    assert_eq!(mach_uuid(&bytes), None);
+}
+
+#[test]
+fn rejects_short_unaligned_and_oversized_commands() {
+    for size in [0, 4, 7, 9, 16, 23, 25, 32, u32::MAX] {
+        let mut bytes = image(1, &uuid_command());
+        set_word(&mut bytes, MACH_HEADER_64_SIZE + 4, size);
+        assert_eq!(mach_uuid(&bytes), None, "command size {size}");
+    }
+}
+
+#[test]
+fn cannot_read_uuid_bytes_outside_the_command() {
+    let mut commands = command(LC_UUID, 8);
+    commands.extend(command(1, 8));
+    commands.extend(command(1, 8));
+    assert_eq!(mach_uuid(&image(3, &commands)), None);
+}
+
+#[test]
+fn validates_commands_after_the_uuid() {
+    let mut commands = uuid_command();
+    commands.extend(command(1, 0));
+    assert_eq!(mach_uuid(&image(2, &commands)), None);
+}
+
+fn image(count: u32, commands: &[u8]) -> Vec<u8> {
+    let mut bytes = vec![0; MACH_HEADER_64_SIZE];
+    set_word(&mut bytes, 0, MACH_MAGIC_64);
+    set_word(&mut bytes, NCMDS, count);
+    set_word(
+        &mut bytes,
+        SIZEOFCMDS,
+        u32::try_from(commands.len()).unwrap(),
+    );
+    bytes.extend(commands);
+    bytes
+}
+
+fn command(kind: u32, size: u32) -> Vec<u8> {
+    let mut bytes = kind.to_ne_bytes().to_vec();
+    bytes.extend(size.to_ne_bytes());
+    bytes
+}
+
+fn uuid_command() -> Vec<u8> {
+    let mut bytes = command(LC_UUID, 24);
+    bytes.extend(UUID);
+    bytes
+}
+
+fn set_word(bytes: &mut [u8], offset: usize, word: u32) {
+    bytes[offset..offset + 4].copy_from_slice(&word.to_ne_bytes());
+}

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -15,6 +15,7 @@ use mtld3d_shared::{
     mtl::{CursorOverlayFlags, DestroyKind, QuadPipelineKind, TextureCreateFlags},
     mtl_handle::{MTLBufferKind, MTLTextureKind},
 };
+use objc2_core_foundation::kCFRunLoopCommonModes;
 
 use crate::{LOG_TARGET, metal, metal::handle::IntoRetained};
 
@@ -128,6 +129,22 @@ fn log_identity() {
     let id = id.as_deref().unwrap_or("no-image-id");
     let build = identity::BUILD;
     info!(target: LOG_TARGET, "mtld3d.so {build} {id} initialized");
+    let Some(image) = core_foundation_image() else {
+        warn!(target: LOG_TARGET, "CoreFoundation image identity unavailable");
+        return;
+    };
+    let base = image.base();
+    let uuid = image.uuid().unwrap_or("unavailable");
+    match image.path() {
+        Some(path) => info!(target: LOG_TARGET,
+            "CoreFoundation path=\"{}\" base={base:#x} uuid={uuid}",
+            path.display().to_string().escape_debug()),
+        None => warn!(target: LOG_TARGET,
+            "CoreFoundation path=unavailable base={base:#x} uuid={uuid}"),
+    }
+    if image.uuid().is_none() {
+        warn!(target: LOG_TARGET, "CoreFoundation image UUID unavailable");
+    }
 }
 
 pub extern "C" fn get_device_info_handler(args: *mut c_void) -> i32 {
@@ -944,3 +961,17 @@ pub extern "C" fn destroy_resources_bulk_handler(args: *mut c_void) -> i32 {
     }
     STATUS_SUCCESS
 }
+
+/// Resolve the public export's storage, without following a CF object pointer.
+fn core_foundation_image() -> Option<identity::LoadedImage> {
+    // The address of the exported variable belongs to CoreFoundation. Reading
+    // its value instead would follow a CF object, and a Rust wrapper function
+    // would identify the image the wrapper was linked into.
+    let symbol = (&raw const kCFRunLoopCommonModes).cast();
+    // SAFETY: CoreFoundation is a linked dependency and stays mapped throughout
+    // this call, including the immutable Mach-O header and load commands.
+    unsafe { identity::LoadedImage::for_symbol(symbol) }
+}
+
+#[cfg(test)]
+mod tests;

--- a/unix/unix/src/handlers/tests.rs
+++ b/unix/unix/src/handlers/tests.rs
@@ -1,0 +1,24 @@
+use super::{core_foundation_image, identity, kCFRunLoopCommonModes};
+
+#[test]
+fn core_foundation_identity_names_the_framework() {
+    let framework = core_foundation_image().expect("linked CoreFoundation image");
+    let path = framework.path().expect("loaded framework path");
+    assert_eq!(path.file_name().unwrap(), "CoreFoundation");
+    assert!(path.to_str().unwrap().contains("CoreFoundation.framework/"));
+    let uuid = framework.uuid().expect("loaded framework UUID");
+    assert_eq!(uuid.len(), 36);
+    let own_symbol = (identity::image_id as *const ()).cast();
+    // SAFETY: the image executing this function remains loaded during the call.
+    let own = unsafe { identity::LoadedImage::for_symbol(own_symbol) }.unwrap();
+    assert_ne!(framework.base(), own.base());
+    assert_ne!(Some(uuid), own.uuid());
+    assert_eq!(own.uuid(), identity::image_id().as_deref());
+    assert!((&raw const kCFRunLoopCommonModes) as usize >= framework.base());
+    println!(
+        "CoreFoundation path={} base={:#x} uuid={uuid}",
+        path.display(),
+        framework.base()
+    );
+    println!("caller base={:#x} uuid={}", own.base(), own.uuid().unwrap());
+}


### PR DESCRIPTION
A native CoreFoundation crash could be mapped to an OS build and instruction offset, but the process log did not name the framework image that supplied those instructions. The existing build stamp identified only mtld3d.so.

Log the loaded CoreFoundation path, Mach-O base and UUID once during logger initialization. Resolve the storage address of the already-linked public kCFRunLoopCommonModes export without reading the CF object it points to. The typed CFRunLoopGetMain function is a Rust wrapper, so using its address would identify the caller image again. The shared identity helper now returns an owned snapshot and reuses one bounded Mach-O parser for the caller and framework images. Missing loader identity, path or UUID is explicit. The PE implementation and mtld3d build stamp are unchanged.

Verification: make fmt, make check, make ISOLATED=1 test and make ISOLATED=1 conformance. Eight CPU fixtures cover UUID extraction and malformed header/load-command bounds. The exact native CoreFoundation identity test passed under LLDB; its loaded path, base and UUID matched LLDB's independent module record for the same process and differed from the caller image. The native identity proof does not establish the UUID of a different architecture or an earlier crashed process.

Rules check: CONTRIBUTING.md requires the complete shared-code gates, including isolated test and conformance, before landing. make check passed the formatting, Clippy, audit and documentation rules from CONVENTIONS.md. The new identity snapshot owns its data behind private fields and safe accessors; its unsafe constructor documents the loaded-image lifetime and readable-header contract. Tests live in separate child modules. No statics, config keys, wire fields, dependencies, derives or suppressions are added, and the Mach-O parser is shared. Under ARCHITECTURE.md, this runs under the existing one-time logger initialization and uses the existing startup backlog and process sink. No timer behavior, private object reads, callback, crash-handler allocation or threading changes are included.

Closes #597
