### PR TITLE
Log render-pass and readback resource identities on demand

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -283,6 +283,29 @@ target's construction and observation scope. A clean local run validates
 construction and completion on that device; it does not demonstrate a real
 error payload or establish another GPU's fault attribution.
 
+The same debug target records synchronous encoding metadata. `render-pass`
+reads the assembled descriptor just before render-encoder creation: four color
+slots, depth and stencil, their actual texture and resolve bindings, subresources,
+load/store/clear values and resolve filters. `commands` counts the existing
+command list, including state setters; it is not a draw count. `texture-copy`
+records accepted texture-to-texture endpoints, slices and validated region.
+`readback-copy` records the final selected source after any readback resolve or
+fallback, the actual destination Metal buffer, PE destination address/length,
+and encoded offset, row pitch and image pitch. Image pitch counts block rows
+for compressed textures. The existing `readback-wait` record supplies completion.
+Texture extents in these records are base-level extents; `level` selects the mip.
+
+These records include command-buffer pointer, label and queue, plus pass or
+blit site, so a producer attachment can be followed through copies into a
+readback destination. All additional property queries and formatting are behind
+the debug filter. They establish encoding inputs, not pixel correctness or
+successful encoder creation. The attachment count is fixed, but label lengths
+and the number of passes and copies determine output volume. Measure lines and
+bytes on the focused test before enabling this target for a full-suite capture.
+Join within a process and ordered resource lifetime: pointers and per-device
+sequences can be reused, and successful full-suite logs lack direct test identity.
+No pixel contents are read by these records.
+
 For a bounded manual CI run, set `e2e_filter` to
 `msaa::depth_test_holds_on_a_multisampled_target` and `e2e_log` to
 `mtld3d=warn,mtld3d::unix::command=debug` in the workflow dispatch form. The

--- a/unix/unix/src/metal/command.rs
+++ b/unix/unix/src/metal/command.rs
@@ -2034,6 +2034,26 @@ fn encode_leading_blits(
                     );
                     continue;
                 }
+                diagnostics::texture_copy(
+                    cmd_buf,
+                    site,
+                    i,
+                    &diagnostics::TextureCopy {
+                        texture: &src,
+                        endpoint: &src_endpoint,
+                        slice: cmd.src_slice as usize,
+                    },
+                    &diagnostics::TextureCopy {
+                        texture: &dst,
+                        endpoint: &dst_endpoint,
+                        slice: cmd.dst_slice as usize,
+                    },
+                    &CopyRegion {
+                        width: region_w as usize,
+                        height: region_h as usize,
+                        depth: region_depth as usize,
+                    },
+                );
                 mtld3d_shared::crumb!("blit:tex2tex", cmd.src_handle, cmd.dst_handle);
                 // SAFETY: objc2 typed binding; `src`/`dst` are retained Metal
                 // textures live for the call; the region fits both live mip
@@ -2388,6 +2408,7 @@ fn encode_pass(
         }
     }
 
