### PR TITLE
Keep display sinks alive through native attachment teardown

### DIFF
--- a/windows/d3d9/src/device.rs
+++ b/windows/d3d9/src/device.rs
@@ -3522,8 +3522,6 @@ extern "system" fn device_release(this: *mut c_void) -> u32 {
         // Locked has been released.
         device_inner.shutdown();
 
-        drop(device_inner);
-
         if !backbuffer_msaa_handle.is_null() {
             let handles = [backbuffer_msaa_handle.raw()];
             let mut destroy = mtld3d_shared::DestroyResourcesBulkParams {
@@ -3536,6 +3534,11 @@ extern "system" fn device_release(this: *mut c_void) -> u32 {
             unix_call(&mut destroy);
         }
         unix_call(&mut params);
+
+        // Native observers may write the cursor state's boxed display sinks
+        // until the destroy thunk unregisters the attachment under its lock.
+        // Keep their backing alive until that thunk has returned.
+        drop(device_inner);
 
         // Intentionally LEAK the small wrapper shell (vtbl ptr + refcount +
         // inner ptr — ~24 bytes) instead of freeing it. The heavy state


### PR DESCRIPTION
Refs #580.

`device_release` dropped the `DeviceInner` box, and with it the `Box<DisplaySinks>` that holds the two `AtomicU32` words the unix main thread publishes the backing scale and the cursor kick into, before it issued `DestroyCommandQueue`. That thunk is what unregisters the view's attachment record, and the record is the only thing that stops a main-thread observer from writing through the sink addresses: `publish_backing_scale` and `request_cursor_kick_all` take the registry lock, check the record is still live, and store. Between the drop and the thunk the record was live and the memory behind the sinks was already freed, so a display change or a pointer return landing in that window stored a small integer into freed PE heap memory. The contract that rules this out is written down in four places (`DisplaySinks` in `cursor.rs`, `AttachMetalLayerParams::backing_scale_ptr` in `params.rs`, the module doc of `attachment.rs`, and the attachment section of `docs/ARCHITECTURE.md`): the box drops only after the thunk has returned. The code has never matched it; the drop has sat before the thunk since the tree's first commit and #380 added the sinks on top of that order.

The fix moves `drop(device_inner)` after the `DestroyCommandQueue` call. Nothing that drops there calls back into the unix side: `DeviceInner` has no `Drop` impl, `PageBox` and `BufferBacking` drops are PE-local bookkeeping, and every Metal resource the inner state owned has already gone out through `shutdown` and the destroy thunks above. The comment at the new position states the invariant. `destroy_partial_device` needs no change, since in `create_device` the box is a local that outlives the partial destroy.

Whether this is the cause of #580 is not established. The trap there fires when a timer treated as repeating has an interval that converts to zero ticks, and a four-byte store of 1 or 2 into either word of a zero `_interval` produces exactly such a value, which matches the shape of the sink writes. But the sinks live in snmalloc memory on the PE side and CoreFoundation timers in the system malloc, and no route from one to the other has been found. The issue stays open and blocked on a recurrence. This change is correct on its own terms either way.

Alternatives considered: moving the sink storage to the unix side and having the PE side read it through a thunk per present, which would remove the raw pointers entirely but replaces a relaxed load with a boundary crossing every frame and abandons the stable-backing contract `docs/ARCHITECTURE.md` already defines for these pointers; sending `DetachMetalLayer` at the top of `device_release` before any teardown, which would unregister earlier but duplicates work `DestroyCommandQueue` already does and changes the order of the view release against the shutdown fence for no gain.

No test pins the ordering: the write that would observe it comes from an AppKit notification landing in a window of a few microseconds inside `Release`, and under snmalloc a stray store into a freed slot corrupts a free list rather than failing at the store, so neither the end-to-end suite nor a unit test can make it fail deterministically before the change. The existing `attachment/tests.rs` cases cover the unix half of the contract (a detached record publishes nowhere, a reused view address is a new record).

Verification: `make check` green (audit clean), `make test ISOLATED=1` green on both architectures, 555 passed in 4 processes each. A reviewer should confirm that nothing between the new drop position and the old one reads `device_inner`, and that the wrapper-shell leak comment below it still describes what happened above.
