### PR TITLE
Defer occlusion query dump formatting until enabled

### DIFF
--- a/windows/d3d9/src/query.rs
+++ b/windows/d3d9/src/query.rs
@@ -303,12 +303,12 @@ extern "system" fn query_get_data(
         return D3D_OK;
     }
     let device_inner_ptr = inner.device_inner;
-    let dump_event = |msg: &str| {
+    let dump_event = |msg: &dyn Fn() -> String| {
         // SAFETY: `inner.device_inner` was stamped at `Self::new` from a
         // live `DeviceInner` and is kept alive by the device.
         let dev = unsafe { &*device_inner_ptr };
         if dev.frame_dump_active() {
-            dev.frame_dump_event(msg);
+            dev.frame_dump_event(&msg());
         }
     };
     let wanted = inner.data_size.min(size) as usize;
@@ -331,9 +331,7 @@ extern "system" fn query_get_data(
                 // the FLUSH stub below and the exhaustion path in `visibility`,
                 // so a missing query never makes a title cull geometry it would
                 // otherwise draw (lens flares, occlusion-gated effects).
-                dump_event(&format!(
-                    "Query({this:?}) GetData → no slot, stub fully-visible"
-                ));
+                dump_event(&|| format!("Query({this:?}) GetData → no slot, stub fully-visible"));
                 if has_output {
                     // SAFETY: `data` is non-null with >= `size` writable bytes per
                     // the ABI and `size >= 1`; `write_occlusion` writes `min(size, 8)`.
@@ -374,10 +372,12 @@ extern "system" fn query_get_data(
                             // the real count finalizes naturally on
                             // the next `begin_frame` intake if the
                             // game ever reads via `flags = 0`.
-                            dump_event(&format!(
-                                "Query({this:?}) GetData(FLUSH) → stub fully-visible \
+                            dump_event(&|| {
+                                format!(
+                                    "Query({this:?}) GetData(FLUSH) → stub fully-visible \
                                  (query.flushImmediate)"
-                            ));
+                                )
+                            });
                             if has_output {
                                 // SAFETY: as above, non-null `data`, `size >= 1`.
                                 unsafe { write_occlusion(data, size, u64::from(u32::MAX)) };
@@ -419,10 +419,12 @@ extern "system" fn query_get_data(
                                 dev.encoder_intake_visibility_for(core.seq_end_loaded());
                             }
                             if core.status() == QueryStatus::Issued {
-                                dump_event(&format!(
-                                    "Query({this:?}) GetData(FLUSH) → flushed, count {}",
-                                    core.get_u64()
-                                ));
+                                dump_event(&|| {
+                                    format!(
+                                        "Query({this:?}) GetData(FLUSH) → flushed, count {}",
+                                        core.get_u64()
+                                    )
+                                });
                                 if has_output {
                                     // SAFETY: as above, non-null `data`, `size >= 1`.
                                     unsafe { write_occlusion(data, size, core.get_u64()) };
@@ -431,16 +433,13 @@ extern "system" fn query_get_data(
                             }
                         }
                     }
-                    dump_event(&format!("Query({this:?}) GetData → S_FALSE, pending"));
+                    dump_event(&|| format!("Query({this:?}) GetData → S_FALSE, pending"));
                     // S_FALSE (0x1) — still not ready; caller will
                     // retry.
                     1
                 }
                 QueryStatus::Issued => {
-                    dump_event(&format!(
-                        "Query({this:?}) GetData → count {}",
-                        core.get_u64()
-                    ));
+                    dump_event(&|| format!("Query({this:?}) GetData → count {}", core.get_u64()));
                     if has_output {
                         // SAFETY: as above, non-null `data`, `size >= 1`.
                         unsafe { write_occlusion(data, size, core.get_u64()) };


### PR DESCRIPTION
Status-only occlusion polls build frame-dump strings even when dumping is disabled. The readiness repair in #587 exposed that work to pending and completed status polls.

Make the local dump helper accept a borrowed message builder and invoke it only after `frame_dump_active()`. All five callers defer formatting and diagnostic-only result reads. Readiness, FLUSH, generation and output-buffer handling stay unchanged, as does enabled-dump text. Guarding each callsite separately would also avoid the cost; keeping the gate in the existing helper avoids repeating it.

Closes #614.

## Performance

Compared with the same base commit, `fc110fe`, on an M5 Max running macOS 27.0 (26A5425a), Wine 11.0-12-g935cf02c317 and rustc 1.97.1. Both builds use `PROD=1`, with PERF/CRUMB, Metal validation and capture disabled. Seven alternating AB/BA process pairs per architecture, fifteen samples of 200,000 polls per process, first five discarded as warmup. Values are means of process medians.

| PE | Status poll | Before | After | Reduction |
| --- | --- | ---: | ---: | ---: |
| i686 | Pending | 69.07 ns | 4.68 ns | 93.2% |
| i686 | Completed | 108.06 ns | 4.69 ns | 95.7% |
| x86_64 | Pending | 42.08 ns | 3.89 ns | 90.7% |
| x86_64 | Completed | 57.77 ns | 4.11 ns | 92.9% |

All four paired bootstrap 95% confidence intervals exclude zero. All 2,520 query samples agree on HRESULTs and result values across builds. Data-bearing polls also improve; never-issued controls remain below 9 ns. These measurements establish synthetic polling cost, not game FPS recovery.

## Verification

- `make fmt` and `make check` passed, including Clippy, audit, isolation/discovery checks and rustdoc.
- `make test ISOLATED=1 PROD=1` passed: 1,505 native tests and 555 end-to-end tests per PE architecture, zero failures or tests not run. `WINE_SDK` was supplied through the environment and installation paths verified inside each private worktree.
- A bounded F12 probe produced identical normalized GetData messages on both architectures: two pending, one flushed/count and two completed/count records, with completed counts of 1596.
- `git diff --check` passed.

## Rules check

Only COM diagnostic wiring changes. No new statics, config keys, wire fields, dependencies, derives, lint suppressions, unsafe operations or duplicate diagnostic framework. API-lock placement and pointer lifetimes are unchanged. Existing tests and the performance probe cover the change without adding a timing threshold to CI.