+    diagnostics::render_pass(cmd_buf, &rp_desc, pass_idx, pass.command_count);
     mtld3d_shared::crumb!("pass:rendenc", pass_idx as u64);
     let Some(encoder) = cmd_buf.renderCommandEncoderWithDescriptor(&rp_desc) else {
         error!(
@@ -3275,6 +3296,21 @@ pub fn blit_texture_to_buffer(args: &BlitArgs) -> bool {
     // format, where the block height is 1.
     let bytes_per_image =
         mtld3d_shared::blit_geometry::bytes_per_image(bytes_per_row, height, block_height) as usize;
+    diagnostics::readback(
+        &cmd_buf,
+        &diagnostics::TextureCopy {
+            texture,
+            endpoint: &src_endpoint,
+            slice: slice as usize,
+        },
+        &dst_buffer,
+        &CopyBufferEndpoint {
+            bytes_per_image,
+            ..destination
+        },
+        &region,
+        (dst_ptr, dst_len),
+    );
     // SAFETY: objc2 typed binding; `texture`/`dst_buffer` are retained Metal
     // objects live for the call; the geometry cleared
     // `copy_texture_to_buffer_reject` above.

--- a/unix/unix/src/metal/command/diagnostics.rs
+++ b/unix/unix/src/metal/command/diagnostics.rs
@@ -9,12 +9,170 @@ use objc2::{
 };
 use objc2_foundation::{NSArray, NSError, NSString};
 use objc2_metal::{
-    MTLCommandBuffer, MTLCommandBufferDescriptor, MTLCommandBufferEncoderInfo,
+    MTLBuffer, MTLCommandBuffer, MTLCommandBufferDescriptor, MTLCommandBufferEncoderInfo,
     MTLCommandBufferEncoderInfoErrorKey, MTLCommandBufferErrorOption, MTLCommandBufferStatus,
-    MTLCommandEncoderErrorState, MTLCommandQueue, MTLDevice,
+    MTLCommandEncoderErrorState, MTLCommandQueue, MTLDevice, MTLRenderPassAttachmentDescriptor,
+    MTLRenderPassDescriptor, MTLResource, MTLTexture,
 };
 
+use super::{BlitSite, CopyBufferEndpoint, CopyEndpoint, CopyRegion};
+
 const LOG_TARGET: &str = "mtld3d::unix::command";
+
+pub struct TextureCopy<'a> {
+    pub texture: &'a ProtocolObject<dyn MTLTexture>,
+    pub endpoint: &'a CopyEndpoint,
+    pub slice: usize,
+}
+
+pub fn render_pass(
+    cb: &ProtocolObject<dyn MTLCommandBuffer>,
+    descriptor: &MTLRenderPassDescriptor,
+    pass_index: usize,
+    command_count: u32,
+) {
+    if !log_enabled!(target: LOG_TARGET, Level::Debug) {
+        return;
+    }
+    let mut attachments = String::new();
+    let colors = descriptor.colorAttachments();
+    for index in 0..4 {
+        // SAFETY: the four supported color slots are within Metal's attachment array.
+        let color = unsafe { colors.objectAtIndexedSubscript(index) };
+        write!(
+            attachments,
+            " color[{index}]={{{} clear={:?}}}",
+            attachment_details(&color),
+            color.clearColor(),
+        )
+        .expect("writing to a String cannot fail");
+    }
+    let depth = descriptor.depthAttachment();
+    let stencil = descriptor.stencilAttachment();
+    debug!(
+        target: LOG_TARGET,
+        "render-pass {} site=pass{pass_index} commands={command_count}{} \
+         depth={{{} clear={} resolve_filter={:?}}} \
+         stencil={{{} clear={} resolve_filter={:?}}}",
+        buffer_identity(cb),
+        attachments,
+        attachment_details(&depth),
+        depth.clearDepth(),
+        depth.depthResolveFilter(),
+        attachment_details(&stencil),
+        stencil.clearStencil(),
+        stencil.stencilResolveFilter(),
+    );
+}
+
+pub fn texture_copy(
+    cb: &ProtocolObject<dyn MTLCommandBuffer>,
+    site: BlitSite,
+    index: usize,
+    source: &TextureCopy<'_>,
+    destination: &TextureCopy<'_>,
+    region: &CopyRegion,
+) {
+    if !log_enabled!(target: LOG_TARGET, Level::Debug) {
+        return;
+    }
+    debug!(
+        target: LOG_TARGET,
+        "texture-copy {} site={site}/{index} src={{{} {} slice={} z=0}} \
+         dst={{{} {} slice={} z=0}} region={region}",
+        buffer_identity(cb),
+        texture_identity(source.texture),
+        source.endpoint,
+        source.slice,
+        texture_identity(destination.texture),
+        destination.endpoint,
+        destination.slice,
+    );
+}
+
+pub fn readback(
+    cb: &ProtocolObject<dyn MTLCommandBuffer>,
+    source: &TextureCopy<'_>,
+    buffer: &ProtocolObject<dyn MTLBuffer>,
+    destination: &CopyBufferEndpoint,
+    region: &CopyRegion,
+    pe_destination: (u64, u64),
+) {
+    if !log_enabled!(target: LOG_TARGET, Level::Debug) {
+        return;
+    }
+    debug!(
+        target: LOG_TARGET,
+        "readback-copy {} site=readback-blit src={{{} {} slice={} z=0}} \
+         dst={{buffer={buffer:p} label={} storage={:?} {destination}}} \
+         pe_destination={:#x} pe_length={} region={region}",
+        buffer_identity(cb),
+        texture_identity(source.texture),
+        source.endpoint,
+        source.slice,
+        optional_string(buffer.label().map(|s| s.to_string()).as_deref()),
+        buffer.storageMode(),
+        pe_destination.0,
+        pe_destination.1,
+    );
+}
+
+fn buffer_identity(cb: &ProtocolObject<dyn MTLCommandBuffer>) -> String {
+    format!(
+        "buffer={cb:p} label={} queue={:p}",
+        optional_string(cb.label().map(|s| s.to_string()).as_deref()),
+        Retained::as_ptr(&cb.commandQueue()),
+    )
+}
+
+fn texture_identity(texture: &ProtocolObject<dyn MTLTexture>) -> String {
+    format!(
+        "texture={texture:p} label={} storage={:?} usage={:#x} type={:?} array_length={}",
+        optional_string(texture.label().map(|s| s.to_string()).as_deref()),
+        texture.storageMode(),
+        texture.usage().0,
+        texture.textureType(),
+        texture.arrayLength(),
+    )
+}
+
+fn attachment_texture(texture: Option<&ProtocolObject<dyn MTLTexture>>, level: usize) -> String {
+    let Some(texture) = texture else {
+        return "missing".to_owned();
+    };
+    let endpoint = CopyEndpoint {
+        pixel_format: texture.pixelFormat(),
+        sample_count: texture.sampleCount(),
+        width: texture.width(),
+        height: texture.height(),
+        depth: texture.depth(),
+        level,
+        levels: texture.mipmapLevelCount(),
+        origin_x: 0,
+        origin_y: 0,
+    };
+    format!("{} {endpoint}", texture_identity(texture))
+}
+
+fn attachment_details(attachment: &MTLRenderPassAttachmentDescriptor) -> String {
+    format!(
+        "texture={{{}}} level={} slice={} plane={} resolve={{{}}} \
+         resolve_level={} resolve_slice={} resolve_plane={} load={:?} store={:?}",
+        attachment_texture(attachment.texture().as_deref(), attachment.level()),
+        attachment.level(),
+        attachment.slice(),
+        attachment.depthPlane(),
+        attachment_texture(
+            attachment.resolveTexture().as_deref(),
+            attachment.resolveLevel(),
+        ),
+        attachment.resolveLevel(),
+        attachment.resolveSlice(),
+        attachment.resolveDepthPlane(),
+        attachment.loadAction(),
+        attachment.storeAction(),
+    )
+}
 
 pub fn command_buffer(
     queue: &ProtocolObject<dyn MTLCommandQueue>,

--- a/unix/unix/src/metal/command/diagnostics.rs
+++ b/unix/unix/src/metal/command/diagnostics.rs
@@ -19,13 +19,13 @@ use super::{BlitSite, CopyBufferEndpoint, CopyEndpoint, CopyRegion};
 
 const LOG_TARGET: &str = "mtld3d::unix::command";
 
-pub struct TextureCopy<'a> {
-    pub texture: &'a ProtocolObject<dyn MTLTexture>,
-    pub endpoint: &'a CopyEndpoint,
-    pub slice: usize,
+pub(super) struct TextureCopy<'a> {
+    pub(super) texture: &'a ProtocolObject<dyn MTLTexture>,
+    pub(super) endpoint: &'a CopyEndpoint,
+    pub(super) slice: usize,
 }
 
-pub fn render_pass(
+pub(super) fn render_pass(
     cb: &ProtocolObject<dyn MTLCommandBuffer>,
     descriptor: &MTLRenderPassDescriptor,
     pass_index: usize,
@@ -65,7 +65,7 @@ pub fn render_pass(
     );
 }
 
-pub fn texture_copy(
+pub(super) fn texture_copy(
     cb: &ProtocolObject<dyn MTLCommandBuffer>,
     site: BlitSite,
     index: usize,
@@ -90,7 +90,7 @@ pub fn texture_copy(
     );
 }
 
-pub fn readback(
+pub(super) fn readback(
     cb: &ProtocolObject<dyn MTLCommandBuffer>,
     source: &TextureCopy<'_>,
     buffer: &ProtocolObject<dyn MTLBuffer>,


### PR DESCRIPTION
Completed command buffers alone cannot identify which attachments produced a readback or which textures intervening copies consumed. Add synchronous records under the existing `mtld3d::unix::command=debug` target for the assembled render-pass descriptor, accepted texture copies and final texture-to-buffer readback. Each record names the command buffer and existing encoding site so attachment and copy identities can be followed through to the existing completion observation.

Keep command-only diagnostic APIs visible to their parent module, while preserving the sibling backbuffer initialization APIs. Reuse the existing endpoint and optional-field formatters and query live typed Metal objects only after the debug filter accepts the record. Readback records use the selected source after existing resolve/fallback handling and the actual encoded destination offset and row/image pitches. The command count includes state setters and is named as commands. No additional wait or pixel capture is needed for this metadata. These records establish encoding inputs and preserve the existing all-black-row assertion; they do not identify a cause of #510, which remains open.

Verification: the existing multisampled-depth test passed on i686 and x86_64 with command logging disabled and enabled. Each enabled run produced three metadata records totaling 3,382 bytes and an approximately 11.1 KB process log; disabled runs produced no command-target records. The records join the 4x color/depth pass through its 1x resolve and texture copy to the selected Managed readback buffer, with offset 0, row pitch 2,560 and image pitch 1,228,800. Matching readback observations were Completed and the existing pixel assertion passed. Both DLL and Unix startup stamps matched the measured candidate, before the visibility-only integration adjustment and unchanged-patch rebase. These are output-volume and identity checks, not a timing-overhead measurement or Intel failure reproduction. The existing pure optional-identity fixture also passed (1 test).

Landing gates: `make check` (formatting, Clippy, audit and rustdoc), `make ISOLATED=1 test`, and full `make ISOLATED=1 conformance` on both architectures.

Rules check: CONTRIBUTING.md's complete source and runtime gates are listed above; conformance is required for these render-path observations. CONVENTIONS.md: no new static, configuration key, environment variable, wire field, dependency, derive or lint suppression; existing value formatters are reused. The borrowed TextureCopy bag serves the two copy sites. ARCHITECTURE.md: observations remain on the Unix side with live typed objects and the existing debug target. No callback, registry, counter, wait, GPU copy, PE-memory read, pixel dump, descriptor mutation or submission/retirement change. The diagnostic documentation explains pointer reuse and incomplete successful-test attribution.

Closes #601
