### PR TITLE
Observe backbuffer initialization and allocation identities

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -201,7 +201,7 @@ Every crate logs via `log` + `env_logger`. All targets sit under `mtld3d::*` and
 | `mtld3d::perf`            | 5-second averaged performance summary (`PERF=1` builds only)             |
 | `mtld3d::shim`            | Wine unix-call PE shim DLL                                               |
 | `mtld3d::unix`            | Metal-side `.so`                                                         |
-| `mtld3d::unix::command`   | command-buffer completion records and encoder error details (debug)      |
+| `mtld3d::unix::command`   | command-buffer completion/error and backbuffer allocation/view records (debug) |
 | `mtld3d::unix::cursor`    | software cursor overlay window: sprite renders, show/hide, layer mode    |
 | `mtld3d::unix::present`   | presented-cadence probe, one row per frame (trace)                       |
 | `mtld3d::unix::depth`     | comparison-sampler creation, the unix mirror of `d3d9::depth` (trace)    |
@@ -219,22 +219,28 @@ build stamp; the allocating loader query never runs from a signal handler.
 ### Command-buffer completion and encoder errors
 
 `RUST_LOG=mtld3d=warn,mtld3d::unix::command=debug` enables
-`EncoderExecutionStatus` collection for frame, upload and synchronous readback
-command buffers. These buffers keep retained resource references in both modes;
-with the target disabled, creation uses the ordinary `commandBuffer()` path.
+`EncoderExecutionStatus` collection for frame, upload, synchronous readback and
+creation-time texture-clear command buffers. These buffers keep retained
+resource references in both modes; with the target disabled, creation uses
+the ordinary `commandBuffer()` path.
 Collection can add CPU, GPU and memory overhead, and logging every completion
 can be verbose. Use a bounded workload when gathering diagnostics.
 
-The existing frame/upload callbacks, retirement waits, CPU submission cleanup
-and readback wait log `command-buffer` records with the actual buffer, queue
-and device addresses, device registry ID and name, labels, role, sequence where
-known, observation site, numeric/named status and error options. Roles come from
+The frame/upload callbacks, retirement waits, CPU submission cleanup,
+readback wait and diagnostic-only initialization callback log `command-buffer`
+records with the actual buffer, queue and device addresses, device registry
+ID and name, labels, role, sequence where known, observation site,
+numeric/named status and error options. Roles come from
 the constructor-owned labels; an unrecognized or missing label reports `unknown`.
-Readback sequences are `unavailable`. One buffer can appear at several sites,
-so correlate the addresses and site with the sequence and log order. Addresses
-can be reused after release. No new wait or callback is added. Only a recorded
-`Completed` status establishes successful completion of that observed buffer;
-absence of an error record does not.
+Readback and initialization sequences are `unavailable`. Initialization uses
+the exact `mtld3d-init-clear` label and `initialization-callback` observation
+site. One buffer can appear at several sites, so correlate the addresses and
+site with the sequence and log order. Addresses can be reused after release,
+and log order is not a causal order across queues.
+No new wait is added. The initialization callback adds scheduling and logging
+work only with diagnostics enabled, so captures can alter failure frequency.
+Only a recorded `Completed` status establishes successful completion of that
+observed buffer; absence of an error record does not.
 
 On failure, the following `command-buffer-error` record names the same buffer,
 sequence and site and includes the signed `NSError` code, domain and description.
@@ -249,10 +255,33 @@ No per-draw signposts are inserted, so existing labels can be all the driver has
 `Affected` does not establish that the encoder caused the error, and an encoder's
 `Completed` state does not make the whole buffer successful.
 
