### PR TITLE
Attribute shader and pipeline creation costs in PERF reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,8 @@ endif
 ifeq ($(PERF),1)
 export MTLD3D_PERF := 1
 $(info ==> PERF=1: cfg(perf_tracking) compile-time perf telemetry enabled)
+else ifeq ($(PERF),0)
+export MTLD3D_PERF := 0
 endif
 
 # Frame pointers are opt-in: the toolchain default decides for a normal build,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -370,11 +370,15 @@ build there can delay encoding and eventually backpressure the API thread.
 Native phase durations cross the PE/Unix boundary as nanoseconds in fixed
 `repr(C)` output fields, including on failure. Unreached or disabled phases
 are zero. `NanosSetTimer` measures each duration in its owning runtime; raw PE
-and native ticks are never subtracted. The fields retain the same layout
-without PERF, while collection and slow-event storage compile out. Shader
-prewarm transfers its private measurements with its existing one-shot payload
-and logs startup totals separately from gameplay frames. This instrumentation
-does not change compilation scheduling, cache contents, or prewarming policy.
+and native ticks are never subtracted. The `TimingOutput` wrapper reserves the
+same wire layout without PERF but elides its initialization, writes, and reads.
+PERF callers initialize a zero fallback before crossing the boundary, so mixed
+PERF/native builds are safe.
+Collection and slow-event storage also compile out. The shader prewarm thread
+logs its private startup totals before sending its existing completion payload.
+This instrumentation does not change compilation scheduling, cache contents,
+or prewarming policy. Explicit `PERF=0` also overrides an inherited
+`MTLD3D_PERF` environment variable.
 
 ### Don't hand-roll `rdtsc()` brackets — use `perf::ApiTimer` / `CycleSetTimer` / `CycleAddTimer`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -339,15 +339,57 @@ Counter aggregation — mixing these up misreads the log:
 
 No ANSI colour anywhere: every line goes to the process's log file, and `env_logger` is told so (`WriteStyle::Never`) rather than left to auto-detect a terminal, which under Wine would be wrong in both directions.
 
+### Shader and pipeline attribution
+
+The same PERF summary appends cold-work accounting from
+`windows/core/src/perf/compilation.rs`. VS and PS library misses include MSL
+emission, native preparation, Metal library compilation, entry-point lookup,
+and cache compression/write. Primary and no-color sibling PSO misses include
+native descriptor preparation and the synchronous Metal PSO build. Draw-path
+depth-state misses are separate. Cache hits do not count as creation attempts;
+a source-index miss that finds an already-prewarmed library is still a hit.
+
+Rows report total duration, ms/frame, peak summed duration on one encoder
+submission, attempts (`calls`), and failures. Successful calls are attempts
+minus failures. Nested rows overlap their parent totals and must not be added
+to them. Resolve and pipeline remainders subtract measured children on each
+submission before taking a window maximum. They include cache lookup,
+bookkeeping, thunk overhead, and telemetry overhead; they are not a separate
+Metal compilation phase.
+
+Each five-second window retains at most five individual operations taking at
+least 2 ms. Parent totals do not compete with their children for these slots.
+Owned metadata is captured only for a retained operation and formatted with
+the summary: device, encoder submission sequence, shader disk identities, and
+for PSOs the vertex declaration/layout, attachments, sample count, blend/write
+state, and sibling flag. `encoder_ops_same_submission` belongs to that same
+submission. It does not correlate the operation with an unrelated API or
+presentation peak. Pipeline builds already run on the encoder thread; a long
+build there can delay encoding and eventually backpressure the API thread.
+
+Native phase durations cross the PE/Unix boundary as nanoseconds in fixed
+`repr(C)` output fields, including on failure. Unreached or disabled phases
+are zero. `NanosSetTimer` measures each duration in its owning runtime; raw PE
+and native ticks are never subtracted. The fields retain the same layout
+without PERF, while collection and slow-event storage compile out. Shader
+prewarm transfers its private measurements with its existing one-shot payload
+and logs startup totals separately from gameplay frames. This instrumentation
+does not change compilation scheduling, cache contents, or prewarming policy.
+
 ### Don't hand-roll `rdtsc()` brackets — use `perf::ApiTimer` / `CycleSetTimer` / `CycleAddTimer`
 
 Time measurements that flow into the perf summary go through one of:
 
 - `ApiTimer` — D3D9 vtable entry brackets, accumulates into `api_cycles_by_category[Category]`.
 - `CycleAddTimer` — sub-scope inside an outer `ApiTimer`, accumulates into a `*mut u64` field (e.g. `query_wait_cycles`).
+- `NanosSetTimer`: elapsed wall time in nanoseconds for native thunk outputs and cold compilation phases.
 - `CycleSetTimer` — once-per-frame measurement that overwrites a `*mut u64` field (e.g. `present_block_cycles`, `op_cycles`, `submit_cycles`, `drawable_wait_tsc`).
 
-All three gate on a static `PERF_TRACKING_ENABLED: AtomicBool` latched once at logger init from `log_enabled!(target: "mtld3d::perf", Level::Info)`. When perf isn't being reported the helpers cost ~1 ns per call (one `Relaxed` atomic load + branch); when it is, the cached load avoids the per-call env_logger filter walk — the level chosen for the latch (Info) is paid once at init, not per call. On a non-`PERF` build the helpers compile to nothing (`cfg(perf_tracking)`).
+All four read `PERF_TRACKING_ENABLED`, a static `AtomicBool` latched once at
+logger initialization from `log_enabled!(target: "mtld3d::perf", Level::Info)`.
+A disabled helper reads no clock. The cached gate avoids a filter lookup on
+every measurement. On a non-PERF build, the helpers compile to nothing
+(`cfg(perf_tracking)`).
 
 The summary itself emits at `info!` on the same target, so the user-facing switch on a `PERF=1` build is a single `RUST_LOG=mtld3d::perf=info` for both the cycle accounting and the rendered grid.
 

--- a/unix/shared/src/params.rs
+++ b/unix/shared/src/params.rs
@@ -33,6 +33,13 @@ const _: () = {
         b: u64,
     }
     // 8 (not 4) ⇒ repr(C) u64 is 8-aligned on this target.
+    // Duration outputs have identical offsets in i686 PE and 64-bit Unix,
+    // independent of cfg(perf_tracking). Every Windows check compiles these.
+    assert!(core::mem::offset_of!(CompileShaderLibraryParams, timings) == 56);
+    assert!(core::mem::size_of::<CompileShaderLibraryParams>() == 80);
+    assert!(core::mem::offset_of!(CreateRenderPipelineParams, timings) == 192);
+    assert!(core::mem::size_of::<CreateRenderPipelineParams>() == 208);
+
     assert!(core::mem::offset_of!(U64After4, b) == 8);
     // A real wire struct whose `u64 id` sits after device_handle(8) + three
     // 4-byte fields: offset 24 ⇒ u64 8-aligned; would be 20 if 4-aligned.
@@ -531,6 +538,7 @@ pub struct CreateRenderPipelineParams {
     pub sample_count: u32, // in
     pub extra: [ExtraColorAttachmentParams; 3], // in: colorAttachments[1..=3]
     pub pipeline_handle: MetalHandle<MTLRenderPipelineStateKind>, // out
+    pub timings: super::perf::PipelineTimings, // out: nanoseconds, zero when PERF is disabled
 }
 
 /// One extra colour attachment (`colorAttachments[1..=3]`) of a render pipeline.
