### PR TITLE
Dump the object a CoreFoundation trap holds in rbx

### DIFF
--- a/unix/unix/src/crash.rs
+++ b/unix/unix/src/crash.rs
@@ -46,6 +46,15 @@
 //! thread without one is reported in full here and ends the process, so the
 //! report leads with the fault that caused it.
 //!
+//! A trap `CoreFoundation` raises itself (`SIGILL` on a deliberate `ud2`, the
+//! way the framework halts on a run-loop timer it refuses to reschedule) names
+//! its condition in a string and nothing else, while the object it was checking
+//! is in `rbx`. The terminal report of such a trap therefore adds the first
+//! words of that object, each copied by the kernel rather than dereferenced and
+//! annotated with the image and symbol `dladdr` resolves it to, so the object's
+//! class, callout and context read as their owners without the handler assuming
+//! any layout.
+//!
 //! `RUST_BACKTRACE=1` is also set here (if unset) so the default Rust
 //! panic hook prints message + backtrace before `abort()` flows through
 //! to the SIGABRT branch.
@@ -426,6 +435,8 @@ extern "C" fn handler(signo: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut 
         }
         #[cfg(target_arch = "x86_64")]
         report_nonvolatile_registers(ctx);
+        #[cfg(target_arch = "x86_64")]
+        report_trap_object(signo, ctx);
         let ret = caller_pc(ctx, sp);
         if ret != 0 {
             let mut rb = [0u8; 192];
@@ -744,46 +755,66 @@ fn our_frames_on_stack(sp: u64, words: usize) {
 
 /// Copy a stack word without dereferencing the faulting stack.
 ///
-/// The Mach call copies into fixed local storage and returns an error for an
-/// unreadable source, including a mapping whose protection changes during the
-/// copy. Only a complete copy is used. No allocation or logger lock is needed;
-/// a failed read writes directly to the crash descriptor and ends that scan.
+/// The address is `sp` plus four bytes per slot, the step that tolerates a
+/// 32-bit guest stack's alignment. Only a complete copy is used; a failed
+/// read writes directly to the crash descriptor and ends that scan.
 fn stack_word<const N: usize>(sp: u64, slot: usize) -> Option<[u8; N]> {
     const UNREADABLE: &[u8] = b"[mtld3d::unix] stack read unavailable, stopping scan\n";
 
     let address = slot
         .checked_mul(4)
-        .and_then(|offset| sp.checked_add(offset as u64))
-        .filter(|address| address.checked_add(N as u64).is_some());
-    if let Some(address) = address {
-        let mut bytes = [0u8; N];
-        let mut copied = 0;
-        // SAFETY: reads libSystem's task port for this process.
-        let task = unsafe { mach_task_self_ };
-        // SAFETY: the kernel validates the source address. The destination
-        // holds N writable bytes, and `copied` is a live size out-parameter.
-        let status = unsafe {
-            mach_vm_read_overwrite(
-                task,
-                address,
-                N as u64,
-                bytes.as_mut_ptr() as usize as u64,
-                &raw mut copied,
-            )
-        };
-        if status == libc::KERN_SUCCESS && copied == N as u64 {
-            return Some(bytes);
+        .and_then(|offset| sp.checked_add(offset as u64));
+    let word = address.and_then(copy_word::<N>);
+    if word.is_none() {
+        // SAFETY: write(2) is async-signal-safe; the bytes have static storage.
+        unsafe {
+            let _ = libc::write(
+                crate::log_file::raw_fd(),
+                UNREADABLE.as_ptr().cast::<c_void>(),
+                UNREADABLE.len(),
+            );
         }
     }
-    // SAFETY: write(2) is async-signal-safe; the bytes have static storage.
-    unsafe {
-        let _ = libc::write(
-            crate::log_file::raw_fd(),
-            UNREADABLE.as_ptr().cast::<c_void>(),
-            UNREADABLE.len(),
-        );
-    }
-    None
+    word
+}
+
+/// Copy the `index`th `N`-byte word of the object at `base`, without dereferencing it.
+///
+/// The object's words are consecutive, so the address is `base` plus `N`
+/// bytes per index. `None` for an address that overflows or that the kernel
+/// declines to copy; the caller decides what a failed read ends.
+#[cfg(target_arch = "x86_64")]
+fn object_word<const N: usize>(base: u64, index: usize) -> Option<[u8; N]> {
+    index
+        .checked_mul(N)
+        .and_then(|offset| base.checked_add(offset as u64))
+        .and_then(copy_word::<N>)
+}
+
+/// Copy `N` bytes at `address` into local storage through the kernel.
+///
+/// The Mach call reports an unreadable source, including a mapping whose
+/// protection changes during the copy, instead of faulting the caller; a
+/// mapping probe could not promise that. Only a complete copy is returned.
+/// No allocation and no lock, so a signal handler may ask.
+fn copy_word<const N: usize>(address: u64) -> Option<[u8; N]> {
+    address.checked_add(N as u64)?;
+    let mut bytes = [0u8; N];
+    let mut copied = 0;
+    // SAFETY: reads libSystem's task port for this process.
+    let task = unsafe { mach_task_self_ };
+    // SAFETY: the kernel validates the source address. The destination
+    // holds N writable bytes, and `copied` is a live size out-parameter.
+    let status = unsafe {
+        mach_vm_read_overwrite(
+            task,
+            address,
+            N as u64,
+            bytes.as_mut_ptr() as usize as u64,
+            &raw mut copied,
+        )
+    };
+    (status == libc::KERN_SUCCESS && copied == N as u64).then_some(bytes)
 }
 
 /// What dyld knows about `addr`: its image, and the nearest symbol below it.
@@ -815,8 +846,6 @@ fn dladdr_image(addr: u64) -> Option<*const core::ffi::c_char> {
 fn dladdr_is_ours(addr: u64) -> bool {
     /// Scanned for in the image path, without allocating.
     const NEEDLE: &[u8] = b"mtld3d";
-    /// Bound on the path scan, so a corrupt `dli_fname` can't spin.
-    const PATH_MAX_SCAN: usize = 4096;
 
     let Some(path) = dladdr_image(addr) else {
         return false;
@@ -844,6 +873,166 @@ fn dladdr_is_ours(addr: u64) -> bool {
         idx += 1;
     }
     false
+}
+
+/// Bound on every scan of an image path, so a corrupt `dli_fname` can't spin.
+const PATH_MAX_SCAN: usize = 4096;
+
+/// Length of the NUL-terminated image path dyld owns, bounded by [`PATH_MAX_SCAN`].
+#[cfg(target_arch = "x86_64")]
+fn image_path_len(path: *const core::ffi::c_char) -> usize {
+    let mut len = 0usize;
+    while len < PATH_MAX_SCAN && image_path_byte(path, len) != 0 {
+        len += 1;
+    }
+    len
+}
+
+/// One byte of the NUL-terminated image path dyld owns.
+///
+/// Callers stay within the length [`image_path_len`] measured, or stop at
+/// the first zero this returns.
+#[cfg(target_arch = "x86_64")]
+const fn image_path_byte(path: *const core::ffi::c_char, index: usize) -> u8 {
+    // SAFETY: an offset within a NUL-terminated C string owned by dyld, which
+    // the caller bounds by its measured length or by the NUL itself.
+    let at = unsafe { path.cast::<u8>().add(index) };
+    // SAFETY: as above; reads one byte of that string.
+    unsafe { at.read() }
+}
+
+/// True when the image path dyld owns ends in `suffix`.
+#[cfg(target_arch = "x86_64")]
+fn image_path_ends_with(path: *const core::ffi::c_char, suffix: &[u8]) -> bool {
+    let len = image_path_len(path);
+    if len < suffix.len() {
+        return false;
+    }
+    let start = len - suffix.len();
+    suffix
+        .iter()
+        .enumerate()
+        .all(|(i, &byte)| image_path_byte(path, start + i) == byte)
+}
+
+/// Append the last component of the image path dyld owns, at most 32 bytes of it.
+#[cfg(target_arch = "x86_64")]
+fn push_image_basename(buf: &mut [u8; 192], pos: &mut usize, path: *const core::ffi::c_char) {
+    /// The longest basename a line carries; keeps the whole line in its buffer.
+    const BASENAME_MAX: usize = 32;
+
+    let len = image_path_len(path);
+    let mut start = 0usize;
+    for index in 0..len {
+        if image_path_byte(path, index) == b'/' {
+            start = index + 1;
+        }
+    }
+    let mut name = [0u8; BASENAME_MAX];
+    let take = (len - start).min(BASENAME_MAX);
+    for (i, slot) in name.iter_mut().enumerate().take(take) {
+        *slot = image_path_byte(path, start + i);
+    }
+    push(buf, pos, &name[..take]);
+}
+
+/// Words copied out of the object a `CoreFoundation` trap holds in `rbx`.
+///
+/// Enough to cover a run-loop timer in every layout the framework has had:
+/// the runtime base, the lock, the run loop and mode pointers, the fire date,
+/// the interval, the tolerance, the fire ticks, the order, the callout and
+/// the context. Fixed, so the dump's length is too.
+#[cfg(target_arch = "x86_64")]
+const TRAP_OBJECT_WORDS: usize = 24;
+
+/// Dump the object a `CoreFoundation` trap holds in `rbx`, without touching it.
+///
+/// A framework trap (`SIGILL` on a deliberate `ud2`) names its condition in a
+/// string and nothing else, while the object it was checking is in `rbx`,
+/// which the trapping function keeps live across the cold call. Each word of
+/// that object is copied by the kernel into local storage, printed as hex at
+/// its offset, and followed by the image and symbol `dladdr` resolves it to,
+/// so a class pointer, a callout or a context reads as its owner while the
+/// handler assumes nothing about the layout. Only a `SIGILL` whose PC lies in
+/// `CoreFoundation` qualifies: a trap in our own code has its own report, and
+/// a memory fault's `rbx` is arbitrary. The first unreadable word ends the
+/// dump, and nothing here dereferences the object or calls into the framework.
+#[cfg(target_arch = "x86_64")]
+fn report_trap_object(signo: c_int, ctx: *mut c_void) {
+    /// The image whose traps carry their object in `rbx`.
+    const IMAGE_SUFFIX: &[u8] = b"/CoreFoundation";
+    const HDR: &[u8] = b"[mtld3d::unix] CoreFoundation trap object words at rbx:\n";
+    const UNREADABLE: &[u8] = b"[mtld3d::unix] trap object read unavailable, stopping dump\n";
+    /// The longest symbol name a word's line carries.
+    const SYMBOL_MAX: usize = 64;
+
+    if signo != libc::SIGILL {
+        return;
+    }
+    let Some(trap) = dladdr_info(fault_pc(ctx)) else {
+        return;
+    };
+    if !image_path_ends_with(trap.dli_fname, IMAGE_SUFFIX) {
+        return;
+    }
+    let base = mcontext_u64(ctx, mem::offset_of!(libc::__darwin_mcontext64, __ss.__rbx));
+    if base == 0 {
+        return;
+    }
+    let fd = crate::log_file::raw_fd();
+    // SAFETY: write(2) is async-signal-safe; the bytes have static storage.
+    unsafe {
+        let _ = libc::write(fd, HDR.as_ptr().cast::<c_void>(), HDR.len());
+    }
+    for index in 0..TRAP_OBJECT_WORDS {
+        let Some(bytes) = object_word::<8>(base, index) else {
+            // SAFETY: as above.
+            unsafe {
+                let _ = libc::write(fd, UNREADABLE.as_ptr().cast::<c_void>(), UNREADABLE.len());
+            }
+            return;
+        };
+        let word = u64::from_ne_bytes(bytes);
+        let mut b = [0u8; 192];
+        let mut p = 0;
+        push(&mut b, &mut p, b"  +");
+        push_hex(&mut b, &mut p, (index * 8) as u64);
+        push(&mut b, &mut p, b" ");
+        push_hex(&mut b, &mut p, word);
+        if word >= 0x1000
+            && let Some(target) = dladdr_info(word)
+        {
+            push(&mut b, &mut p, b" ");
+            push_image_basename(&mut b, &mut p, target.dli_fname);
+            push(&mut b, &mut p, b"+");
+            push_hex(
+                &mut b,
+                &mut p,
+                word.wrapping_sub(target.dli_fbase as usize as u64),
+            );
+            if !target.dli_sname.is_null() {
+                // SAFETY: `dli_sname` is the NUL-terminated symbol name dyld
+                // owns; `strlen` is async-signal-safe.
+                let name_len = unsafe { libc::strlen(target.dli_sname) };
+                // SAFETY: `name_len` bytes at `dli_sname` are the name just measured.
+                let name =
+                    unsafe { core::slice::from_raw_parts(target.dli_sname.cast::<u8>(), name_len) };
+                push(&mut b, &mut p, b" ");
+                push(&mut b, &mut p, &name[..name_len.min(SYMBOL_MAX)]);
+                push(&mut b, &mut p, b"+");
+                push_hex(
+                    &mut b,
+                    &mut p,
+                    word.wrapping_sub(target.dli_saddr as usize as u64),
+                );
+            }
+        }
+        push(&mut b, &mut p, b"\n");
+        // SAFETY: write(2) is async-signal-safe; the buffer holds p initialized bytes.
+        unsafe {
+            let _ = libc::write(fd, b.as_ptr().cast::<c_void>(), p);
+        }
+    }
 }
 
 /// Capacity of the frame buffer handed to `backtrace`.

--- a/unix/unix/src/crash/tests.rs
+++ b/unix/unix/src/crash/tests.rs
@@ -15,6 +15,14 @@
 //! that answers with no TEB, where handing it back would fault inside Wine,
 //! and pins that the process ends here with the first fault named.
 //!
+//! The trap-object tests take a `SIGILL` whose PC is a real `CoreFoundation`
+//! symbol on a thread that answers with no TEB, the shape of the framework's
+//! own trap, and point `rbx` at memory of a known kind: a readable object
+//! whose first word resolves to a symbol, an unmapped page, an object that
+//! ends one word before a protected page, and the null it may hold. The dump
+//! has to name what it can read and stop at the first word it cannot, and
+//! must stay absent from a trap in our own code and from a memory fault.
+//!
 //! Wine is not in a unit test's process, so the branch that asks it for the
 //! calling thread's TEB is exercised through a stand-in `NtCurrentTeb` stored
 //! where the install-time lookup would have put one: what the handler reads is
@@ -40,6 +48,10 @@ const NO_TEB_SELFTEST_ENV: &str = "MTLD3D_CRASH_NO_TEB_SELFTEST";
 
 /// Set in a child that scans across a protected stack boundary.
 const STACK_SELFTEST_ENV: &str = "MTLD3D_CRASH_STACK_SELFTEST";
+
+/// Set in the re-executed child that takes a `CoreFoundation` trap; its value picks the object.
+#[cfg(target_arch = "x86_64")]
+const TRAP_OBJECT_SELFTEST_ENV: &str = "MTLD3D_CRASH_TRAP_OBJECT_SELFTEST";
 
 /// The byte a stand-in TEB pointer points at; only its address is ever used.
 static FAKE_TEB: u8 = 0;
@@ -387,6 +399,214 @@ fn illegal_instruction_in_our_code_is_fatal() {
     let report = String::from_utf8_lossy(&out.stderr);
     assert_eq!(out.status.code(), Some(1), "{report}");
     assert!(report.contains("FATAL: SIGILL"), "{report}");
+    assert!(!report.contains("trap object"), "{report}");
+}
+
+/// Address of a `CoreFoundation` function, the PC a framework trap reports.
+///
+/// Looked up by name so the address is inside the framework's own image and
+/// not a wrapper of ours; the crate links the framework, so it is loaded.
+#[cfg(target_arch = "x86_64")]
+fn core_foundation_pc() -> u64 {
+    // SAFETY: `dlsym` with the default handle reads the loaded images only.
+    let symbol = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"CFRunLoopGetCurrent".as_ptr()) };
+    assert!(!symbol.is_null(), "CoreFoundation is loaded");
+    symbol as usize as u64
+}
+
+/// Take a `CoreFoundation` trap in the child with `rbx` naming `object`.
+///
+/// The context is read only by the handler, never restored as machine state;
+/// the stack pointer stays zero so the stack scans stay out of the report.
+#[cfg(target_arch = "x86_64")]
+fn trap_with_object(signo: libc::c_int, object: u64) {
+    // The install resolves Wine's `NtCurrentTeb` and finds none here, so the
+    // stand-in goes in after it.
+    super::install();
+    pin_wine_teb(no_teb_stub);
+    // SAFETY: Darwin's machine context contains only integer state.
+    let mut registers: libc::__darwin_mcontext64 = unsafe { core::mem::zeroed() };
+    registers.__ss.__rip = core_foundation_pc();
+    registers.__ss.__rbx = object;
+    // SAFETY: ucontext contains integers and nullable raw pointers.
+    let mut context: libc::ucontext_t = unsafe { core::mem::zeroed() };
+    context.uc_mcontext = &raw mut registers;
+    context.uc_mcsize = core::mem::size_of_val(&registers);
+    super::handler(signo, ptr::null_mut(), (&raw mut context).cast());
+    unreachable!("the terminal handler must end the child");
+}
+
+/// Re-execute this test binary into one trap-object child and return its report.
+#[cfg(target_arch = "x86_64")]
+fn trap_object_report(test: &str, mode: &str) -> String {
+    let out = std::process::Command::new(std::env::current_exe().expect("test binary path"))
+        .args(["--exact", test, "--nocapture"])
+        .env(TRAP_OBJECT_SELFTEST_ENV, mode)
+        .output()
+        .expect("re-exec the test binary");
+    let report = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert_eq!(out.status.code(), Some(1), "{mode}: {report}");
+    report
+}
+
+/// The dump names a word that resolves to a symbol and prints the rest as hex.
+///
+/// The object's first word is the address of a function in this binary, so
+/// its line has to carry this binary's name and an offset; the second word is
+/// a bit pattern no image covers, so its line ends at the hex.
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn trap_object_words_are_dumped_and_resolved() {
+    const TEST: &str = "crash::tests::trap_object_words_are_dumped_and_resolved";
+
+    if std::env::var_os(TRAP_OBJECT_SELFTEST_ENV).is_some() {
+        let mut object = [0u64; super::TRAP_OBJECT_WORDS];
+        object[0] = super::install as usize as u64;
+        object[1] = 0x8000_0000_0000_0001;
+        object[super::TRAP_OBJECT_WORDS - 1] = 0x0123_4567_89ab_cdef;
+        trap_with_object(libc::SIGILL, object.as_ptr() as usize as u64);
+    }
+
+    let report = trap_object_report(TEST, "resolved");
+    assert!(report.contains("FATAL: SIGILL"), "{report}");
+    assert!(report.contains("no Wine TEB"), "{report}");
+    assert!(
+        report.contains("CoreFoundation trap object words at rbx:\n"),
+        "{report}"
+    );
+    let exe = std::env::current_exe().expect("test binary path");
+    let basename = exe
+        .file_name()
+        .and_then(|n| n.to_str())
+        .expect("utf-8 test binary name");
+    let first = report
+        .lines()
+        .find(|line| line.starts_with("  +0x0000000000000000 "))
+        .unwrap_or_else(|| panic!("first word missing:\n{report}"));
+    // The child's load address differs from this process's, so the line is
+    // checked by the names it resolves to rather than by the address.
+    assert!(
+        first.contains(&basename[..basename.len().min(32)]),
+        "{first}\n{report}"
+    );
+    assert!(
+        first.contains("install+0x0000000000000000"),
+        "{first}\n{report}"
+    );
+    assert!(
+        report.contains("  +0x0000000000000008 0x8000000000000001\n"),
+        "{report}"
+    );
+    assert!(
+        report.contains("  +0x00000000000000b8 0x0123456789abcdef\n"),
+        "{report}"
+    );
+    assert!(!report.contains("trap object read unavailable"), "{report}");
+    assert_eq!(
+        report
+            .lines()
+            .filter(|line| line.starts_with("  +0x"))
+            .count(),
+        super::TRAP_OBJECT_WORDS,
+        "{report}"
+    );
+}
+
+/// An unreadable object costs one line and nothing else in the report.
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn trap_object_at_an_unmapped_page_stops_the_dump() {
+    const TEST: &str = "crash::tests::trap_object_at_an_unmapped_page_stops_the_dump";
+
+    if std::env::var_os(TRAP_OBJECT_SELFTEST_ENV).is_some() {
+        trap_with_object(libc::SIGILL, 0xdead_b000);
+    }
+
+    let report = trap_object_report(TEST, "unmapped");
+    assert!(report.contains("FATAL: SIGILL"), "{report}");
+    assert!(
+        report.contains("CoreFoundation trap object words at rbx:\n"),
+        "{report}"
+    );
+    assert!(
+        report.contains("trap object read unavailable, stopping dump\n"),
+        "{report}"
+    );
+    assert!(!report.contains("  +0x"), "{report}");
+    assert!(report.contains("native backtrace:"), "{report}");
+}
+
+/// An object that ends at a protected page yields its readable words, then stops.
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn trap_object_dump_stops_at_a_protected_page() {
+    const TEST: &str = "crash::tests::trap_object_dump_stops_at_a_protected_page";
+
+    if std::env::var_os(TRAP_OBJECT_SELFTEST_ENV).is_some() {
+        // SAFETY: sysconf reads the process's constant page size.
+        let page = usize::try_from(unsafe { libc::sysconf(libc::_SC_PAGESIZE) })
+            .expect("positive page size");
+        // SAFETY: anonymous mapping with no fixed address or backing file.
+        let mapping = unsafe {
+            libc::mmap(
+                ptr::null_mut(),
+                page * 2,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANON,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(mapping, libc::MAP_FAILED);
+        let boundary = mapping as usize + page;
+        // SAFETY: the second page is inside the live mapping and page-aligned.
+        let protected = unsafe { libc::mprotect(boundary as *mut c_void, page, libc::PROT_NONE) };
+        assert_eq!(protected, 0);
+        // SAFETY: the two words below the boundary are inside the readable page.
+        unsafe {
+            (boundary as *mut u64).sub(2).write(0x1111_1111_1111_1111);
+            (boundary as *mut u64).sub(1).write(0x2222_2222_2222_2222);
+        }
+        trap_with_object(libc::SIGILL, (boundary - 16) as u64);
+    }
+
+    let report = trap_object_report(TEST, "boundary");
+    assert!(
+        report.contains("  +0x0000000000000000 0x1111111111111111\n"),
+        "{report}"
+    );
+    assert!(
+        report.contains("  +0x0000000000000008 0x2222222222222222\n"),
+        "{report}"
+    );
+    assert!(!report.contains("  +0x0000000000000010"), "{report}");
+    assert!(
+        report.contains("trap object read unavailable, stopping dump\n"),
+        "{report}"
+    );
+}
+
+/// A null `rbx` and a memory fault in the framework both leave the dump out.
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn trap_object_dump_needs_a_framework_trap_with_an_object() {
+    const TEST: &str = "crash::tests::trap_object_dump_needs_a_framework_trap_with_an_object";
+
+    if let Ok(mode) = std::env::var(TRAP_OBJECT_SELFTEST_ENV) {
+        let object = [super::install as usize as u64; super::TRAP_OBJECT_WORDS];
+        match mode.as_str() {
+            "null" => trap_with_object(libc::SIGILL, 0),
+            "segv" => trap_with_object(libc::SIGSEGV, object.as_ptr() as usize as u64),
+            other => panic!("unknown mode {other}"),
+        }
+    }
+
+    let report = trap_object_report(TEST, "null");
+    assert!(report.contains("FATAL: SIGILL"), "{report}");
+    assert!(!report.contains("trap object"), "{report}");
+    let report = trap_object_report(TEST, "segv");
+    assert!(report.contains("FATAL: SIGSEGV"), "{report}");
+    assert!(!report.contains("trap object"), "{report}");
 }
 
 #[test]


### PR DESCRIPTION
Closes #617. Refs #580.

When CoreFoundation halts on its own `ud2`, the report we keep names the trap and nothing about the object it was checking. The two occurrences of #580 read `signo=4 ... sym=__CFRunLoopDoTimer.cold.2+0xe` on the Cocoa main thread; the second also carried `rbx=0x600003e66640`, the timer, because #596 retains the nonvolatile registers. That is an address in a dead process. The callout, the context and the interval sit in the object behind it, and the handler did not read them, so a recurrence could not say whose timer died or what value its interval held.

The terminal report of a `SIGILL` whose PC resolves into `CoreFoundation` now adds a dump of the object in `rbx`: 24 eight-byte words, each copied by the kernel into local storage through `mach_vm_read_overwrite`, printed as offset and hex, and followed by the image basename, offset and symbol when `dladdr` resolves the word. That names the isa class, the callout and the context owners without the handler knowing the layout, and leaves the interval bits for the reader to apply the offsets to. Twenty-four words cover a run-loop timer in every layout the framework has had. The first word the kernel declines to copy prints one static line and ends the dump. The gate is `SIGILL`, a `dladdr` image path ending in `/CoreFoundation` compared byte by byte with a bounded scan, and a non-null `rbx`; the dump runs after the register line and before termination, on x86_64 only, since that is the architecture every Wine process on our images runs as.

The Mach copy that the stack scan used inside `stack_word` is split into `copy_word`, and `stack_word` keeps its four-byte stepping and its unavailable line on top of it; the new `object_word` steps by the word size and leaves the message to its caller. The handler stays on `mach_vm_read_overwrite`, `dladdr`, `strlen` and `write`: no allocation, no lock, no Objective-C message, and no CoreFoundation call, since `CFRunLoopTimerGetInterval` and its siblings take the timer's lock and dereference the object whose state is in question. Every line goes through the existing 192-byte `push` helpers with symbol names cut at 64 bytes and basenames at 32, so the longest line fits its buffer; the dump has a fixed line count. The re-entrancy latch, `FOREIGN_REPORT_LIMIT`, forwarding to the previous disposition, the no-TEB decision and `_exit(1)` are unchanged.

Alternatives considered: reading the interval, callout and context at the offsets the captured disassembly shows, which would print typed values but bakes one image's layout into the handler and would mislead on any other CoreFoundation build, whereas the raw words with `dladdr` annotations stay correct everywhere and the reader applies the offsets against the UUID the log already prints; calling `CFRunLoopTimerGetInterval` and `CFRunLoopTimerGetContext` from the handler, rejected because they lock and dereference the object; keeping the LLDB capture on branch `issue-580` as the answer, rejected because it has to be attached to the process that dies and the fault has appeared twice in about forty-five main runs.

Tests in `crash/tests.rs`, subprocess style, x86_64 only. A synthetic context puts the PC on the real `CFRunLoopGetCurrent` (looked up with `dlsym` so the address is inside the framework's image) on a thread whose stand-in `NtCurrentTeb` answers null, the shape of the actual trap. `rbx` points at a readable object whose first word is a function of this binary (its line carries the binary's name and the `install` symbol) and whose other words are sentinels at the expected offsets; at an unmapped page (the header, one unavailable line, the rest of the report, exit 1); at an object that ends one word before a page mapped `PROT_NONE` (two words print, the third stops the dump); and at zero, plus a `SIGSEGV` with the same PC (no dump either way). The existing our-image `SIGILL` test asserts the dump is absent. The stand-in TEB goes in after `install`, which resolves the real one and finds none, and the resolved line is checked by its names rather than its address because the child's load address differs from the parent's.

Verification: `cargo +stable test -p mtld3d-unix --target x86_64-apple-darwin crash::tests` 15 passed, the same on `aarch64-apple-darwin` 9 passed (the new tests are x86_64-only, the arm64 build compiles and its existing tests hold), `make check` green with the audit clean, `make test ISOLATED=1` green on both architectures with 555 passed in 4 processes each. A reviewer should read `report_trap_object` against the list of async-signal-safe calls above and confirm no path in it touches the object other than through `copy_word`.

Rules check: no static, config key, wire field, dependency, derive, lint suppression or environment variable in production code; the only new selector is the test-only `MTLD3D_CRASH_TRAP_OBJECT_SELFTEST` in the existing subprocess-test pattern. Doc blocks follow the title-and-body shape, every unsafe block holds one operation with a SAFETY line, the helpers are gated to x86_64 with the dump so the native build carries no dead code, and comments state the invariant without incident numbers. The boundary and threading contracts in `docs/ARCHITECTURE.md` are untouched; this is unix-side diagnostics only and conformance does not apply.
