### PR TITLE
Preserve Metal errors when encoder metadata is missing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -248,8 +248,11 @@ It checks the encoder-info array and each element's protocol conformance before
 printing labels, numeric/named states and signposts in recorded order. Variable
 strings are quoted and escaped to keep each record on one line. Missing errors,
 missing keys, malformed payloads, empty arrays and unavailable protocol metadata
-remain distinct. The typed encoder-info protocol promises nonnull labels and
-signpost arrays; an empty signpost array is reported as `empty`, never as success.
+remain distinct. Encoder labels and signpost arrays are read through Foundation's
+nullable key-value getter after checking `NSObject` inheritance. Nil metadata is
+reported as `missing`, an empty signpost array as `empty`, and wrong value or
+element classes as malformed. A conforming encoder outside `NSObject` retains
+its state with object metadata reported as `unavailable-non-nsobject`.
 No per-draw signposts are inserted, so existing labels can be all the driver has.
 `Unknown`, `Completed`, `Affected`, `Pending` and `Faulted` remain distinct:
 `Affected` does not establish that the encoder caused the error, and an encoder's

--- a/unix/unix/src/metal/command/diagnostics.rs
+++ b/unix/unix/src/metal/command/diagnostics.rs
@@ -7,7 +7,7 @@ use objc2::{
     rc::{Retained, autoreleasepool},
     runtime::{AnyObject, ProtocolObject},
 };
-use objc2_foundation::{NSArray, NSError, NSString};
+use objc2_foundation::{NSArray, NSError, NSObject, NSObjectNSKeyValueCoding, NSString, ns_string};
 use objc2_metal::{
     MTLBuffer, MTLCommandBuffer, MTLCommandBufferDescriptor, MTLCommandBufferEncoderInfo,
     MTLCommandBufferEncoderInfoErrorKey, MTLCommandBufferErrorOption, MTLCommandBufferStatus,
@@ -371,20 +371,51 @@ fn append_encoder_info(output: &mut String, payload: Option<&AnyObject>) {
             Retained::cast_unchecked::<ProtocolObject<dyn MTLCommandBufferEncoderInfo>>(object)
         };
         let state = encoder.errorState();
+        // The protocol's object getters can return nil despite their nonnull bindings.
+        // NSObject's typed KVC getter preserves nil and calls these declared accessors.
+        let metadata = AsRef::<AnyObject>::as_ref(&*encoder).downcast_ref::<NSObject>();
+        let label = metadata.map_or_else(
+            || "unavailable-non-nsobject".to_owned(),
+            |object| metadata_string(object.valueForKey(ns_string!("label")).as_deref()),
+        );
         write!(
             output,
-            "label={:?} state={}({}) signposts=",
-            encoder.label().to_string(),
+            "label={label} state={}({}) signposts=",
             state.0,
             encoder_state_name(state),
         )
         .expect("writing to a String cannot fail");
-        append_signposts(output, &encoder.debugSignposts());
+        if let Some(object) = metadata {
+            append_signposts(
+                output,
+                object.valueForKey(ns_string!("debugSignposts")).as_deref(),
+            );
+        } else {
+            output.push_str("unavailable-non-nsobject");
+        }
         output.push('}');
     }
 }
 