-Creation-time texture clears, cursor-overlay buffers and the empty teardown
-fence are outside this target's construction and observation scope. A clean
-local run validates construction and completion on that device; it does not
-demonstrate a real error payload or establish another GPU's fault attribution.
+The initialization callback captures no resource, PE memory or caller borrow.
+Its executable lifetime depends on the D3D loading contract: `CreateDevice`
+sets the used latch before a clear can be submitted, and D3D DLL detach then
+self-terminates before Wine unloads its statically imported shim and Unix
+image. Native unit clients compile this code into their test executable.
+This is not a general contract for a client that directly loads and unloads
+the shim or Unix image. A change allowing surviving D3D unload after
+`CreateDevice` must revisit the callback. Process exit can end callbacks
+before they log; the shutdown fence does not prove all earlier callbacks
+finished, and missing records remain unobserved completions.
+
+The target also records each successful backbuffer's base and optional view
+and MSAA handles with its request device and queue. Each refused sRGB view
+records the live base texture and device identities, actual base label,
+dimensions, format, usage, type, mip and array sizes, and requested view
+format, type, ranges and swizzle. Extra view queries run only in the enabled
+refusal branch. The ordinary allocation errors carry the live allocation
+device and registry ID; backbuffer failures carry the request device and
+queue handles. Join these records within the process and creation interval:
+addresses can be reused, and system driver errors without texture handles
+cannot be matched one-to-one by timing alone. A refused optional view does
+not establish a failed base allocation or memory exhaustion.
+
+Cursor-overlay buffers and the empty teardown fence are outside this
+target's construction and observation scope. A clean local run validates
+construction and completion on that device; it does not demonstrate a real
+error payload or establish another GPU's fault attribution.
 
 For a bounded manual CI run, set `e2e_filter` to
 `msaa::depth_test_holds_on_a_multisampled_target` and `e2e_log` to

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -417,8 +417,12 @@ pub extern "C" fn create_backbuffer_handler(args: *mut c_void) -> i32 {
     else {
         error!(
             target: LOG_TARGET,
-            "failed to create {}x{} backbuffer (samples={})",
-            params.width, params.height, params.sample_count
+            "failed to create {}x{} backbuffer (samples={}) device={:#x} queue={:#x}",
+            params.width,
+            params.height,
+            params.sample_count,
+            params.device_handle.raw(),
+            params.queue_handle.raw(),
         );
         return STATUS_UNSUCCESSFUL;
     };
@@ -434,8 +438,12 @@ pub extern "C" fn create_backbuffer_handler(args: *mut c_void) -> i32 {
         error!(
             target: LOG_TARGET,
             "failed to create the {}x multisampled companion of the {}x{} backbuffer; the \
-             single-sample texture is released again",
-            params.sample_count, params.width, params.height
+             single-sample texture is released again; device={:#x} queue={:#x}",
+            params.sample_count,
+            params.width,
+            params.height,
+            params.device_handle.raw(),
+            params.queue_handle.raw(),
         );
         // Both handles are minted and neither has been handed back, so this
         // side owns their only copies; the view goes first, since it holds a
@@ -463,8 +471,9 @@ pub extern "C" fn create_backbuffer_handler(args: *mut c_void) -> i32 {
     // window drag. The CreateDevice + AttachMetalLayer info
     // lines already cover the boot-time milestone.
     debug!(
-        target: LOG_TARGET,
-        "created backbuffer {}x{} samples={}: texture {:#x} srgb {:#x} msaa {:#x} msaa_srgb {:#x}",
+        target: "mtld3d::unix::command",
+        "created backbuffer {}x{} samples={}: texture {:#x} srgb {:#x} msaa {:#x} \
+         msaa_srgb {:#x} device={:#x} queue={:#x}",
         params.width,
         params.height,
         params.sample_count,
@@ -472,6 +481,8 @@ pub extern "C" fn create_backbuffer_handler(args: *mut c_void) -> i32 {
         params.srgb_texture_handle.raw(),
         params.msaa_texture_handle.raw(),
         params.msaa_srgb_texture_handle.raw(),
+        params.device_handle.raw(),
+        params.queue_handle.raw(),
     );
     STATUS_SUCCESS
 }

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -40,7 +40,7 @@ use crate::{
     metal::{handle::IntoRetained, macdrv::attachment, null_texture, texture::mtl_pixel_format},
 };
 
-mod diagnostics;
+pub mod diagnostics;
 
 /// `Retained<ProtocolObject<dyn MTLCommandBuffer>>` is not `Send`/`Sync` in objc2.
 ///

--- a/unix/unix/src/metal/command/diagnostics.rs
+++ b/unix/unix/src/metal/command/diagnostics.rs
@@ -1,9 +1,10 @@
 use std::fmt::Write;
 
+use block2::RcBlock;
 use log::{Level, debug, log_enabled};
 use objc2::{
     ProtocolType,
-    rc::Retained,
+    rc::{Retained, autoreleasepool},
     runtime::{AnyObject, ProtocolObject},
 };
 use objc2_foundation::{NSArray, NSError, NSString};
@@ -23,6 +24,37 @@ pub fn command_buffer(
         || queue.commandBuffer(),
         |descriptor| queue.commandBufferWithDescriptor(&descriptor),
     )
+}
+
+/// Observe a creation-time clear without publishing a frame retirement sequence.
+pub fn observe_initialization(cb: &ProtocolObject<dyn MTLCommandBuffer>) {
+    if !log_enabled!(target: LOG_TARGET, Level::Debug) {
+        return;
+    }
+    let handler = RcBlock::new(
+        |cb_ptr: core::ptr::NonNull<ProtocolObject<dyn MTLCommandBuffer>>| {
+            autoreleasepool(|_| {
+                // SAFETY: Metal supplies the completed buffer, valid for this invocation.
+                // No reference to it escapes the callback.
+                let cb = unsafe { cb_ptr.as_ref() };
+                let status = cb.status();
+                completion(cb, status, None, "initialization-callback");
+                if status == MTLCommandBufferStatus::Error {
+                    failure(cb, None, "initialization-callback", cb.error().as_deref());
+                }
+            });
+        },
+    );
+    // Executable lifetime is separate from the block's captures: D3D CreateDevice sets
+    // USED before any clear, so d3d9 detach self-terminates before Wine can unload its
+    // statically imported shim and this Unix image. Native unit clients compile this
+    // code into their test executable. Surviving direct-shim unload has no such contract.
+    // Revisit this observer if D3D unload after CreateDevice can leave the process alive.
+    // Process exit may end a callback before it logs; no completion is inferred then.
+    // SAFETY: the live buffer has not been committed. Metal copies the valid block at
+    // registration, so our handle may drop. The block captures nothing, uses only the
+    // invocation's live argument and thread-safe diagnostics, and creates its own pool.
+    unsafe { cb.addCompletedHandler(RcBlock::as_ptr(&handler)) };
 }
 
 pub fn completion(
@@ -97,6 +129,7 @@ fn buffer_role(label: Option<&str>) -> &'static str {
         Some(label) if label.starts_with("mtld3d-frame-") => "frame",
         Some(label) if label.starts_with("mtld3d-upload-") => "upload",
         Some("mtld3d-readback") => "readback",
+        Some("mtld3d-init-clear") => "initialization",
         // Labels belong to the constructors; do not guess an unknown buffer's role.
         _ => "unknown",
     }

--- a/unix/unix/src/metal/command/diagnostics/tests.rs
+++ b/unix/unix/src/metal/command/diagnostics/tests.rs
@@ -155,6 +155,8 @@ fn optional_identity_fields_preserve_missing_and_escape_present_strings() {
     assert_eq!(buffer_role(Some("mtld3d-frame-0x1")), "frame");
     assert_eq!(buffer_role(Some("mtld3d-upload-0x1")), "upload");
     assert_eq!(buffer_role(Some("mtld3d-readback")), "readback");
+    assert_eq!(buffer_role(Some("mtld3d-init-clear")), "initialization");
+    assert_eq!(buffer_role(Some("mtld3d-init-clear-extra")), "unknown");
     assert_eq!(buffer_role(Some("unexpected")), "unknown");
     assert_eq!(buffer_role(None), "unknown");
 }

--- a/unix/unix/src/metal/texture.rs
+++ b/unix/unix/src/metal/texture.rs
@@ -9,14 +9,17 @@ use mtld3d_shared::{
 };
 use objc2::{rc::Retained, runtime::ProtocolObject};
 use objc2_metal::{
-    MTLBlendFactor, MTLClearColor, MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue,
-    MTLCompareFunction, MTLDepthStencilDescriptor, MTLDevice, MTLLoadAction, MTLPixelFormat,
-    MTLRenderPassDescriptor, MTLResource, MTLStencilDescriptor, MTLStencilOperation,
-    MTLStorageMode, MTLStoreAction, MTLTexture, MTLTextureDescriptor, MTLTextureSwizzle,
-    MTLTextureSwizzleChannels, MTLTextureType, MTLTextureUsage,
+    MTLBlendFactor, MTLClearColor, MTLCommandBuffer, MTLCommandEncoder, MTLCompareFunction,
+    MTLDepthStencilDescriptor, MTLDevice, MTLLoadAction, MTLPixelFormat, MTLRenderPassDescriptor,
+    MTLResource, MTLStencilDescriptor, MTLStencilOperation, MTLStorageMode, MTLStoreAction,
+    MTLTexture, MTLTextureDescriptor, MTLTextureSwizzle, MTLTextureSwizzleChannels, MTLTextureType,
+    MTLTextureUsage,
 };
 
-use crate::metal::handle::{IntoRetained, ReleaseRetain};
+use crate::metal::{
+    command::diagnostics,
+    handle::{IntoRetained, ReleaseRetain},
+};
 
 /// The texture handles this side has minted and not yet destroyed.
 ///
@@ -165,6 +168,35 @@ fn srgb_twin_view(
         )
     };
     let Some(view) = view else {
+        if log::log_enabled!(target: "mtld3d::unix::command", log::Level::Debug) {
+            let device = texture.device();
+            log::debug!(
+                target: "mtld3d::unix::command",
+                "texture-view-refused base={texture:p} device={:p} registry_id={:#x} \
+                 label={:?} width={} height={} depth={} samples={} pixel_format={} \
+                 usage={:#x} texture_type={} mip_levels={} array_length={} \
+                 view_pixel_format={} view_texture_type={} view_levels=0..{levels} \
+                 view_slices=0..{slices} view_swizzle=({},{},{},{})",
+                Retained::as_ptr(&device),
+                device.registryID(),
+                texture.label().map(|label| label.to_string()),
+                texture.width(),
+                texture.height(),
+                texture.depth(),
+                texture.sampleCount(),
+                texture.pixelFormat().0,
+                texture.usage().0,
+                texture.textureType().0,
+                texture.mipmapLevelCount(),
+                texture.arrayLength(),
+                mtl_pixel_format(srgb_format).0,
+                texture.textureType().0,
+                swizzle.red.0,
+                swizzle.green.0,
+                swizzle.blue.0,
+                swizzle.alpha.0,
+            );
+        }
         mtld3d_shared::log_once_warn!(
             target: crate::LOG_TARGET,
             "{label}: Metal declined the {srgb_format:?} view of a {format:?} texture; \
@@ -235,7 +267,7 @@ pub fn clear_new_color_textures(
         );
         return;
     };
-    let Some(cmd_buf) = queue.commandBuffer() else {
+    let Some(cmd_buf) = diagnostics::command_buffer(&queue) else {
         mtld3d_shared::log_once_warn!(
             target: crate::LOG_TARGET,
             "clear_new_color_textures: commandBuffer() returned nil for the creation-time \
@@ -248,6 +280,7 @@ pub fn clear_new_color_textures(
     for texture in &textures {
         clear_one_texture(&cmd_buf, texture, clear_color);
     }
+    diagnostics::observe_initialization(&cmd_buf);
     cmd_buf.commit();
 }
 
@@ -465,7 +498,7 @@ fn log_texture_refused(
         target: crate::LOG_TARGET,
         "{label}: newTextureWithDescriptor returned nil for {}x{} {pixel_format:?} samples={} \
          usage={:#x} storage={} on '{}' (allocated {} B, recommended working set {} B, unified \
-         memory: {})",
+         memory: {}) device={device:p} registry_id={:#x}",
         desc.width(),
         desc.height(),
         desc.sampleCount(),
@@ -475,6 +508,7 @@ fn log_texture_refused(
         device.currentAllocatedSize(),
         device.recommendedMaxWorkingSetSize(),
         device.hasUnifiedMemory(),
+        device.registryID(),
     );
 }
 


### PR DESCRIPTION
Creation-time texture clears had no completion observation, so successful frame and readback records could not establish their result. Backbuffer allocation and optional sRGB-view refusals also lacked the device and queue identities needed to connect them to those records.

Extend `mtld3d::unix::command=debug` through the existing diagnostic constructor and formatter for initialization clears. The observer records the actual completion status and error, has no frame sequence, captures no resources or PE state, and uses its own autorelease pool. Its executable lifetime depends on the existing CreateDevice latch, D3D detach self-termination and Wine dependency-unload contract. Process exit can still end callbacks before they log.

Add the four allocation/view joins: live allocation device and registry ID on native nil, request device/queue handles on backbuffer failure and the existing success record, and actual base texture plus requested view metadata on each refused sRGB view. Additional view queries and the callback are debug-only. Retained references, descriptors, commit order and existing waits remain unchanged. An allocation registry or another wait would change resource lifetime and timing and is unnecessary for these joins. Diagnostic callbacks and logging can themselves change scheduling.

This provides missing evidence for #477 and #510; neither cause is established or fixed by this change. A missing callback is unobserved, and a refused optional view does not establish a failed base allocation or memory exhaustion.

Verification: the five existing fresh render-target, cube/mip, MSAA and concurrent-retarget tests passed on both PE architectures with command diagnostics disabled and enabled. Disabled logs contained no command-target records; enabled logs contained 188 i686 and 190 x86_64 initialization observations, all Completed. Both DLL and Unix startup stamps matched the tested candidate. These runs did not reproduce allocation nil, view refusal or command-buffer errors. The enabled process logs were about 435 KB and 439 KB; no timing-overhead claim is made. The exact pure identity-format fixture also passed.

Landing gates: `make check` (formatting, Clippy, audit and docs), `make ISOLATED=1 test` and full `make ISOLATED=1 conformance` for both architectures. No baseline change.

The first i686 conformance attempt stopped because the expected hidden-window activation-message assertion at `device.c:4319` counted one failure against a pin of two. A separate unchanged-main control counted two, with both iterations missing `WM_ACTIVATEAPP(FALSE)`, and passed. The unchanged candidate also passed a repeated i686 leg with count two and the same two missing messages in its raw output. These observations establish count variability on that candidate, not its cause; all results are retained, and the final gate uses the unchanged baseline.

Rules check: CONTRIBUTING.md requires the full gates on the final candidate; conformance is required because diagnostic construction changes render-target initialization. CONVENTIONS.md: no static, config key, environment variable, wire field, dependency, derive, suppression or duplicate formatter. Typed objc2/block2 APIs retain the existing boundary and one-operation unsafe blocks. ARCHITECTURE.md: queues, resource retention, PE backing and AppKit ownership remain unchanged; no registry, counter, new wait, retry or PE write. The diagnostic scope documents code lifetime, scheduling overhead, pointer reuse and incomplete exit observations. No shader/caps/classifier/baseline change is needed.

Closes #599
