### PR TITLE
Decide a fault is ours by the image file name, not the path

### DIFF
--- a/unix/unix/src/crash.rs
+++ b/unix/unix/src/crash.rs
@@ -669,7 +669,7 @@ fn push_thread_name(buf: &mut [u8; 192], pos: &mut usize) {
 /// Scan the raw stack for return addresses into our own dylib and print them.
 ///
 /// Walks up to 4096 words from `sp` and `backtrace_symbols_fd`-prints each
-/// value that `dladdr` resolves into a module whose path contains `mtld3d`.
+/// value that `dladdr` resolves into a module whose file name is ours.
 /// Caps the printed count so a deep stack can't flood. Stack words are copied
 /// by the kernel into local storage, without dereferencing the faulting stack.
 /// Arch-neutral: a spilled return address is a stack word on both arches, and
@@ -728,7 +728,7 @@ const STACK_SCAN_WORDS: usize = 4096;
 /// Print the return addresses into our own dylib among `words` stack words above `sp`.
 ///
 /// `backtrace_symbols_fd`-prints each value that `dladdr` resolves into a
-/// module whose path contains `mtld3d`, capped so a deep stack can't flood.
+/// module whose file name is ours, capped so a deep stack can't flood.
 /// The 4-byte step tolerates a 32-bit guest stack's alignment; a spilled
 /// return address is a stack word on both arches.
 fn our_frames_on_stack(sp: u64, words: usize) {
@@ -840,47 +840,50 @@ fn dladdr_image(addr: u64) -> Option<*const core::ffi::c_char> {
 
 /// True when `addr` resolves (via `dladdr`) into our own `.so`.
 ///
-/// The match is on a loaded image whose filename contains the bytes `mtld3d`.
+/// The match is on a loaded image whose file name begins with `mtld3d`.
 /// Filters stack garbage and libsystem/Wine/Metal frames down to our own call
 /// chain.
 fn dladdr_is_ours(addr: u64) -> bool {
-    /// Scanned for in the image path, without allocating.
-    const NEEDLE: &[u8] = b"mtld3d";
-
     let Some(path) = dladdr_image(addr) else {
         return false;
     };
-    let path = path.cast::<u8>();
-    let mut idx = 0usize;
-    let mut matched = 0usize;
-    while idx < PATH_MAX_SCAN {
-        // SAFETY: an offset within a NUL-terminated C string owned by dyld,
-        // bounded by the NUL check below.
-        let at = unsafe { path.add(idx) };
-        // SAFETY: as above; reads one byte of that string.
-        let byte = unsafe { at.read() };
-        if byte == 0 {
-            break;
-        }
-        matched = if byte == NEEDLE[matched] {
-            matched + 1
-        } else {
-            usize::from(byte == NEEDLE[0])
-        };
-        if matched == NEEDLE.len() {
-            return true;
-        }
-        idx += 1;
-    }
-    false
+    path_names_our_image(path)
+}
+
+/// Whether the NUL-terminated image path names one of our own images.
+///
+/// The file name decides, not the path. A directory anywhere above the image
+/// can carry our name, and matching the whole path then claims every image
+/// under it: Wine installed beside us is the layout where that matters, where claiming
+/// its `ntdll.so` sends a fault Wine would have turned into a Windows
+/// exception down the terminal path instead of back to it.
+///
+/// Split from [`dladdr_is_ours`] so the suite can pin the rule without a live
+/// `dladdr`.
+fn path_names_our_image(path: *const core::ffi::c_char) -> bool {
+    /// Matched against the image's file name.
+    const NEEDLE: &[u8] = b"mtld3d";
+
+    let len = image_path_len(path);
+    // The file name starts one past the last separator, or at the beginning
+    // when the path carries none.
+    let start = (0..len)
+        .rfind(|&i| image_path_byte(path, i) == b'/')
+        .map_or(0, |i| i + 1);
+    // It has to begin with the needle, so `mtld3d.so` matches and an
+    // unrelated `ntdll.so` under an `mtld3d`-named directory does not.
+    len - start >= NEEDLE.len()
+        && NEEDLE
+            .iter()
+            .enumerate()
+            .all(|(i, &want)| image_path_byte(path, start + i) == want)
 }
 
 /// Bound on every scan of an image path, so a corrupt `dli_fname` can't spin.
 const PATH_MAX_SCAN: usize = 4096;
 
 /// Length of the NUL-terminated image path dyld owns, bounded by [`PATH_MAX_SCAN`].
-#[cfg(target_arch = "x86_64")]
-fn image_path_len(path: *const core::ffi::c_char) -> usize {
+const fn image_path_len(path: *const core::ffi::c_char) -> usize {
     let mut len = 0usize;
     while len < PATH_MAX_SCAN && image_path_byte(path, len) != 0 {
         len += 1;
@@ -892,7 +895,6 @@ fn image_path_len(path: *const core::ffi::c_char) -> usize {
 ///
 /// Callers stay within the length [`image_path_len`] measured, or stop at
 /// the first zero this returns.
-#[cfg(target_arch = "x86_64")]
 const fn image_path_byte(path: *const core::ffi::c_char, index: usize) -> u8 {
     // SAFETY: an offset within a NUL-terminated C string owned by dyld, which
     // the caller bounds by its measured length or by the NUL itself.

--- a/unix/unix/src/crash/tests.rs
+++ b/unix/unix/src/crash/tests.rs
@@ -745,3 +745,38 @@ fn check_stack_boundaries(test: &str, scan: fn(u64)) {
     assert!(!report.contains("FATAL"), "{report}");
     assert!(report.contains("stack read unavailable"), "{report}");
 }
+
+/// The file name decides ownership, not the path.
+///
+/// Wine lives under a directory named after this project in a normal
+/// developer install, and claiming its images sends a fault Wine would have
+/// recovered down the terminal path instead of back to it.
+#[test]
+fn only_the_image_file_name_decides_whether_a_fault_is_ours() {
+    fn names_ours(path: &str) -> bool {
+        let c = std::ffi::CString::new(path).expect("no interior NUL");
+        super::path_names_our_image(c.as_ptr())
+    }
+
+    assert!(names_ours("/opt/mtld3d/lib/wine/x86_64-unix/mtld3d.so"));
+    assert!(names_ours("mtld3d.so"));
+    assert!(
+        !names_ours("/opt/mtld3d-toolchain/components/wine/lib/wine/x86_64-unix/ntdll.so"),
+        "Wine's own image under a directory named for this project is not ours",
+    );
+    assert!(
+        !names_ours("ntdll.so"),
+        "a bare foreign file name is not ours"
+    );
+    assert!(
+        !names_ours("/opt/mtld3d/"),
+        "a trailing separator names no file"
+    );
+    assert!(!names_ours("/usr/lib/system/libsystem_platform.dylib"));
+    assert!(!names_ours("/opt/mtld3d/lib/wine/x86_64-unix/winemetal.so"));
+    assert!(
+        !names_ours("/x/libmtld3d_unix.dylib"),
+        "the file name has to begin with the needle, not merely contain it",
+    );
+    assert!(!names_ours(""));
+}


### PR DESCRIPTION
League of Legends dies a few hundred milliseconds into startup, inside
`r3dRenderLayer::SetMode`, and the log carries a fault the layer never made:
a `SIGSEGV` at address zero whose `fault_pc` is Wine's own
`__wine_unix_call_dispatcher`, on a thread Wine never named. The same title
runs to its game loop with
`MTLD3D_NO_CRASH_HANDLER=1`: 35 lines of its own log become 942, ending in
`GAMESTATE_GAMELOOP Render`. The handler is what ends the process, not the
fault.

`dladdr_is_ours` asked whether a faulting address belongs to this project by
scanning the image's whole path for `mtld3d`. A Wine tree installed under a
directory carrying that name, which is what a working copy of this project
beside its toolchain looks like, puts the needle in the path of every Wine
image: `.../mtld3d-toolchain/components/wine/lib/wine/x86_64-unix/ntdll.so`
matches, and so does every other one. The handler reads that as its own fault,
skips `forward_to_previous` and takes the terminal path, so a fault Wine was
about to translate into a Windows exception, which the application catches and
continues from, ends the process instead. The title never made a call into us:
the faulting thread is one Wine never named, the crumb ring holds nothing for
it, and the frame is Wine's own dispatcher. Nothing about it is
title-specific; any fault in any Wine image, on a tree laid out this way, is
fatal.

The file name decides, not the path. `path_names_our_image` finds the last
separator and matches the needle from there, so `mtld3d.so` is ours and
`ntdll.so` under a directory named for us is not. It reuses the bounded
`image_path_len` and `image_path_byte` the x86_64 report already walks paths
with, which drops their architecture gate and leaves the new rule with no
unsafe of its own, and it is split out of `dladdr_is_ours` so it can be pinned
without a live `dladdr`.

Alternatives considered: comparing the faulting image's base address against
our own, captured from any function in this image at install time, is the
exact test and does not depend on what the image is called. It is the better
rule if the install name ever varies; the file name is stable across every
shipped layout and needs nothing stored, so this change keeps the name.

Verification: `make check` and `make test` pass, 1169 and 382 host unit tests
and 560 end-to-end tests per architecture, and conformance is unchanged on
both architectures. `only_the_image_file_name_decides_whether_a_fault_is_ours`
is checked against the code it pins: with the previous whole-path scan
restored it fails on the Wine-image case, and it is the only failure.
`fault_report_decodes_registers` covers the other direction, since the test
binary's own name carries the needle and its faults have to stay ours. In the
title, it reaches its game loop over three runs, where every run before ended
in the report above.

Rules check: this changes the crash handler's ownership test and its existing
unit coverage only. It adds no statics, config keys, wire fields,
dependencies, derives, warning suppressions, ABI constants, or duplicated
logic. `make check` passes the formatting, Clippy, audit and documentation
gates from `CONTRIBUTING.md` and `docs/CONVENTIONS.md`. The handler stays on
the signal-forwarding path described in its own module documentation.