-fn append_signposts(output: &mut String, signposts: &NSArray<NSString>) {
+fn metadata_string(value: Option<&AnyObject>) -> String {
+    let Some(value) = value else {
+        return optional_string(None);
+    };
+    value.downcast_ref::<NSString>().map_or_else(
+        || "malformed-non-string".to_owned(),
+        |value| optional_string(Some(&value.to_string())),
+    )
+}
+
+fn append_signposts(output: &mut String, signposts: Option<&AnyObject>) {
+    let Some(signposts) = signposts else {
+        output.push_str("missing");
+        return;
+    };
+    let Some(signposts) = signposts.downcast_ref::<NSArray<AnyObject>>() else {
+        output.push_str("malformed-non-array");
+        return;
+    };
     if signposts.is_empty() {
         output.push_str("empty");
         return;
@@ -394,7 +425,7 @@ fn append_signposts(output: &mut String, signposts: &NSArray<NSString>) {
         if index != 0 {
             output.push_str(", ");
         }
-        write!(output, "{:?}", signpost.to_string()).expect("writing to a String cannot fail");
+        output.push_str(&metadata_string(Some(&signpost)));
     }
     output.push(']');
 }

--- a/unix/unix/src/metal/command/diagnostics/tests.rs
+++ b/unix/unix/src/metal/command/diagnostics/tests.rs
@@ -9,7 +9,7 @@ use objc2_metal::{
 
 use super::{
     append_signposts, buffer_role, diagnostic_descriptor, encoder_state_name, error_details,
-    optional_string, sequence, status_name,
+    metadata_string, optional_string, sequence, status_name,
 };
 
 define_class!(
@@ -49,6 +49,129 @@ impl CommandEncoderInfoFixture {
         #[unsafe(method_family = new)]
         fn new() -> Retained<Self>;
     );
+}
+
+define_class!(
+    // SAFETY: NSObject has no subclassing requirements. This fixture has no ivars or Drop.
+    #[unsafe(super = NSObject)]
+    struct NilSignpostsEncoderInfoFixture;
+
+    // SAFETY: NSObject supplies the NSObjectProtocol methods.
+    unsafe impl NSObjectProtocol for NilSignpostsEncoderInfoFixture {}
+
+    // SAFETY: the methods use the protocol's Objective-C ABI. The object return is
+    // deliberately nullable to model missing metadata; no invalid Retained is created.
+    unsafe impl MTLCommandBufferEncoderInfo for NilSignpostsEncoderInfoFixture {
+        #[unsafe(method_id(label))]
+        fn label(&self) -> Retained<NSString> {
+            NSString::from_str("init-clear")
+        }
+
+        #[unsafe(method_id(debugSignposts))]
+        fn debug_signposts(&self) -> Option<Retained<NSArray<NSString>>> {
+            None
+        }
+
+        #[unsafe(method(errorState))]
+        fn error_state(&self) -> MTLCommandEncoderErrorState {
+            MTLCommandEncoderErrorState::Faulted
+        }
+    }
+);
+
+impl NilSignpostsEncoderInfoFixture {
+    extern_methods!(
+        // SAFETY: NSObject's inherited new initializes this subclass, which has no ivars.
+        #[unsafe(method(new))]
+        #[unsafe(method_family = new)]
+        fn new() -> Retained<Self>;
+    );
+}
+
+define_class!(
+    // SAFETY: NSObject has no subclassing requirements. This fixture has no ivars or Drop.
+    #[unsafe(super = NSObject)]
+    struct MissingLabelEncoderInfoFixture;
+
+    // SAFETY: NSObject supplies the NSObjectProtocol methods.
+    unsafe impl NSObjectProtocol for MissingLabelEncoderInfoFixture {}
+
+    // SAFETY: the methods use the protocol's Objective-C ABI. Object metadata is
+    // deliberately incomplete and consumed only through checked, nullable KVC reads.
+    unsafe impl MTLCommandBufferEncoderInfo for MissingLabelEncoderInfoFixture {
+        #[unsafe(method_id(label))]
+        fn label(&self) -> Option<Retained<NSString>> {
+            None
+        }
+
+        #[unsafe(method_id(debugSignposts))]
+        fn debug_signposts(&self) -> Retained<NSArray<AnyObject>> {
+            NSArray::from_slice(&[
+                NSString::from_str("before\nmarker").as_ref(),
+                NSObject::new().as_ref(),
+                NSString::from_str("after\"marker").as_ref(),
+            ])
+        }
+
+        #[unsafe(method(errorState))]
+        fn error_state(&self) -> MTLCommandEncoderErrorState {
+            MTLCommandEncoderErrorState::Pending
+        }
+    }
+);
+
+impl MissingLabelEncoderInfoFixture {
+    extern_methods!(
+        // SAFETY: NSObject's inherited new initializes this subclass, which has no ivars.
+        #[unsafe(method(new))]
+        #[unsafe(method_family = new)]
+        fn new() -> Retained<Self>;
+    );
+}
+
+#[test]
+fn nil_signposts_preserve_primary_error_and_encoder_state() {
+    let encoder = NilSignpostsEncoderInfoFixture::new();
+    let payload = NSArray::<AnyObject>::from_slice(&[encoder.as_ref()]);
+    let details = error_details(Some(&fixture_error(Some(payload.as_ref()))));
+    assert_eq!(
+        details,
+        "error=present domain=\"fixture\\n\\\"domain\" code=-9 \
+         description=\"driver\\n\\\"detail\\\\\" encoder_info=present encoder_count=1 \
+         encoder[0]={label=\"init-clear\" state=4(Faulted) signposts=missing}",
+    );
+}
+
+#[test]
+fn nil_label_and_malformed_signpost_preserve_available_metadata() {
+    let encoder = MissingLabelEncoderInfoFixture::new();
+    let payload = NSArray::<AnyObject>::from_slice(&[encoder.as_ref()]);
+    let details = error_details(Some(&fixture_error(Some(payload.as_ref()))));
+    assert_eq!(
+        details,
+        "error=present domain=\"fixture\\n\\\"domain\" code=-9 \
+         description=\"driver\\n\\\"detail\\\\\" encoder_info=present encoder_count=1 \
+         encoder[0]={label=missing state=3(Pending) \
+         signposts=[\"before\\nmarker\", malformed-non-string, \"after\\\"marker\"]}",
+    );
+}
+
+#[test]
+fn metadata_class_checks_distinguish_missing_and_malformed_values() {
+    assert_eq!(metadata_string(None), "missing");
+    assert_eq!(
+        metadata_string(Some(NSObject::new().as_ref())),
+        "malformed-non-string",
+    );
+    let mut missing = String::new();
+    append_signposts(&mut missing, None);
+    assert_eq!(missing, "missing");
+    let mut malformed = String::new();
+    append_signposts(
+        &mut malformed,
+        Some(NSString::from_str("not an array").as_ref()),
+    );
+    assert_eq!(malformed, "malformed-non-array");
 }
 
 #[test]
@@ -112,7 +235,7 @@ fn encoder_payload_checks_array_class_and_protocol_per_element() {
 #[test]
 fn empty_signposts_do_not_claim_success() {
     let mut output = String::new();
-    append_signposts(&mut output, &NSArray::new());
+    append_signposts(&mut output, Some(NSArray::<AnyObject>::new().as_ref()));
     assert_eq!(output, "empty");
 }
 


### PR DESCRIPTION
A Metal command-buffer error can carry an encoder whose `debugSignposts` getter returns nil. The nonnull objc2-metal getter then panics while formatting the diagnostic, before the NSError record is emitted. An initialization completion callback hit this path in the [Intel x86_64 diagnostic run](https://github.com/athei/mtld3d/actions/runs/34204915714/job/101996829290).

Read encoder labels and signposts through Foundation's existing nullable key-value getter after checking NSObject inheritance and Metal protocol conformance. Check each returned value and signpost element before formatting. Preserve the signed NSError code, domain, description, encoder state and available metadata, with distinct missing, empty, malformed and unavailable markers. This avoids duplicating the Metal protocol with local nullable bindings. It does not change or explain the underlying GPU failure.

## Verification

The deterministic nil-signposts fixture calls the production `error_details` formatter with a real Objective-C nil return. It fails before the fix with `unexpected NULL returned from ... debugSignposts` and passes after it. The diagnostics module has 10 passing CPU/Foundation-only tests, including nil labels, malformed signposts, the existing positive encoder fixture, and malformed payloads. `make fmt` and `make check` passed, including Clippy, audit, isolation/discovery regressions and documentation.

Final landing gates: `make check` and full `make ISOLATED=1 test`. Conformance is not needed for this formatter-only change: no render, state, shader or shared-crate behavior changes. The regression uses synthetic Foundation objects and does not induce a GPU hang.

## Rules check

CONTRIBUTING.md: one diagnostic failure with a deterministic before/after regression; the full check and test gates are listed above. CONVENTIONS.md: existing module/test placement, checked typed Foundation access, existing string formatter reuse, no new production ABI bindings, statics, configuration keys, wire fields, dependencies, derives or lint suppressions. `make check` enforces the applicable mechanical rules and passed. ARCHITECTURE.md: existing debug gating, callback ownership and thread behavior stay intact; the diagnostic documentation now covers nil and malformed metadata. No waits, callbacks or registries are added.

Closes #610