@@ -686,6 +694,7 @@ pub struct CompileShaderLibraryParams {
     pub pad0: u32,                                   // align next u64
     pub library_handle: MetalHandle<MTLLibraryKind>, // out
     pub fn_handle: MetalHandle<MTLFunctionKind>,     // out
+    pub timings: super::perf::ShaderTimings,         // out: nanoseconds, zero when PERF is disabled
 }
 
 impl Thunk for CompileShaderLibraryParams {

--- a/unix/shared/src/params.rs
+++ b/unix/shared/src/params.rs
@@ -538,7 +538,7 @@ pub struct CreateRenderPipelineParams {
     pub sample_count: u32, // in
     pub extra: [ExtraColorAttachmentParams; 3], // in: colorAttachments[1..=3]
     pub pipeline_handle: MetalHandle<MTLRenderPipelineStateKind>, // out
-    pub timings: super::perf::PipelineTimings, // out: nanoseconds, zero when PERF is disabled
+    pub timings: super::perf::TimingOutput<super::perf::PipelineTimings>, // out: nanoseconds when PERF is enabled
 }
 
 /// One extra colour attachment (`colorAttachments[1..=3]`) of a render pipeline.
@@ -694,7 +694,7 @@ pub struct CompileShaderLibraryParams {
     pub pad0: u32,                                   // align next u64
     pub library_handle: MetalHandle<MTLLibraryKind>, // out
     pub fn_handle: MetalHandle<MTLFunctionKind>,     // out
-    pub timings: super::perf::ShaderTimings,         // out: nanoseconds, zero when PERF is disabled
+    pub timings: super::perf::TimingOutput<super::perf::ShaderTimings>, // out: nanoseconds when PERF is enabled
 }
 
 impl Thunk for CompileShaderLibraryParams {

--- a/unix/shared/src/perf.rs
+++ b/unix/shared/src/perf.rs
@@ -31,9 +31,67 @@ use log::{Level, log_enabled};
 #[cfg(perf_tracking)]
 use crate::tsc::rdtsc;
 
+/// Fixed-layout output storage that performs no initialization without PERF.
+///
+/// The PE caller initializes its fallback before a thunk in a PERF build, so
+/// a native build without PERF can leave the output untouched. A disabled PE
+/// caller never reads the payload, including when the native build writes it.
+/// Only the two scalar timing records use this boundary wrapper.
+#[repr(transparent)]
+pub struct TimingOutput<T>(core::mem::MaybeUninit<T>);
+
+impl<T: Default> TimingOutput<T> {
+    #[cfg(perf_tracking)]
+    #[must_use]
+    pub fn new() -> Self {
+        Self(core::mem::MaybeUninit::new(T::default()))
+    }
+
+    #[cfg(not(perf_tracking))]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self(core::mem::MaybeUninit::uninit())
+    }
+
+    /// Publish a native measurement.
+    #[cfg(perf_tracking)]
+    pub const fn write(&mut self, value: T) {
+        self.0.write(value);
+    }
+
+    /// Leave the reserved bytes untouched in a disabled build.
+    #[cfg(not(perf_tracking))]
+    pub fn write(&mut self, value: T) {
+        let _ = (self, value);
+    }
+
+    /// Consume a caller-owned output initialized before the thunk.
+    #[cfg(perf_tracking)]
+    #[must_use]
+    pub const fn into_inner(self) -> T {
+        // SAFETY: this runtime's constructor initializes T before crossing
+        // the boundary; native writes only replace it with another valid T.
+        // The field is private, so safe callers cannot bypass initialization.
+        unsafe { self.0.assume_init() }
+    }
+
+    /// Synthesize zero durations without reading the reserved bytes.
+    #[cfg(not(perf_tracking))]
+    #[must_use]
+    pub fn into_inner(self) -> T {
+        T::default()
+    }
+}
+
+impl<T: Default> Default for TimingOutput<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Native shader compilation durations returned to the caller in nanoseconds.
 ///
-/// Fixed layout in both PERF and non-PERF builds; zero means unmeasured.
+/// Zero means unmeasured; `TimingOutput` preserves layout in non-PERF builds.
 #[repr(C)]
 pub struct ShaderTimings {
     pub preparation_ns: u64,
@@ -42,6 +100,13 @@ pub struct ShaderTimings {
 }
 
 impl ShaderTimings {
+    /// Clear native scratch only when instrumentation exists in this build.
+    pub const fn reset(&mut self) {
+        if cfg!(perf_tracking) {
+            *self = Self::new();
+        }
+    }
+
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -68,6 +133,13 @@ pub struct PipelineTimings {
 }
 
 impl PipelineTimings {
+    /// Clear native scratch only when instrumentation exists in this build.
+    pub const fn reset(&mut self) {
+        if cfg!(perf_tracking) {
+            *self = Self::new();
+        }
+    }
+
     #[must_use]
     pub const fn new() -> Self {
         Self {
@@ -349,3 +421,6 @@ impl Drop for NanosSetTimer {
 impl Drop for NanosSetTimer {
     fn drop(&mut self) {}
 }
+
+#[cfg(test)]
+mod tests;

--- a/unix/shared/src/perf.rs
+++ b/unix/shared/src/perf.rs
@@ -31,6 +31,58 @@ use log::{Level, log_enabled};
 #[cfg(perf_tracking)]
 use crate::tsc::rdtsc;
 
+/// Native shader compilation durations returned to the caller in nanoseconds.
+///
+/// Fixed layout in both PERF and non-PERF builds; zero means unmeasured.
+#[repr(C)]
+pub struct ShaderTimings {
+    pub preparation_ns: u64,
+    pub library_ns: u64,
+    pub function_ns: u64,
+}
+
+impl ShaderTimings {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            preparation_ns: 0,
+            library_ns: 0,
+            function_ns: 0,
+        }
+    }
+}
+
+impl Default for ShaderTimings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Native pipeline creation durations returned in nanoseconds.
+///
+/// Preparation excludes the synchronous Metal pipeline build.
+#[repr(C)]
+pub struct PipelineTimings {
+    pub preparation_ns: u64,
+    pub build_ns: u64,
+}
+
+impl PipelineTimings {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            preparation_ns: 0,
+            build_ns: 0,
+        }
+    }
+}
+
+impl Default for PipelineTimings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Cached `log_enabled!(target: "mtld3d::perf", Level::Info)` result.
 ///
 /// Latched once at logger init via `init_tracking_enabled`. Read on the
@@ -245,8 +297,8 @@ impl Drop for CycleAddTimer {
 /// [`crate::tsc::ns_to_cycles`].
 ///
 /// Same null-check plus perf-enabled gate as [`CycleSetTimer`]; the clock reads
-/// cost more than `rdtsc`, which is why this is for once-per-frame brackets
-/// (today: the `nextDrawable` wait) rather than hot-path measurements.
+/// cost more than `rdtsc`, so use this for once-per-frame waits and cold
+/// shader/pipeline builds, not per-draw cache hits.
 #[cfg(perf_tracking)]
 pub struct NanosSetTimer {
     /// `None` when the gate is off, so a disabled timer reads no clock at all.

--- a/unix/shared/src/perf/tests.rs
+++ b/unix/shared/src/perf/tests.rs
@@ -1,0 +1,32 @@
+use super::{PipelineTimings, ShaderTimings, TimingOutput};
+
+#[test]
+fn timing_output_layout_and_fallback_are_stable() {
+    assert_eq!(size_of::<TimingOutput<ShaderTimings>>(), 24);
+    assert_eq!(
+        align_of::<TimingOutput<ShaderTimings>>(),
+        align_of::<ShaderTimings>()
+    );
+    assert_eq!(size_of::<TimingOutput<PipelineTimings>>(), 16);
+    let value = TimingOutput::<ShaderTimings>::new().into_inner();
+    assert_eq!(
+        (value.preparation_ns, value.library_ns, value.function_ns),
+        (0, 0, 0)
+    );
+}
+
+#[test]
+fn timing_output_publishes_only_in_perf_builds() {
+    let mut output = TimingOutput::new();
+    output.write(PipelineTimings {
+        preparation_ns: 12,
+        build_ns: 34,
+    });
+    let value = output.into_inner();
+    let expected = if cfg!(perf_tracking) {
+        (12, 34)
+    } else {
+        (0, 0)
+    };
+    assert_eq!((value.preparation_ns, value.build_ns), expected);
+}

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -522,7 +522,7 @@ pub extern "C" fn create_render_pipeline_handler(args: *mut c_void) -> i32 {
 
     let mut timings = mtld3d_shared::perf::PipelineTimings::new();
     let result = metal::create_render_pipeline(params, attrs, layouts, &mut timings);
-    params.timings = timings;
+    params.timings.write(timings);
     if let Some(handle) = result {
         params.pipeline_handle = handle;
         STATUS_SUCCESS
@@ -587,7 +587,9 @@ pub extern "C" fn compile_shader_library_handler(args: *mut c_void) -> i32 {
         return -1;
     };
 
-    params.timings = mtld3d_shared::perf::ShaderTimings::new();
+    params
+        .timings
+        .write(mtld3d_shared::perf::ShaderTimings::new());
     if params.msl_ptr == 0 || params.msl_len == 0 {
         warn!(target: LOG_TARGET, "CompileShaderLibrary: empty source");
         return STATUS_UNSUCCESSFUL;
@@ -617,13 +619,15 @@ pub extern "C" fn compile_shader_library_handler(args: *mut c_void) -> i32 {
         return STATUS_UNSUCCESSFUL;
     };
 
+    let mut timings = mtld3d_shared::perf::ShaderTimings::new();
     let result = metal::compile_shader_library(
         params.device_handle,
         src,
         params.stage_tag,
         entry,
-        &mut params.timings,
+        &mut timings,
     );
+    params.timings.write(timings);
     match result {
         Some((lib, func)) => {
             params.library_handle = lib;

--- a/unix/unix/src/handlers.rs
+++ b/unix/unix/src/handlers.rs
@@ -520,7 +520,10 @@ pub extern "C" fn create_render_pipeline_handler(args: *mut c_void) -> i32 {
         }
     };
 
-    if let Some(handle) = metal::create_render_pipeline(params, attrs, layouts) {
+    let mut timings = mtld3d_shared::perf::PipelineTimings::new();
+    let result = metal::create_render_pipeline(params, attrs, layouts, &mut timings);
+    params.timings = timings;
+    if let Some(handle) = result {
         params.pipeline_handle = handle;
         STATUS_SUCCESS
     } else {
@@ -584,6 +587,7 @@ pub extern "C" fn compile_shader_library_handler(args: *mut c_void) -> i32 {
         return -1;
     };
 
+    params.timings = mtld3d_shared::perf::ShaderTimings::new();
     if params.msl_ptr == 0 || params.msl_len == 0 {
         warn!(target: LOG_TARGET, "CompileShaderLibrary: empty source");
         return STATUS_UNSUCCESSFUL;
@@ -613,7 +617,14 @@ pub extern "C" fn compile_shader_library_handler(args: *mut c_void) -> i32 {
         return STATUS_UNSUCCESSFUL;
     };
 
-    match metal::compile_shader_library(params.device_handle, src, params.stage_tag, entry) {
+    let result = metal::compile_shader_library(
+        params.device_handle,
+        src,
+        params.stage_tag,
+        entry,
+        &mut params.timings,
+    );
+    match result {
         Some((lib, func)) => {
             params.library_handle = lib;
             params.fn_handle = func;

--- a/unix/unix/src/handlers/tests.rs
+++ b/unix/unix/src/handlers/tests.rs
@@ -35,19 +35,21 @@ fn rejected_shader_thunk_clears_timing_outputs() {
         pad0: 0,
         library_handle: mtld3d_shared::MetalHandle::NULL,
         fn_handle: mtld3d_shared::MetalHandle::NULL,
-        timings: mtld3d_shared::perf::ShaderTimings {
-            preparation_ns: u64::MAX,
-            library_ns: u64::MAX,
-            function_ns: u64::MAX,
-        },
+        timings: mtld3d_shared::perf::TimingOutput::new(),
     };
+    params.timings.write(mtld3d_shared::perf::ShaderTimings {
+        preparation_ns: u64::MAX,
+        library_ns: u64::MAX,
+        function_ns: u64::MAX,
+    });
     let result = super::compile_shader_library_handler((&raw mut params).cast());
     assert_ne!(result, 0);
+    let timings = params.timings.into_inner();
     assert_eq!(
         (
-            params.timings.preparation_ns,
-            params.timings.library_ns,
-            params.timings.function_ns
+            timings.preparation_ns,
+            timings.library_ns,
+            timings.function_ns
         ),
         (0, 0, 0)
     );

--- a/unix/unix/src/handlers/tests.rs
+++ b/unix/unix/src/handlers/tests.rs
@@ -22,3 +22,33 @@ fn core_foundation_identity_names_the_framework() {
     );
     println!("caller base={:#x} uuid={}", own.base(), own.uuid().unwrap());
 }
+
+#[test]
+fn rejected_shader_thunk_clears_timing_outputs() {
+    let mut params = mtld3d_shared::CompileShaderLibraryParams {
+        device_handle: mtld3d_shared::MetalHandle::NULL,
+        msl_ptr: 0,
+        msl_len: 0,
+        stage_tag: mtld3d_shared::mtl::StageTag::Vertex,
+        entry_ptr: 0,
+        entry_len: 0,
+        pad0: 0,
+        library_handle: mtld3d_shared::MetalHandle::NULL,
+        fn_handle: mtld3d_shared::MetalHandle::NULL,
+        timings: mtld3d_shared::perf::ShaderTimings {
+            preparation_ns: u64::MAX,
+            library_ns: u64::MAX,
+            function_ns: u64::MAX,
+        },
+    };
+    let result = super::compile_shader_library_handler((&raw mut params).cast());
+    assert_ne!(result, 0);
+    assert_eq!(
+        (
+            params.timings.preparation_ns,
+            params.timings.library_ns,
+            params.timings.function_ns
+        ),
+        (0, 0, 0)
+    );
+}

--- a/unix/unix/src/metal/pipeline.rs
+++ b/unix/unix/src/metal/pipeline.rs
@@ -29,7 +29,7 @@ pub fn create_render_pipeline(
     vertex_layouts: &[VertexBufferLayoutDesc],
     timings: &mut mtld3d_shared::perf::PipelineTimings,
 ) -> Option<MetalHandle<MTLRenderPipelineStateKind>> {
-    *timings = mtld3d_shared::perf::PipelineTimings::new();
+    timings.reset();
     let preparation = mtld3d_shared::perf::NanosSetTimer::start(&raw mut timings.preparation_ns);
     let device = params.device_handle.into_retained()?;
     let vertex_function = params.vs_fn_handle.into_retained()?;

--- a/unix/unix/src/metal/pipeline.rs
+++ b/unix/unix/src/metal/pipeline.rs
@@ -27,7 +27,10 @@ pub fn create_render_pipeline(
     params: &CreateRenderPipelineParams,
     vertex_attrs: &[VertexAttrDesc],
     vertex_layouts: &[VertexBufferLayoutDesc],
+    timings: &mut mtld3d_shared::perf::PipelineTimings,
 ) -> Option<MetalHandle<MTLRenderPipelineStateKind>> {
+    *timings = mtld3d_shared::perf::PipelineTimings::new();
+    let preparation = mtld3d_shared::perf::NanosSetTimer::start(&raw mut timings.preparation_ns);
     let device = params.device_handle.into_retained()?;
     let vertex_function = params.vs_fn_handle.into_retained()?;
     let fragment_function = params.ps_fn_handle.into_retained()?;
@@ -166,7 +169,11 @@ pub fn create_render_pipeline(
         }
     }
 
-    let pipeline = match device.newRenderPipelineStateWithDescriptor_error(&desc) {
+    drop(preparation);
+    let build = mtld3d_shared::perf::NanosSetTimer::start(&raw mut timings.build_ns);
+    let result = device.newRenderPipelineStateWithDescriptor_error(&desc);
+    drop(build);
+    let pipeline = match result {
         Ok(pso) => pso,
         Err(e) => {
             error!(target: LOG_TARGET, "pipeline creation failed: {e}");

--- a/unix/unix/src/metal/shader.rs
+++ b/unix/unix/src/metal/shader.rs
@@ -12,6 +12,9 @@ use crate::{
     metal::handle::{IntoRetained, ReleaseRetain},
 };
 
+#[cfg(test)]
+mod tests;
+
 /// Compile MSL source text into a library and resolve a single entry point.
 ///
 /// `entry` is the function name to look up via `newFunctionWithName:` and
@@ -30,7 +33,10 @@ pub fn compile_shader_library(
     msl: &str,
     stage_tag: StageTag,
     entry: &str,
+    timings: &mut mtld3d_shared::perf::ShaderTimings,
 ) -> Option<(MetalHandle<MTLLibraryKind>, MetalHandle<MTLFunctionKind>)> {
+    *timings = mtld3d_shared::perf::ShaderTimings::new();
+    let preparation = mtld3d_shared::perf::NanosSetTimer::start(&raw mut timings.preparation_ns);
     let device = device_handle.into_retained()?;
 
     let source = objc2_foundation::NSString::from_str(msl);
@@ -58,7 +64,11 @@ pub fn compile_shader_library(
         StageTag::Vertex => options.setMathMode(MTLMathMode::Safe),
         StageTag::Fragment => options.setMathMode(MTLMathMode::Fast),
     }
-    let library = match device.newLibraryWithSource_options_error(&source, Some(&options)) {
+    drop(preparation);
+    let compile = mtld3d_shared::perf::NanosSetTimer::start(&raw mut timings.library_ns);
+    let compiled = device.newLibraryWithSource_options_error(&source, Some(&options));
+    drop(compile);
+    let library = match compiled {
         Ok(lib) => lib,
         Err(e) => {
             error!(target: LOG_TARGET, "shader compilation failed: {e}");
@@ -66,6 +76,7 @@ pub fn compile_shader_library(
         }
     };
 
+    let function = mtld3d_shared::perf::NanosSetTimer::start(&raw mut timings.function_ns);
     let name = objc2_foundation::NSString::from_str(entry);
     // `setLabel` makes the per-shader entry name surface in Xcode views
     // that show the library/object identity rather than the function-source
@@ -73,7 +84,9 @@ pub fn compile_shader_library(
     // the resource browser. Same string as the function name keeps
     // captures self-consistent across all Xcode tabs.
     library.setLabel(Some(&name));
-    let func = library.newFunctionWithName(&name)?;
+    let resolved = library.newFunctionWithName(&name);
+    drop(function);
+    let func = resolved?;
 
     // SAFETY: `Retained::into_raw` transfers the canonical retain into the
     // typed library handle.

--- a/unix/unix/src/metal/shader.rs
+++ b/unix/unix/src/metal/shader.rs
@@ -35,7 +35,7 @@ pub fn compile_shader_library(
     entry: &str,
     timings: &mut mtld3d_shared::perf::ShaderTimings,
 ) -> Option<(MetalHandle<MTLLibraryKind>, MetalHandle<MTLFunctionKind>)> {
-    *timings = mtld3d_shared::perf::ShaderTimings::new();
+    timings.reset();
     let preparation = mtld3d_shared::perf::NanosSetTimer::start(&raw mut timings.preparation_ns);
     let device = device_handle.into_retained()?;
 

--- a/unix/unix/src/metal/shader/tests.rs
+++ b/unix/unix/src/metal/shader/tests.rs
@@ -5,6 +5,9 @@ use objc2_metal::MTLCreateSystemDefaultDevice;
 use super::{compile_shader_library, destroy_function, destroy_library};
 
 fn poisoned_timings() -> ShaderTimings {
+    if !mtld3d_shared::perf::perf_enabled() {
+        return ShaderTimings::new();
+    }
     ShaderTimings {
         preparation_ns: u64::MAX,
         library_ns: u64::MAX,

--- a/unix/unix/src/metal/shader/tests.rs
+++ b/unix/unix/src/metal/shader/tests.rs
@@ -1,0 +1,64 @@
+use mtld3d_shared::{MetalHandle, mtl::StageTag, perf::ShaderTimings};
+use objc2::rc::Retained;
+use objc2_metal::MTLCreateSystemDefaultDevice;
+
+use super::{compile_shader_library, destroy_function, destroy_library};
+
+fn poisoned_timings() -> ShaderTimings {
+    ShaderTimings {
+        preparation_ns: u64::MAX,
+        library_ns: u64::MAX,
+        function_ns: u64::MAX,
+    }
+}
+
+#[test]
+fn shader_timings_reset_unreached_phases_and_preserve_results() {
+    mtld3d_shared::init_logger();
+    mtld3d_shared::perf::init_tracking_enabled();
+    let mut timings = poisoned_timings();
+    assert!(
+        compile_shader_library(MetalHandle::NULL, "", StageTag::Vertex, "", &mut timings).is_none()
+    );
+    assert_eq!(timings.library_ns, 0);
+    assert_eq!(timings.function_ns, 0);
+    assert_ne!(timings.preparation_ns, u64::MAX);
+
+    let device = MTLCreateSystemDefaultDevice().expect("Metal device for shader timing test");
+    // SAFETY: the device's retain stays alive until all three calls return.
+    let handle = unsafe { MetalHandle::new(Retained::as_ptr(&device) as u64) };
+    let msl = "#include <metal_stdlib>\nusing namespace metal;\nvertex float4 probe(uint id [[vertex_id]]) { return float4(float(id), 0, 0, 1); }";
+    for (source, entry, success, function_reached) in [
+        (msl, "probe", true, true),
+        (msl, "missing", false, true),
+        ("invalid MSL", "probe", false, false),
+    ] {
+        timings = poisoned_timings();
+        let result = compile_shader_library(handle, source, StageTag::Vertex, entry, &mut timings);
+        assert_eq!(result.is_some(), success);
+        assert_ne!(timings.preparation_ns, u64::MAX);
+        assert_ne!(timings.library_ns, u64::MAX);
+        assert_ne!(timings.function_ns, u64::MAX);
+        if !function_reached {
+            assert_eq!(timings.function_ns, 0);
+        }
+        if mtld3d_shared::perf::perf_enabled() {
+            assert!(timings.preparation_ns > 0);
+            assert!(timings.library_ns > 0);
+            assert_eq!(timings.function_ns > 0, function_reached);
+        } else {
+            assert_eq!(
+                (
+                    timings.preparation_ns,
+                    timings.library_ns,
+                    timings.function_ns
+                ),
+                (0, 0, 0)
+            );
+        }
+        if let Some((library, function)) = result {
+            destroy_function(function.raw());
+            destroy_library(library.raw());
+        }
+    }
+}

--- a/windows/core/src/perf.rs
+++ b/windows/core/src/perf.rs
@@ -60,6 +60,8 @@ use super::passes::Pass;
 #[cfg(perf_tracking)]
 use super::passes::{ColorLoad, DepthLoad};
 
+pub mod compilation;
+
 /// Window length for the averaged `mtld3d::perf=debug` summary.
 ///
 /// The per-pass / present-texture / per-pair detail rides on a separate
@@ -1710,6 +1712,7 @@ pub struct FrameSummaryContext {
 /// is compile-time-elided.
 #[cfg(perf_tracking)]
 pub struct EncoderPerfState {
+    compilation: compilation::CompilationPerf,
     /// Rolling aggregator for the 5-second `info!` summary.
     perf_window: PerfWindow,
 
@@ -1773,6 +1776,7 @@ impl EncoderPerfState {
     #[must_use]
     pub fn new() -> Self {
         Self {
+            compilation: compilation::CompilationPerf::new(),
             perf_window: PerfWindow::new(),
             counters: FrameCounters::new(),
             timing: FrameTiming::new(),
@@ -2096,6 +2100,11 @@ impl EncoderPerfState {
             enc_cyc: enc_cycles,
             submit_status,
         };
+        self.compilation.finish_frame(
+            compilation::cycles_to_ns(self.enc.op_sub_cycles[OpSub::Resolve as usize]),
+            compilation::cycles_to_ns(self.enc.op_sub_cycles[OpSub::Pipeline as usize]),
+            compilation::cycles_to_ns(self.enc.op_cycles),
+        );
         self.perf_window.accumulate(&sample);
 
         let window_cycles = rdtsc().saturating_sub(self.perf_window.started_tsc);
@@ -2119,7 +2128,9 @@ impl EncoderPerfState {
 
         if want_stats {
             let window_secs = cycles_to_ms(window_cycles) / 1e3;
-            let rendered = Summary::render(&self.perf_window, caches, window_secs);
+            let mut rendered = Summary::render(&self.perf_window, caches, window_secs);
+            self.compilation
+                .append_window(&mut rendered, self.perf_window.frames);
             info!(target: LOG_TARGET, "{rendered}");
         }
 
@@ -2223,14 +2234,18 @@ impl EncoderPerfState {
 /// ZST twin of [`EncoderPerfState`] for `cfg(not(perf_tracking))`.
 #[cfg(not(perf_tracking))]
 #[derive(Default)]
-pub struct EncoderPerfState;
+pub struct EncoderPerfState {
+    compilation: compilation::CompilationPerf,
+}
 
 #[cfg(not(perf_tracking))]
 impl EncoderPerfState {
     #[must_use]
     #[inline]
     pub const fn new() -> Self {
-        Self
+        Self {
+            compilation: compilation::CompilationPerf::new(),
+        }
     }
 
     #[inline]
@@ -2397,6 +2412,12 @@ struct FrameSample {
     /// Encoder-thread CPU = `op_cycles + submit_cycles`.
     enc_cyc: u64,
     submit_status: i32,
+}
+
+impl EncoderPerfState {
+    pub const fn compilation_mut(&mut self) -> &mut compilation::CompilationPerf {
+        &mut self.compilation
+    }
 }
 
 /// One windowed metric: a running window **sum** and a per-frame **peak**.

--- a/windows/core/src/perf/compilation.rs
+++ b/windows/core/src/perf/compilation.rs
@@ -273,7 +273,7 @@ impl CompilationPerf {
             if metric.calls != 0 {
                 let _ = writeln!(
                     output,
-                    "  {label}: {:.3} ms total, {} calls, {} failed",
+                    "  {label:<20} {:>9.3} ms total  calls={:<5} failed={}",
                     ms(metric.ns),
                     metric.calls,
                     metric.failures
@@ -291,7 +291,7 @@ impl CompilationPerf {
         for (label, metric) in Kind::LABELS.iter().zip(&self.window) {
             let _ = writeln!(
                 output,
-                "  {label:<20} {:>7.3} ms/frame  peak/frame {:>7.3} ms  total {:>9.3} ms  calls={} failed={}",
+                "  {label:<20} {:>7.3} ms/frame  peak/frame {:>7.3} ms  total {:>9.3} ms  calls={:<5} failed={}",
                 ms(metric.ns) / f64::from(frames),
                 ms(metric.peak_ns),
                 ms(metric.ns),

--- a/windows/core/src/perf/compilation.rs
+++ b/windows/core/src/perf/compilation.rs
@@ -1,0 +1,447 @@
+//! Cold shader and pipeline work attributed to its owning encoder submission.
+//!
+//! Native durations are nanoseconds, never raw ticks from another runtime.
+//! Frame totals and individual slow operations are kept distinct.
+
+#[cfg(perf_tracking)]
+use std::fmt::Write as _;
+
+use mtld3d_shared::perf::perf_enabled;
+
+#[cfg(perf_tracking)]
+const SLOW_NS: u64 = 2_000_000;
+#[cfg(perf_tracking)]
+const SLOW_LIMIT: usize = 5;
+
+#[cfg(test)]
+mod tests;
+
+/// One measured operation; parent totals include their nested children.
+#[repr(usize)]
+pub enum Kind {
+    ShaderVs,
+    ShaderPs,
+    EmitVs,
+    EmitPs,
+    ShaderPreparation,
+    Library,
+    Function,
+    CacheWrite,
+    Pipeline,
+    Sibling,
+    PipelinePreparation,
+    PipelineBuild,
+    Depth,
+    ResolveOther,
+    PipelineOther,
+}
+
+#[cfg(perf_tracking)]
+impl Kind {
+    const COUNT: usize = Self::PipelineOther as usize + 1;
+    const LABELS: [&'static str; Self::COUNT] = [
+        "VS miss total",
+        "PS miss total",
+        "  emit VS",
+        "  emit PS",
+        "  shader setup",
+        "  Metal library",
+        "  function lookup",
+        "  cache persist",
+        "PSO primary total",
+        "PSO sibling total",
+        "  PSO setup",
+        "  Metal PSO build",
+        "depth state build",
+        "resolve remainder",
+        "pipeline remainder",
+    ];
+}
+
+/// Per-device compilation accounting; storage vanishes without PERF.
+#[derive(Default)]
+pub struct CompilationPerf {
+    #[cfg(perf_tracking)]
+    frame: [Metric; Kind::COUNT],
+    #[cfg(perf_tracking)]
+    window: [Metric; Kind::COUNT],
+    #[cfg(perf_tracking)]
+    slow: Vec<SlowOperation>,
+    #[cfg(perf_tracking)]
+    frame_serial: u64,
+}
+
+impl CompilationPerf {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(perf_tracking)]
+            frame: [const { Metric::new() }; Kind::COUNT],
+            #[cfg(perf_tracking)]
+            window: [const { Metric::new() }; Kind::COUNT],
+            #[cfg(perf_tracking)]
+            slow: Vec::new(),
+            #[cfg(perf_tracking)]
+            frame_serial: 0,
+        }
+    }
+
+    /// Record elapsed work, evaluating identity only for a retained slow event.
+    pub fn record(
+        &mut self,
+        kind: Kind,
+        ns: u64,
+        success: bool,
+        seq: u64,
+        identity: impl FnOnce() -> Identity,
+    ) {
+        if !perf_enabled() {
+            return;
+        }
+        self.record_enabled(kind, ns, success, seq, identity);
+    }
+
+    #[cfg(not(perf_tracking))]
+    fn record_enabled(
+        &mut self,
+        _kind: Kind,
+        _ns: u64,
+        _success: bool,
+        _seq: u64,
+        _identity: impl FnOnce() -> Identity,
+    ) {
+        *self = Self::new();
+    }
+
+    #[cfg(perf_tracking)]
+    fn record_enabled(
+        &mut self,
+        kind: Kind,
+        ns: u64,
+        success: bool,
+        seq: u64,
+        identity: impl FnOnce() -> Identity,
+    ) {
+        let retain = !matches!(
+            kind,
+            Kind::ShaderVs | Kind::ShaderPs | Kind::Pipeline | Kind::Sibling
+        );
+        let index = kind as usize;
+        let metric = &mut self.frame[index];
+        metric.ns = metric.ns.saturating_add(ns);
+        metric.calls = metric.calls.saturating_add(1);
+        metric.failures = metric.failures.saturating_add(u64::from(!success));
+        // Parent totals remain in the table; retain leaf operations only.
+        if ns < SLOW_NS || !retain {
+            return;
+        }
+        let position = self.slow.partition_point(|event| event.ns >= ns);
+        if position >= SLOW_LIMIT {
+            return;
+        }
+        if self.slow.len() == SLOW_LIMIT {
+            self.slow.pop();
+        }
+        self.slow.insert(
+            position,
+            SlowOperation {
+                kind: index,
+                ns,
+                success,
+                seq,
+                identity: identity(),
+                serial: self.frame_serial,
+                encoder_ns: None,
+            },
+        );
+    }
+
+    /// Fold native shader phases without treating successful preparation as a build result.
+    pub fn shader_parts(
+        &mut self,
+        timings: &mtld3d_shared::perf::ShaderTimings,
+        success: bool,
+        seq: u64,
+        identity: impl Fn() -> Identity,
+    ) {
+        if !perf_enabled() {
+            return;
+        }
+        self.shader_parts_enabled(timings, success, seq, identity);
+    }
+
+    fn shader_parts_enabled(
+        &mut self,
+        timings: &mtld3d_shared::perf::ShaderTimings,
+        success: bool,
+        seq: u64,
+        identity: impl Fn() -> Identity,
+    ) {
+        if timings.preparation_ns == 0 {
+            return;
+        }
+        self.record_enabled(
+            Kind::ShaderPreparation,
+            timings.preparation_ns,
+            success || timings.library_ns != 0,
+            seq,
+            &identity,
+        );
+        if timings.library_ns != 0 {
+            self.record_enabled(
+                Kind::Library,
+                timings.library_ns,
+                success || timings.function_ns != 0,
+                seq,
+                &identity,
+            );
+        }
+        if timings.function_ns != 0 {
+            self.record_enabled(Kind::Function, timings.function_ns, success, seq, identity);
+        }
+    }
+
+    /// Close a submission, calculating residuals before taking window maxima.
+    #[cfg(perf_tracking)]
+    pub fn finish_frame(&mut self, resolve_ns: u64, pipeline_ns: u64, encoder_ns: u64) {
+        let shaders = self.frame[Kind::ShaderVs as usize]
+            .ns
+            .saturating_add(self.frame[Kind::ShaderPs as usize].ns);
+        let pipelines = self.frame[Kind::Pipeline as usize]
+            .ns
+            .saturating_add(self.frame[Kind::Sibling as usize].ns)
+            .saturating_add(self.frame[Kind::Depth as usize].ns);
+        self.frame[Kind::ResolveOther as usize].ns = resolve_ns.saturating_sub(shaders);
+        self.frame[Kind::PipelineOther as usize].ns = pipeline_ns.saturating_sub(pipelines);
+        for (window, frame) in self.window.iter_mut().zip(&mut self.frame) {
+            window.ns = window.ns.saturating_add(frame.ns);
+            window.calls = window.calls.saturating_add(frame.calls);
+            window.failures = window.failures.saturating_add(frame.failures);
+            window.peak_ns = window.peak_ns.max(frame.ns);
+            *frame = Metric::new();
+        }
+        for event in &mut self.slow {
+            if event.serial == self.frame_serial {
+                event.encoder_ns = Some(encoder_ns);
+            }
+        }
+        self.frame_serial = self.frame_serial.wrapping_add(1);
+    }
+
+    /// Render once with the existing PERF summary, then clear the window.
+    #[cfg(perf_tracking)]
+    pub fn append_window(&mut self, output: &mut String, frames: u32) {
+        if self.window.iter().all(|metric| metric.calls == 0) {
+            self.window = [const { Metric::new() }; Kind::COUNT];
+            self.slow.clear();
+            return;
+        }
+        let _ = writeln!(
+            output,
+            "\nCompilation (included in resolve/pipeline; nested rows are not additive)"
+        );
+        self.write_metrics(output, frames.max(1));
+        self.write_slow(output);
+        self.window = [const { Metric::new() }; Kind::COUNT];
+        self.slow.clear();
+    }
+
+    /// Emit startup work separately; no gameplay frame denominator applies.
+    #[cfg(perf_tracking)]
+    pub fn log_startup(&mut self, device: u64) {
+        if !perf_enabled() {
+            return;
+        }
+        self.log_startup_enabled(device);
+    }
+
+    #[cfg(not(perf_tracking))]
+    pub const fn log_startup(&mut self, _device: u64) {
+        *self = Self::new();
+    }
+
+    #[cfg(perf_tracking)]
+    fn log_startup_enabled(&mut self, device: u64) {
+        if self.frame.iter().all(|metric| metric.calls == 0) {
+            return;
+        }
+        self.window = std::mem::take(&mut self.frame);
+        let mut output = format!(
+            "shader prewarm PERF device={device:#x} (startup totals; outside gameplay windows)\n"
+        );
+        for (label, metric) in Kind::LABELS.iter().zip(&self.window) {
+            if metric.calls != 0 {
+                let _ = writeln!(
+                    output,
+                    "  {label}: {:.3} ms total, {} calls, {} failed",
+                    ms(metric.ns),
+                    metric.calls,
+                    metric.failures
+                );
+            }
+        }
+        self.write_slow(&mut output);
+        log::info!(target: super::LOG_TARGET, "{output}");
+        self.window = [const { Metric::new() }; Kind::COUNT];
+        self.slow.clear();
+    }
+
+    #[cfg(perf_tracking)]
+    fn write_metrics(&self, output: &mut String, frames: u32) {
+        for (label, metric) in Kind::LABELS.iter().zip(&self.window) {
+            let _ = writeln!(
+                output,
+                "  {label:<20} {:>7.3} ms/frame  peak/frame {:>7.3} ms  total {:>9.3} ms  calls={} failed={}",
+                ms(metric.ns) / f64::from(frames),
+                ms(metric.peak_ns),
+                ms(metric.ns),
+                metric.calls,
+                metric.failures
+            );
+        }
+    }
+
+    #[cfg(perf_tracking)]
+    fn write_slow(&self, output: &mut String) {
+        for event in &self.slow {
+            let _ = write!(
+                output,
+                "  slow {}: {:.3} ms/call seq={} success={} {}",
+                Kind::LABELS[event.kind].trim(),
+                ms(event.ns),
+                event.seq,
+                event.success,
+                event.identity
+            );
+            if let Some(ns) = event.encoder_ns {
+                let _ = write!(output, " encoder_ops_same_submission={:.3}ms", ms(ns));
+            }
+            output.push('\n');
+        }
+    }
+}
+
+#[cfg(perf_tracking)]
+#[derive(Default)]
+struct Metric {
+    ns: u64,
+    calls: u64,
+    failures: u64,
+    peak_ns: u64,
+}
+
+#[cfg(perf_tracking)]
+impl Metric {
+    const fn new() -> Self {
+        Self {
+            ns: 0,
+            calls: 0,
+            failures: 0,
+            peak_ns: 0,
+        }
+    }
+}
+
+#[cfg(perf_tracking)]
+struct SlowOperation {
+    kind: usize,
+    ns: u64,
+    success: bool,
+    seq: u64,
+    identity: Identity,
+    serial: u64,
+    encoder_ns: Option<u64>,
+}
+
+#[cfg(perf_tracking)]
+fn ms(ns: u64) -> f64 {
+    mtld3d_shared::tsc::u64_to_f64_exact(ns) / 1_000_000.0
+}
+
+/// Convert only PE-owned counters using the PE runtime's calibrated frequency.
+#[cfg(perf_tracking)]
+#[must_use]
+pub fn cycles_to_ns(cycles: u64) -> u64 {
+    u64::try_from(
+        u128::from(cycles) * 1_000_000_000 / u128::from(mtld3d_shared::tsc::tsc_hz().max(1)),
+    )
+    .unwrap_or(u64::MAX)
+}
+
+/// Owned metadata for a retained slow operation, formatted only at summary time.
+pub enum Identity {
+    Shader {
+        device: u64,
+        stage: &'static str,
+        shader: super::PairShaderId,
+    },
+    Prewarm {
+        device: u64,
+        kind: crate::shader_cache::CachedKind,
+        key: u64,
+    },
+    Pipeline {
+        device: u64,
+        vs: super::PairShaderId,
+        ps: super::PairShaderId,
+        snapshot: Box<crate::pipeline_state::PipelineSnapshot>,
+        sibling: bool,
+    },
+    Depth {
+        device: u64,
+        key: u64,
+    },
+}
+
+#[cfg(perf_tracking)]
+impl std::fmt::Display for Identity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Shader {
+                device,
+                stage,
+                shader,
+            } => write!(
+                f,
+                "device={device:#x} stage={stage} shader={}",
+                shader.tag()
+            ),
+            Self::Prewarm { device, kind, key } => write!(
+                f,
+                "device={device:#x} shader={} disk={key:#x}",
+                kind.entry_name(*key)
+            ),
+            Self::Pipeline {
+                device,
+                vs,
+                ps,
+                snapshot,
+                sibling,
+            } => {
+                write!(
+                    f,
+                    "device={device:#x} vs={} ps={} vdecl={:#x} layout=[",
+                    vs.tag(),
+                    ps.tag(),
+                    snapshot.vdecl_hash
+                )?;
+                for (stream, layout) in snapshot.stream_layouts.iter().enumerate() {
+                    if *layout != crate::pipeline_state::StreamLayout::UNUSED {
+                        write!(f, "{stream}:{layout:?};")?;
+                    }
+                }
+                write!(
+                    f,
+                    "] color={:?} attach={:?} samples={} rs={:?} extra={:?} ps_outputs={:#x} sibling={sibling}",
+                    snapshot.color_format,
+                    snapshot.attach,
+                    snapshot.sample_count,
+                    snapshot.rs,
+                    snapshot.extra,
+                    snapshot.ps_color_out_mask
+                )
+            }
+            Self::Depth { device, key } => write!(f, "device={device:#x} depth_key={key:#x}"),
+        }
+    }
+}

--- a/windows/core/src/perf/compilation/tests.rs
+++ b/windows/core/src/perf/compilation/tests.rs
@@ -30,7 +30,7 @@ fn peaks_are_per_frame_and_residuals_use_the_same_frame() {
     assert!(perf.frame.iter().all(|metric| metric.calls == 0));
     let mut output = String::new();
     perf.append_window(&mut output, 2);
-    assert!(output.contains("calls=3 failed=1"));
+    assert!(output.contains("calls=3     failed=1"));
     assert!(output.contains("encoder_ops_same_submission=30.000ms"));
     assert!(output.contains("device=0x7"));
     assert!(perf.slow.is_empty());

--- a/windows/core/src/perf/compilation/tests.rs
+++ b/windows/core/src/perf/compilation/tests.rs
@@ -1,0 +1,129 @@
+#[cfg(perf_tracking)]
+use super::{CompilationPerf, Identity, Kind};
+
+#[cfg(perf_tracking)]
+fn identity() -> Identity {
+    Identity::Depth { device: 7, key: 9 }
+}
+
+#[test]
+#[cfg(perf_tracking)]
+fn peaks_are_per_frame_and_residuals_use_the_same_frame() {
+    let mut perf = CompilationPerf::new();
+    perf.record_enabled(Kind::ShaderVs, 4_000_000, true, 1, identity);
+    perf.record_enabled(Kind::ShaderVs, 6_000_000, false, 1, identity);
+    perf.record_enabled(Kind::Library, 3_000_000, false, 1, identity);
+    perf.record_enabled(Kind::Sibling, 2_000_000, true, 1, identity);
+    perf.finish_frame(12_000_000, 8_000_000, 30_000_000);
+    perf.record_enabled(Kind::ShaderVs, 1_000_000, true, 2, identity);
+    perf.record_enabled(Kind::Library, 2_000_000, true, 2, identity);
+    perf.finish_frame(9_000_000, 1_000_000, 10_000_000);
+    let vs = &perf.window[Kind::ShaderVs as usize];
+    assert_eq!(
+        (vs.ns, vs.peak_ns, vs.calls, vs.failures),
+        (11_000_000, 10_000_000, 3, 1)
+    );
+    assert_eq!(perf.window[Kind::ResolveOther as usize].peak_ns, 8_000_000);
+    assert_eq!(perf.window[Kind::PipelineOther as usize].peak_ns, 6_000_000);
+    assert_eq!(perf.slow[0].encoder_ns, Some(30_000_000));
+    assert_eq!(perf.slow[1].encoder_ns, Some(10_000_000));
+    assert!(perf.frame.iter().all(|metric| metric.calls == 0));
+    let mut output = String::new();
+    perf.append_window(&mut output, 2);
+    assert!(output.contains("calls=3 failed=1"));
+    assert!(output.contains("encoder_ops_same_submission=30.000ms"));
+    assert!(output.contains("device=0x7"));
+    assert!(perf.slow.is_empty());
+    assert!(perf.window.iter().all(|metric| metric.ns == 0));
+}
+
+#[test]
+#[cfg(perf_tracking)]
+fn slow_records_are_bounded_lazy_and_exclude_parent_duplicates() {
+    let mut perf = CompilationPerf::new();
+    perf.record_enabled(Kind::Pipeline, 90_000_000, true, 1, || {
+        panic!("parent retained")
+    });
+    perf.record_enabled(Kind::PipelineBuild, 1_999_999, true, 1, || {
+        panic!("below threshold")
+    });
+    for ms in 2..=6 {
+        perf.record_enabled(Kind::Library, ms * 1_000_000, true, ms, identity);
+    }
+    perf.record_enabled(Kind::Library, 2_000_000, true, 7, || {
+        panic!("non-winning identity")
+    });
+    perf.record_enabled(Kind::PipelineBuild, 9_000_000, false, 8, identity);
+    assert_eq!(perf.slow.len(), 5);
+    assert_eq!(
+        perf.slow.iter().map(|event| event.ns).collect::<Vec<_>>(),
+        vec![9_000_000, 6_000_000, 5_000_000, 4_000_000, 3_000_000]
+    );
+    assert!(!perf.slow[0].success);
+}
+
+#[test]
+#[cfg(perf_tracking)]
+fn empty_windows_reset_remainders() {
+    let mut perf = CompilationPerf::new();
+    perf.finish_frame(90_000_000, 80_000_000, 100_000_000);
+    let mut output = String::new();
+    perf.append_window(&mut output, 1);
+    assert!(output.is_empty());
+    perf.record_enabled(Kind::Depth, 1_000_000, true, 2, identity);
+    perf.finish_frame(2_000_000, 3_000_000, 4_000_000);
+    assert_eq!(perf.window[Kind::ResolveOther as usize].ns, 2_000_000);
+    assert_eq!(perf.window[Kind::PipelineOther as usize].ns, 2_000_000);
+}
+
+#[test]
+#[cfg(not(perf_tracking))]
+fn disabled_perf_has_no_storage_or_identity_work() {
+    let mut perf = super::CompilationPerf::new();
+    assert_eq!(core::mem::size_of_val(&perf), 0);
+    perf.record(super::Kind::Library, u64::MAX, false, 1, || {
+        panic!("disabled identity")
+    });
+    perf.shader_parts(&mtld3d_shared::perf::ShaderTimings::new(), false, 1, || {
+        panic!("disabled identity")
+    });
+}
+
+#[test]
+#[cfg(perf_tracking)]
+fn shader_failure_counts_stop_at_the_failed_phase() {
+    let mut perf = CompilationPerf::new();
+    for (library_ns, function_ns, success) in [
+        (0, 0, false),
+        (3_000_000, 0, false),
+        (4_000_000, 2_000_000, false),
+        (5_000_000, 1_000_000, true),
+    ] {
+        perf.shader_parts_enabled(
+            &mtld3d_shared::perf::ShaderTimings {
+                preparation_ns: 10,
+                library_ns,
+                function_ns,
+            },
+            success,
+            1,
+            identity,
+        );
+    }
+    perf.shader_parts_enabled(
+        &mtld3d_shared::perf::ShaderTimings::new(),
+        false,
+        1,
+        identity,
+    );
+    assert_eq!(perf.frame[Kind::Library as usize].calls, 3);
+    assert_eq!(perf.frame[Kind::Library as usize].failures, 1);
+    assert_eq!(perf.frame[Kind::Function as usize].calls, 2);
+    assert_eq!(perf.frame[Kind::Function as usize].failures, 1);
+    assert_eq!(perf.frame[Kind::ShaderPreparation as usize].calls, 4);
+    assert_eq!(perf.frame[Kind::ShaderPreparation as usize].failures, 1);
+    perf.log_startup_enabled(7);
+    assert!(perf.frame.iter().all(|metric| metric.calls == 0));
+    assert!(perf.window.iter().all(|metric| metric.calls == 0));
+    assert!(perf.slow.is_empty());
+}

--- a/windows/core/src/pipeline_state.rs
+++ b/windows/core/src/pipeline_state.rs
@@ -476,6 +476,7 @@ pub fn params_from_snapshot(inputs: &PipelineBuildInputs<'_>) -> CreateRenderPip
             }
         }),
         pipeline_handle: MetalHandle::NULL,
+        timings: mtld3d_shared::perf::PipelineTimings::new(),
     }
 }
 

--- a/windows/core/src/pipeline_state.rs
+++ b/windows/core/src/pipeline_state.rs
@@ -476,7 +476,7 @@ pub fn params_from_snapshot(inputs: &PipelineBuildInputs<'_>) -> CreateRenderPip
             }
         }),
         pipeline_handle: MetalHandle::NULL,
-        timings: mtld3d_shared::perf::PipelineTimings::new(),
+        timings: mtld3d_shared::perf::TimingOutput::new(),
     }
 }
 

--- a/windows/d3d9/src/draw.rs
+++ b/windows/d3d9/src/draw.rs
@@ -1682,7 +1682,7 @@ pub fn emit_draw(enc: &mut FrameEncoder, draw: DrawOp) {
         ps_color_out_mask,
         sample_count: enc.current_color_sample_count(),
     };
-    let pipeline = enc.get_or_create_pipeline(&pipeline_snapshot, attrs_ref);
+    let pipeline = enc.get_or_create_pipeline(&pipeline_snapshot, attrs_ref, &shaders);
     if pipeline == 0 {
         // Pipeline build failed — e.g. a vertex-declaration/shader attribute
         // mismatch (a shader reads `v0` the bound decl never supplies) or a
@@ -1701,7 +1701,7 @@ pub fn emit_draw(enc: &mut FrameEncoder, draw: DrawOp) {
         let snapshot = render_state
             .depth_stencil_state
             .gated_on_stencil_attachment(has_stencil);
-        enc.get_or_create_depth_stencil(&snapshot)
+        enc.get_or_create_depth_stencil(&snapshot, true)
     } else {
         0
     };

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -36,7 +36,7 @@ use mtld3d_core::{
     perf::{
         CacheSizes, EncoderPerfState, FramePerfPayload, FrameSummaryContext, OpSub, OpSubDetail,
         PairShaderId, PairStatsSample, TaskFaults,
-        compilation::{CompilationPerf, Identity as CompileIdentity, Kind as CompileKind},
+        compilation::{Identity as CompileIdentity, Kind as CompileKind},
         perf_enabled,
     },
     pipeline_state::{self, PipelineBuildInputs, PipelineKey, PipelineSnapshot},
@@ -5946,6 +5946,7 @@ impl FrameEncoder {
         });
         let status = unix_call(&mut params);
         let pipeline = params.pipeline_handle;
+        let timings = params.timings.into_inner();
         drop(total);
         let success = status == 0 && !pipeline.is_null();
         let device = self.device_handle.raw();
@@ -5977,15 +5978,15 @@ impl FrameEncoder {
         );
         perf.record(
             CompileKind::PipelinePreparation,
-            params.timings.preparation_ns,
-            success || params.timings.build_ns != 0,
+            timings.preparation_ns,
+            success || timings.build_ns != 0,
             seq,
             identity,
         );
-        if params.timings.build_ns != 0 {
+        if timings.build_ns != 0 {
             perf.record(
                 CompileKind::PipelineBuild,
-                params.timings.build_ns,
+                timings.build_ns,
                 success,
                 seq,
                 identity,
@@ -8955,8 +8956,6 @@ pub struct EncoderThread {
 /// causing the encoder to compile a shader from scratch that the
 /// prewarm is concurrently compiling from disk.
 struct PrewarmPayload {
-    device: u64,
-    compilation: CompilationPerf,
     entries: Vec<(u64, StageLibHandles)>,
     writes_disabled: bool,
 }
@@ -8973,19 +8972,8 @@ impl PrewarmSender {
     /// Ship pre-warmed handles (empty vec for a cold start) and let the
     /// encoder open the cache for append.
     pub fn send(self, entries: Vec<(u64, StageLibHandles)>) {
-        self.send_measured(entries, CompilationPerf::new(), 0);
-    }
-
-    pub fn send_measured(
-        self,
-        entries: Vec<(u64, StageLibHandles)>,
-        compilation: CompilationPerf,
-        device: u64,
-    ) {
         let _ = self.0.send(PrewarmPayload {
             entries,
-            compilation,
-            device,
             writes_disabled: false,
         });
     }
@@ -9000,8 +8988,6 @@ impl PrewarmSender {
     pub fn send_disabled(self) {
         let _ = self.0.send(PrewarmPayload {
             entries: Vec::new(),
-            device: 0,
-            compilation: CompilationPerf::new(),
             writes_disabled: true,
         });
     }
@@ -9234,10 +9220,10 @@ pub fn compile_stage_library(
         pad0: 0,
         library_handle: MetalHandle::NULL,
         fn_handle: MetalHandle::NULL,
-        timings: ShaderTimings::new(),
+        timings: mtld3d_shared::perf::TimingOutput::new(),
     };
     let status = unix_call(&mut params);
-    *timings = params.timings;
+    *timings = params.timings.into_inner();
     if status != 0 || params.library_handle.is_null() || params.fn_handle.is_null() {
         error!(target: LOG_TARGET, "encoder: CompileShaderLibrary failed (stage={stage_tag:?}, entry={entry})");
         return None;
@@ -9308,8 +9294,7 @@ fn encoder_thread_main(
     // is about to deliver. The Err arm covers a prewarm-thread panic:
     // drop the warm cache, leave writes enabled, fall through so
     // subsequent `Shutdown` can still drain.
-    if let Ok(mut payload) = prewarm_rx.recv() {
-        payload.compilation.log_startup(payload.device);
+    if let Ok(payload) = prewarm_rx.recv() {
         enc.ingest_warm_cache(payload.entries, payload.writes_disabled);
     } else {
         mtld3d_shared::log_once_warn!(

--- a/windows/d3d9/src/encoder.rs
+++ b/windows/d3d9/src/encoder.rs
@@ -35,7 +35,9 @@ use mtld3d_core::{
     },
     perf::{
         CacheSizes, EncoderPerfState, FramePerfPayload, FrameSummaryContext, OpSub, OpSubDetail,
-        PairShaderId, PairStatsSample, TaskFaults, perf_enabled,
+        PairShaderId, PairStatsSample, TaskFaults,
+        compilation::{CompilationPerf, Identity as CompileIdentity, Kind as CompileKind},
+        perf_enabled,
     },
     pipeline_state::{self, PipelineBuildInputs, PipelineKey, PipelineSnapshot},
     render_scale::RenderScale,
@@ -69,6 +71,7 @@ use mtld3d_shared::{
         MTLDeviceKind, MTLFunctionKind, MTLRenderPipelineStateKind, MTLSamplerStateKind,
         MTLTextureKind, NSViewKind,
     },
+    perf::{NanosSetTimer, ShaderTimings},
     tsc::{ns_to_cycles, rdtsc, secs_to_cycles},
 };
 use mtld3d_types::{D3DSAMP_MIPMAPLODBIAS, SAMPLER_STATE_COUNT};
@@ -4467,7 +4470,7 @@ impl FrameEncoder {
         // below is actually emitted (the clear-quad cross-pass rule).
         self.reset_last_bound_for_fresh_encoder();
 
-        let depth_state = self.get_or_create_depth_stencil(&DepthStencilSnapshot::inert());
+        let depth_state = self.get_or_create_depth_stencil(&DepthStencilSnapshot::inert(), false);
         if self.last_bound.pipeline_changed(pipeline) {
             self.pass_state
                 .emit_command(Command::set_render_pipeline_state(pipeline));
@@ -4710,7 +4713,7 @@ impl FrameEncoder {
             }
             return;
         }
-        let depth_state = self.get_or_create_depth_stencil(&snapshot);
+        let depth_state = self.get_or_create_depth_stencil(&snapshot, false);
         // `Clear`'s Z is a raw depth value: D3D9's `MinZ`/`MaxZ` scale a
         // transformed vertex's z, not a clear. The quad writes its value as
         // the vertex's clip-space z, so Metal's viewport depth transform would
@@ -4833,7 +4836,7 @@ impl FrameEncoder {
         // Color clear doesn't write depth: bind a no-write depth-stencil
         // state so a transient color clear over an in-use depth
         // attachment doesn't perturb depth values.
-        let depth_state = self.get_or_create_depth_stencil(&DepthStencilSnapshot::inert());
+        let depth_state = self.get_or_create_depth_stencil(&DepthStencilSnapshot::inert(), false);
         // Color: write rgba as float4 via setFragmentBytes. The caller
         // (`device_clear` → `clear_color`/`clear_color_rects`) passes each
         // channel as f32 BITS, exactly like the folded load-action clear
@@ -5137,15 +5140,39 @@ impl FrameEncoder {
     // ── D3D9→Metal translation + caching (runs on encoder thread) ──
 
     /// Look up or create an `MTLDepthStencilState` for the given D3D9 state.
-    pub fn get_or_create_depth_stencil(&mut self, snapshot: &DepthStencilSnapshot) -> u64 {
+    pub fn get_or_create_depth_stencil(
+        &mut self,
+        snapshot: &DepthStencilSnapshot,
+        draw_phase: bool,
+    ) -> u64 {
         let key = key_from_snapshot(snapshot);
         if let Some(&handle) = self.depth_stencil_cache.get(&key) {
             return handle.raw();
         }
 
+        let mut ns = 0;
+        let timer = NanosSetTimer::start(if draw_phase {
+            &raw mut ns
+        } else {
+            core::ptr::null_mut()
+        });
         let mut params = params_from_snapshot(snapshot, key, self.device_handle);
         let status = unix_call(&mut params);
         let state = params.state_handle;
+        drop(timer);
+        if draw_phase {
+            let device = self.device_handle.raw();
+            self.perf.compilation_mut().record(
+                CompileKind::Depth,
+                ns,
+                status == 0 && !state.is_null(),
+                self.current_submit_seq,
+                || CompileIdentity::Depth {
+                    device,
+                    key: key.raw(),
+                },
+            );
+        }
         if status != 0 || state.is_null() {
             error!(target: LOG_TARGET, "encoder: CreateDepthStencilState failed");
             return 0;
@@ -5397,66 +5424,121 @@ impl FrameEncoder {
         if let Some(&handles) = self.lib_cache.get(&disk_key) {
             return Some(handles);
         }
-        let kind = match source {
-            VsSource::Programmable { vs_id, .. } => {
-                let major = self.program_cache.get(vs_id).map_or(0, |p| p.major);
-                CachedKind::from_programmable(major, false)
-            }
-            VsSource::FixedFunction { .. } => Some(CachedKind::FfVs),
-        };
-        let entry_name = vs_entry_name(source, &self.program_cache, disk_key);
-        let started = Instant::now();
-        let (msl, bucket) = match source {
-            VsSource::Programmable {
-                vs_id,
-                provided_input_mask,
-                clip_plane_count,
-                sampler_kinds,
-                ..
-            } => {
-                let Some(program) = self.program_cache.get(vs_id) else {
-                    error!(target: LOG_TARGET, "VS {vs_id:#x} missing from program_cache");
-                    return None;
-                };
-                let bucket = CompileBucket::from_sm_major(program.major);
-                let msl = match emit_vs_programmable_named(
-                    program,
-                    &entry_name,
-                    *provided_input_mask,
-                    *clip_plane_count,
-                    *sampler_kinds,
-                ) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        error!(target: LOG_TARGET, "emit_vs_programmable failed: {e:?}");
+        let mut total_ns = 0;
+        let mut emit_ns = 0;
+        let mut persist_ns = 0;
+        let mut timings = ShaderTimings::new();
+        let total_timer = NanosSetTimer::start(&raw mut total_ns);
+        let result = (|| {
+            let kind = match source {
+                VsSource::Programmable { vs_id, .. } => {
+                    let major = self.program_cache.get(vs_id).map_or(0, |p| p.major);
+                    CachedKind::from_programmable(major, false)
+                }
+                VsSource::FixedFunction { .. } => Some(CachedKind::FfVs),
+            };
+            let entry_name = vs_entry_name(source, &self.program_cache, disk_key);
+            let started = Instant::now();
+            let emission = NanosSetTimer::start(&raw mut emit_ns);
+            let (msl, bucket) = match source {
+                VsSource::Programmable {
+                    vs_id,
+                    provided_input_mask,
+                    clip_plane_count,
+                    sampler_kinds,
+                    ..
+                } => {
+                    let Some(program) = self.program_cache.get(vs_id) else {
+                        error!(target: LOG_TARGET, "VS {vs_id:#x} missing from program_cache");
                         return None;
-                    }
-                };
-                (msl, bucket)
+                    };
+                    let bucket = CompileBucket::from_sm_major(program.major);
+                    let msl = match emit_vs_programmable_named(
+                        program,
+                        &entry_name,
+                        *provided_input_mask,
+                        *clip_plane_count,
+                        *sampler_kinds,
+                    ) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!(target: LOG_TARGET, "emit_vs_programmable failed: {e:?}");
+                            return None;
+                        }
+                    };
+                    (msl, bucket)
+                }
+                VsSource::FixedFunction { key, .. } => {
+                    mtld3d_shared::crumb!(
+                        "ffvs:emit",
+                        self.current_submit_seq,
+                        u64::from(key.tex_coord_count),
+                    );
+                    (emit_vs_ff_named(key, &entry_name), Some(CompileBucket::Ff))
+                }
+            };
+            drop(emission);
+            if log_enabled!(target: MSL_TRACE_TARGET, Level::Trace) {
+                let tag = shader_source_tag_vs(source);
+                trace!(target: MSL_TRACE_TARGET, "── VS MSL {tag} ──\n{msl}\n── /VS MSL {tag} ──");
             }
-            VsSource::FixedFunction { key, .. } => {
-                mtld3d_shared::crumb!(
-                    "ffvs:emit",
-                    self.current_submit_seq,
-                    u64::from(key.tex_coord_count),
-                );
-                (emit_vs_ff_named(key, &entry_name), Some(CompileBucket::Ff))
+            let handles = compile_stage_library(
+                self.device_handle,
+                StageTag::Vertex,
+                &msl,
+                &entry_name,
+                &mut timings,
+            )?;
+            if let Some(b) = bucket {
+                shader_compile_stats::record(b, started.elapsed());
             }
+            if let Some(kind) = kind
+                && self.flags.contains(FrameEncoderFlags::CACHE_READY)
+                && !self.flags.contains(FrameEncoderFlags::CACHE_DISABLED)
+            {
+                let _persist = NanosSetTimer::start(&raw mut persist_ns);
+                self.cache_write_record(kind, disk_key, &msl);
+            }
+            self.lib_cache.insert(disk_key, handles);
+            Some(handles)
+        })();
+        drop(total_timer);
+        let device = self.device_handle.raw();
+        let seq = self.current_submit_seq;
+        let identity = || CompileIdentity::Shader {
+            device,
+            stage: "VS",
+            shader: PairShaderId {
+                is_programmable: matches!(source, VsSource::Programmable { .. }),
+                hash: disk_key,
+            },
         };
-        if log_enabled!(target: MSL_TRACE_TARGET, Level::Trace) {
-            let tag = shader_source_tag_vs(source);
-            trace!(target: MSL_TRACE_TARGET, "── VS MSL {tag} ──\n{msl}\n── /VS MSL {tag} ──");
+        let perf = self.perf.compilation_mut();
+        perf.record(
+            CompileKind::ShaderVs,
+            total_ns,
+            result.is_some(),
+            seq,
+            identity,
+        );
+        perf.record(
+            CompileKind::EmitVs,
+            emit_ns,
+            timings.preparation_ns != 0 || result.is_some(),
+            seq,
+            identity,
+        );
+        perf.shader_parts(&timings, result.is_some(), seq, identity);
+        if persist_ns != 0 {
+            perf.record(
+                CompileKind::CacheWrite,
+                persist_ns,
+                !self.flags.contains(FrameEncoderFlags::CACHE_DISABLED),
+                seq,
+                identity,
+            );
         }
-        let handles =
-            compile_stage_library(self.device_handle, StageTag::Vertex, &msl, &entry_name)?;
-        if let Some(b) = bucket {
-            shader_compile_stats::record(b, started.elapsed());
-        }
-        if let Some(kind) = kind {
-            self.cache_write_record(kind, disk_key, &msl);
-        }
-        self.lib_cache.insert(disk_key, handles);
-        Some(handles)
+        result
     }
 
     /// Resolve the PS library for a draw.
@@ -5511,50 +5593,105 @@ impl FrameEncoder {
         if let Some(&handles) = self.lib_cache.get(&disk_key) {
             return Some(handles);
         }
-        let kind = match source {
-            PsSource::Programmable { ps_id, .. } => {
-                let major = self.program_cache.get(ps_id).map_or(0, |p| p.major);
-                CachedKind::from_programmable(major, true)
-            }
-            PsSource::FixedFunction { .. } => Some(CachedKind::FfPs),
-        };
-        let entry_name = ps_entry_name(source, &self.program_cache, disk_key);
-        let started = Instant::now();
-        let (msl, bucket) = match source {
-            PsSource::Programmable { ps_id, .. } => {
-                let Some(program) = self.program_cache.get(ps_id) else {
-                    error!(target: LOG_TARGET, "PS {ps_id:#x} missing from program_cache");
-                    return None;
-                };
-                let bucket = CompileBucket::from_sm_major(program.major);
-                let msl = match emit_ps_programmable_named(program, variant, &entry_name) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        error!(target: LOG_TARGET, "emit_ps_programmable failed: {e:?}");
+        let mut total_ns = 0;
+        let mut emit_ns = 0;
+        let mut persist_ns = 0;
+        let mut timings = ShaderTimings::new();
+        let total_timer = NanosSetTimer::start(&raw mut total_ns);
+        let result = (|| {
+            let kind = match source {
+                PsSource::Programmable { ps_id, .. } => {
+                    let major = self.program_cache.get(ps_id).map_or(0, |p| p.major);
+                    CachedKind::from_programmable(major, true)
+                }
+                PsSource::FixedFunction { .. } => Some(CachedKind::FfPs),
+            };
+            let entry_name = ps_entry_name(source, &self.program_cache, disk_key);
+            let started = Instant::now();
+            let emission = NanosSetTimer::start(&raw mut emit_ns);
+            let (msl, bucket) = match source {
+                PsSource::Programmable { ps_id, .. } => {
+                    let Some(program) = self.program_cache.get(ps_id) else {
+                        error!(target: LOG_TARGET, "PS {ps_id:#x} missing from program_cache");
                         return None;
-                    }
-                };
-                (msl, bucket)
+                    };
+                    let bucket = CompileBucket::from_sm_major(program.major);
+                    let msl = match emit_ps_programmable_named(program, variant, &entry_name) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!(target: LOG_TARGET, "emit_ps_programmable failed: {e:?}");
+                            return None;
+                        }
+                    };
+                    (msl, bucket)
+                }
+                PsSource::FixedFunction { key, .. } => (
+                    emit_ps_ff_named(key, variant, &entry_name),
+                    Some(CompileBucket::Ff),
+                ),
+            };
+            drop(emission);
+            if log_enabled!(target: MSL_TRACE_TARGET, Level::Trace) {
+                let tag = shader_source_tag_ps(source, variant);
+                trace!(target: MSL_TRACE_TARGET, "── PS MSL {tag} ──\n{msl}\n── /PS MSL {tag} ──");
             }
-            PsSource::FixedFunction { key, .. } => (
-                emit_ps_ff_named(key, variant, &entry_name),
-                Some(CompileBucket::Ff),
-            ),
+            let handles = compile_stage_library(
+                self.device_handle,
+                StageTag::Fragment,
+                &msl,
+                &entry_name,
+                &mut timings,
+            )?;
+            if let Some(b) = bucket {
+                shader_compile_stats::record(b, started.elapsed());
+            }
+            if let Some(kind) = kind
+                && self.flags.contains(FrameEncoderFlags::CACHE_READY)
+                && !self.flags.contains(FrameEncoderFlags::CACHE_DISABLED)
+            {
+                let _persist = NanosSetTimer::start(&raw mut persist_ns);
+                self.cache_write_record(kind, disk_key, &msl);
+            }
+            self.lib_cache.insert(disk_key, handles);
+            Some(handles)
+        })();
+        drop(total_timer);
+        let device = self.device_handle.raw();
+        let seq = self.current_submit_seq;
+        let identity = || CompileIdentity::Shader {
+            device,
+            stage: "PS",
+            shader: PairShaderId {
+                is_programmable: matches!(source, PsSource::Programmable { .. }),
+                hash: disk_key,
+            },
         };
-        if log_enabled!(target: MSL_TRACE_TARGET, Level::Trace) {
-            let tag = shader_source_tag_ps(source, variant);
-            trace!(target: MSL_TRACE_TARGET, "── PS MSL {tag} ──\n{msl}\n── /PS MSL {tag} ──");
+        let perf = self.perf.compilation_mut();
+        perf.record(
+            CompileKind::ShaderPs,
+            total_ns,
+            result.is_some(),
+            seq,
+            identity,
+        );
+        perf.record(
+            CompileKind::EmitPs,
+            emit_ns,
+            timings.preparation_ns != 0 || result.is_some(),
+            seq,
+            identity,
+        );
+        perf.shader_parts(&timings, result.is_some(), seq, identity);
+        if persist_ns != 0 {
+            perf.record(
+                CompileKind::CacheWrite,
+                persist_ns,
+                !self.flags.contains(FrameEncoderFlags::CACHE_DISABLED),
+                seq,
+                identity,
+            );
         }
-        let handles =
-            compile_stage_library(self.device_handle, StageTag::Fragment, &msl, &entry_name)?;
-        if let Some(b) = bucket {
-            shader_compile_stats::record(b, started.elapsed());
-        }
-        if let Some(kind) = kind {
-            self.cache_write_record(kind, disk_key, &msl);
-        }
-        self.lib_cache.insert(disk_key, handles);
-        Some(handles)
+        result
     }
 
     /// One-shot `debug!` per unique `(rt_handle, vs_key, ps_key)` seen by `emit_draw`.
@@ -5731,6 +5868,7 @@ impl FrameEncoder {
         &mut self,
         snapshot: &PipelineSnapshot,
         vertex_attrs: &[VertexAttrDesc],
+        shaders: &ShaderRef<'_>,
     ) -> u64 {
         self.perf.bump_pipeline_memo_call();
         // L0 memo: a draw whose pipeline snapshot is identical to the
@@ -5751,7 +5889,7 @@ impl FrameEncoder {
             self.perf.bump_pipeline_memo_hit();
             return handle;
         }
-        let with_color = self.resolve_pipeline(snapshot, vertex_attrs);
+        let with_color = self.resolve_pipeline(snapshot, vertex_attrs, shaders, false);
         // Dual-build for zero-mask draws: build the matching no-color
         // variant up-front so pass-finalisation (Rule H) can swap to it
         // retroactively if every draw in the pass had `mask == 0`.
@@ -5772,7 +5910,7 @@ impl FrameEncoder {
             alt.attach
                 .remove(mtld3d_core::pipeline_state::PipelineAttachFlags::HAS_COLOR_OUTPUT);
             alt.extra = mtld3d_core::pipeline_state::ExtraColorAttachments::NONE;
-            let no_color = self.resolve_pipeline(&alt, vertex_attrs);
+            let no_color = self.resolve_pipeline(&alt, vertex_attrs, shaders, true);
             if !no_color.is_null() {
                 self.no_color_pipeline_alt
                     .insert(with_color.raw(), no_color);
@@ -5788,11 +5926,15 @@ impl FrameEncoder {
         &mut self,
         snapshot: &PipelineSnapshot,
         vertex_attrs: &[VertexAttrDesc],
+        shaders: &ShaderRef<'_>,
+        sibling: bool,
     ) -> MetalHandle<MTLRenderPipelineStateKind> {
         let key = pipeline_state::key_from_snapshot(snapshot);
         if let Some(&handle) = self.pipeline_cache.get(&key) {
             return handle;
         }
+        let mut total_ns = 0;
+        let total = NanosSetTimer::start(&raw mut total_ns);
         // One wire layout per used stream; lives on this frame until the
         // synchronous thunk below has read it.
         let vertex_layouts = pipeline_state::vertex_layouts_from_snapshot(snapshot);
@@ -5804,6 +5946,51 @@ impl FrameEncoder {
         });
         let status = unix_call(&mut params);
         let pipeline = params.pipeline_handle;
+        drop(total);
+        let success = status == 0 && !pipeline.is_null();
+        let device = self.device_handle.raw();
+        let identity = || CompileIdentity::Pipeline {
+            device,
+            vs: PairShaderId {
+                is_programmable: matches!(shaders.vs, VsSource::Programmable { .. }),
+                hash: shaders.vs.disk_key(),
+            },
+            ps: PairShaderId {
+                is_programmable: matches!(shaders.ps, PsSource::Programmable { .. }),
+                hash: shaders.ps.disk_key(shaders.variant),
+            },
+            snapshot: Box::new(snapshot.clone()),
+            sibling,
+        };
+        let perf = self.perf.compilation_mut();
+        let seq = self.current_submit_seq;
+        perf.record(
+            if sibling {
+                CompileKind::Sibling
+            } else {
+                CompileKind::Pipeline
+            },
+            total_ns,
+            success,
+            seq,
+            identity,
+        );
+        perf.record(
+            CompileKind::PipelinePreparation,
+            params.timings.preparation_ns,
+            success || params.timings.build_ns != 0,
+            seq,
+            identity,
+        );
+        if params.timings.build_ns != 0 {
+            perf.record(
+                CompileKind::PipelineBuild,
+                params.timings.build_ns,
+                success,
+                seq,
+                identity,
+            );
+        }
         if status != 0 || pipeline.is_null() {
             error!(target: LOG_TARGET, "encoder: CreateRenderPipeline failed");
             return MetalHandle::NULL;
@@ -7327,7 +7514,7 @@ impl FrameEncoder {
         let depth = job.depth.max(1);
         let emit = UploadPassInputs {
             pipeline,
-            depth_state: self.get_or_create_depth_stencil(&DepthStencilSnapshot::inert()),
+            depth_state: self.get_or_create_depth_stencil(&DepthStencilSnapshot::inert(), false),
             staging_buffer_handle,
             texture_handle,
             format: job.info.pixel_format,
@@ -8768,6 +8955,8 @@ pub struct EncoderThread {
 /// causing the encoder to compile a shader from scratch that the
 /// prewarm is concurrently compiling from disk.
 struct PrewarmPayload {
+    device: u64,
+    compilation: CompilationPerf,
     entries: Vec<(u64, StageLibHandles)>,
     writes_disabled: bool,
 }
@@ -8784,8 +8973,19 @@ impl PrewarmSender {
     /// Ship pre-warmed handles (empty vec for a cold start) and let the
     /// encoder open the cache for append.
     pub fn send(self, entries: Vec<(u64, StageLibHandles)>) {
+        self.send_measured(entries, CompilationPerf::new(), 0);
+    }
+
+    pub fn send_measured(
+        self,
+        entries: Vec<(u64, StageLibHandles)>,
+        compilation: CompilationPerf,
+        device: u64,
+    ) {
         let _ = self.0.send(PrewarmPayload {
             entries,
+            compilation,
+            device,
             writes_disabled: false,
         });
     }
@@ -8800,6 +9000,8 @@ impl PrewarmSender {
     pub fn send_disabled(self) {
         let _ = self.0.send(PrewarmPayload {
             entries: Vec::new(),
+            device: 0,
+            compilation: CompilationPerf::new(),
             writes_disabled: true,
         });
     }
@@ -9020,6 +9222,7 @@ pub fn compile_stage_library(
     stage_tag: StageTag,
     msl: &str,
     entry: &str,
+    timings: &mut ShaderTimings,
 ) -> Option<StageLibHandles> {
     let mut params = CompileShaderLibraryParams {
         device_handle,
@@ -9031,8 +9234,10 @@ pub fn compile_stage_library(
         pad0: 0,
         library_handle: MetalHandle::NULL,
         fn_handle: MetalHandle::NULL,
+        timings: ShaderTimings::new(),
     };
     let status = unix_call(&mut params);
+    *timings = params.timings;
     if status != 0 || params.library_handle.is_null() || params.fn_handle.is_null() {
         error!(target: LOG_TARGET, "encoder: CompileShaderLibrary failed (stage={stage_tag:?}, entry={entry})");
         return None;
@@ -9103,7 +9308,8 @@ fn encoder_thread_main(
     // is about to deliver. The Err arm covers a prewarm-thread panic:
     // drop the warm cache, leave writes enabled, fall through so
     // subsequent `Shutdown` can still drain.
-    if let Ok(payload) = prewarm_rx.recv() {
+    if let Ok(mut payload) = prewarm_rx.recv() {
+        payload.compilation.log_startup(payload.device);
         enc.ingest_warm_cache(payload.entries, payload.writes_disabled);
     } else {
         mtld3d_shared::log_once_warn!(

--- a/windows/d3d9/src/shader_prewarm.rs
+++ b/windows/d3d9/src/shader_prewarm.rs
@@ -185,6 +185,7 @@ fn run(
         rewrite_as_bundle(&path, &deduped);
     }
 
+    let mut compilation = mtld3d_core::perf::compilation::CompilationPerf::new();
     let mut warm: Vec<(u64, StageLibHandles)> = Vec::with_capacity(deduped.len());
     let mut counts = [0u32; 4];
     let mut duration_ns = [0u64; 4];
@@ -196,11 +197,20 @@ fn run(
         let stage = stage_for_kind(entry.kind);
         let entry_name = entry.kind.entry_name(entry.key);
         let started = Instant::now();
-        let Some(handles) = compile_stage_library(device_handle, stage, &entry.msl, &entry_name)
-        else {
+        let mut timings = mtld3d_shared::perf::ShaderTimings::new();
+        let handles =
+            compile_stage_library(device_handle, stage, &entry.msl, &entry_name, &mut timings);
+        let elapsed = started.elapsed();
+        compilation.shader_parts(&timings, handles.is_some(), 0, || {
+            mtld3d_core::perf::compilation::Identity::Prewarm {
+                device: device_handle.raw(),
+                kind: entry.kind,
+                key: entry.key,
+            }
+        });
+        let Some(handles) = handles else {
             continue;
         };
-        let elapsed = started.elapsed();
         let idx = bucket_index(entry.kind.compile_bucket());
         counts[idx] += 1;
         // u128 nanos → u64: saturates at ~584 years; pre-warm batch fits easily.
@@ -210,7 +220,7 @@ fn run(
 
     let total: u32 = counts.iter().sum();
     let cached = u32::try_from(warm.len()).unwrap_or(u32::MAX);
-    sender.send(warm);
+    sender.send_measured(warm, compilation, device_handle.raw());
     if total > 0 {
         let snap = Snapshot {
             counts,

--- a/windows/d3d9/src/shader_prewarm.rs
+++ b/windows/d3d9/src/shader_prewarm.rs
@@ -220,7 +220,8 @@ fn run(
 
     let total: u32 = counts.iter().sum();
     let cached = u32::try_from(warm.len()).unwrap_or(u32::MAX);
-    sender.send_measured(warm, compilation, device_handle.raw());
+    compilation.log_startup(device_handle.raw());
+    sender.send(warm);
     if total > 0 {
         let snap = Snapshot {
             counts,


### PR DESCRIPTION
The PERF `resolve` and `pipeline` rows combine cache lookup, shader work, descriptor setup, and Metal pipeline creation. A large peak therefore does not identify which phase stalled the encoder. This adds phase attribution to the existing report without changing compilation scheduling or prewarming.

The report separates VS/PS misses into MSL emission, native preparation, Metal library creation, function lookup, and disk-cache persistence. It splits primary and no-color sibling PSO misses, times native descriptor preparation and Metal PSO creation, and tracks draw-path depth-state misses. Rows show attempts, failures, totals, averages, and per-submission summed peaks. Nested rows overlap their parents; resolve/pipeline remainder is calculated per submission before taking a maximum.

Each window retains at most five individual operations lasting at least 2 ms, with shader/state identity, submission sequence, and encoder time from that same submission. Parent totals do not consume these slots. Metadata is captured lazily and formatted when the summary prints. Shader prewarm gets a separate startup report. Timing and counter columns are aligned in both reports.

`PERF=0` removes collection, timers, slow-event storage, and timing-output initialization/read/write work. Fixed-layout output storage keeps the PE/Unix ABI identical between configurations; enabled callers initialize a zero fallback and disabled callers do not read the reserved bytes. Explicit `PERF=0` overrides an inherited `MTLD3D_PERF=1`.

## Live verification

WoW 1.12, `PROD=1 PERF=1`, `WoW-5715.log` at `c738515`: 13 windows and 7,339 frame samples. The 12 compilation-active windows reconcile primary/sibling counts with native calls and pipeline-cache growth, ending at 190 PSOs, with zero compilation failures.

- 160 primary and 30 sibling PSO builds: 1,168.495 ms combined parent time, including 1,162.639 ms inside Metal PSO creation and 3.080 ms in descriptor preparation.
- Worst summed Metal PSO time in one submission: 191.442 ms. Largest retained individual call: 23.184 ms, with 24.105 ms of encoder operations in that same submission.
- Two gameplay shader-library builds: 21.418 ms. Startup prewarm separately loaded 95 libraries in 718.669 ms of Metal library time.

These measurements distinguish PSO creation from shader-library work. They do not correlate independent API/presentation window peaks or establish a regression against a different game run. Internal clear/blit/upload/presentation pipelines are outside this draw-path attribution.

## Alternatives and scope

Runtime-only instrumentation was rejected because disabled builds must not retain timing or metadata work. Logging each creation inline would add formatting to the measured path and produce unbounded output. Moving compilation to another worker or adding PSO prewarm would change execution and belongs in a follow-up; pipeline creation already runs on the encoder thread.

## Verification and rules check

- `make check PERF=0` and `make check PERF=1`: formatting, audit, Clippy, and documentation passed. The final alignment-only follow-up was rechecked with PERF enabled.
- `WINE_SDK=/path/to/wine make ISOLATED=1 test PERF=0 JOBS=1`: 1,510 host tests and 556 end-to-end tests on each PE architecture passed.
- `WINE_SDK=/path/to/wine make ISOLATED=1 test PROD=1 PERF=1 JOBS=1`: 1,534 host tests and 556 end-to-end tests on each PE architecture passed, including the final formatting change.
- Optimized i686/x86_64 LLVM probes: the disabled collector/timer probe aliases its control; output init/write/read/reset probes contain only returns. This checks the added telemetry operations, not bytewise identity of entire DLLs.
- Cold/warm rendering probes on both PE architectures passed pixel checks and expected phase counts. A final probe checks the aligned output. Native tests cover failures and boundary layouts; collector tests cover accounting, failure attribution, bounded lazy capture, window reset, and disabled storage.
- Aggregation lives in `mtld3d-core`; d3d9 wires measured calls into it. The two thunk outputs have fixed offsets/sizes. No new global, atomic, runtime config, dependency, Clone/Copy derive, or lint suppression. Tests use sibling modules, and no end-to-end suite module was added.
- Shader emission, cache keys/content, rendering behavior, scheduling, and AppKit ownership are unchanged. No optimization is included.
